### PR TITLE
Qchen/multi tenancy/fix deployment creation

### DIFF
--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -31,39 +31,50 @@ import (
 )
 
 func TestServiceAccountCreation(t *testing.T) {
+	testServiceAccountCreation(t, metav1.TenantDefault)
+}
+
+func TestServiceAccountCreationWithMultiTenancy(t *testing.T) {
+	testServiceAccountCreation(t, "test-te")
+}
+
+func testServiceAccountCreation(t *testing.T, tenant string) {
 	ns := metav1.NamespaceDefault
 
 	defaultName := "default"
 	managedName := "managed"
 
 	activeNS := &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Name: ns},
+		ObjectMeta: metav1.ObjectMeta{Tenant: tenant, Name: ns},
 		Status: v1.NamespaceStatus{
 			Phase: v1.NamespaceActive,
 		},
 	}
 	terminatingNS := &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Name: ns},
+		ObjectMeta: metav1.ObjectMeta{Tenant: tenant, Name: ns},
 		Status: v1.NamespaceStatus{
 			Phase: v1.NamespaceTerminating,
 		},
 	}
 	defaultServiceAccount := &v1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault,
+		ObjectMeta: metav1.ObjectMeta{
+			Tenant:          tenant,
 			Name:            defaultName,
 			Namespace:       ns,
 			ResourceVersion: "1",
 		},
 	}
 	managedServiceAccount := &v1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault,
+		ObjectMeta: metav1.ObjectMeta{
+			Tenant:          tenant,
 			Name:            managedName,
 			Namespace:       ns,
 			ResourceVersion: "1",
 		},
 	}
 	unmanagedServiceAccount := &v1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault,
+		ObjectMeta: metav1.ObjectMeta{
+			Tenant:          tenant,
 			Name:            "other-unmanaged",
 			Namespace:       ns,
 			ResourceVersion: "1",

--- a/pkg/controller/serviceaccount/tokengetter.go
+++ b/pkg/controller/serviceaccount/tokengetter.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,22 +42,34 @@ func NewGetterFromClient(c clientset.Interface, secretLister v1listers.SecretLis
 }
 
 func (c clientGetter) GetServiceAccount(namespace, name string) (*v1.ServiceAccount, error) {
-	if serviceAccount, err := c.serviceAccountLister.ServiceAccounts(namespace).Get(name); err == nil {
-		return serviceAccount, nil
-	}
-	return c.client.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
+	return c.GetServiceAccountWithMultiTenancy(metav1.TenantDefault, namespace, name)
 }
 
 func (c clientGetter) GetPod(namespace, name string) (*v1.Pod, error) {
-	if pod, err := c.podLister.Pods(namespace).Get(name); err == nil {
-		return pod, nil
-	}
-	return c.client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+	return c.GetPodWithMultiTenancy(metav1.TenantDefault, namespace, name)
 }
 
 func (c clientGetter) GetSecret(namespace, name string) (*v1.Secret, error) {
-	if secret, err := c.secretLister.Secrets(namespace).Get(name); err == nil {
+	return c.GetSecretWithMultiTenancy(metav1.TenantDefault, namespace, name)
+}
+
+func (c clientGetter) GetServiceAccountWithMultiTenancy(tenant, namespace, name string) (*v1.ServiceAccount, error) {
+	if serviceAccount, err := c.serviceAccountLister.ServiceAccountsWithMultiTenancy(namespace, tenant).Get(name); err == nil {
+		return serviceAccount, nil
+	}
+	return c.client.CoreV1().ServiceAccountsWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
+}
+
+func (c clientGetter) GetPodWithMultiTenancy(tenant, namespace, name string) (*v1.Pod, error) {
+	if pod, err := c.podLister.PodsWithMultiTenancy(namespace, tenant).Get(name); err == nil {
+		return pod, nil
+	}
+	return c.client.CoreV1().PodsWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
+}
+
+func (c clientGetter) GetSecretWithMultiTenancy(tenant, namespace, name string) (*v1.Secret, error) {
+	if secret, err := c.secretLister.SecretsWithMultiTenancy(namespace, tenant).Get(name); err == nil {
 		return secret, nil
 	}
-	return c.client.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	return c.client.CoreV1().SecretsWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
 }

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -243,24 +243,24 @@ func (e *TokensController) syncServiceAccount() {
 		return
 	}
 
-	sa, err := e.getServiceAccount(saInfo.namespace, saInfo.name, saInfo.uid, false)
+	sa, err := e.getServiceAccount(saInfo.tenant, saInfo.namespace, saInfo.name, saInfo.uid, false)
 	switch {
 	case err != nil:
 		klog.Error(err)
 		retry = true
 	case sa == nil:
 		// service account no longer exists, so delete related tokens
-		klog.V(4).Infof("syncServiceAccount(%s/%s), service account deleted, removing tokens", saInfo.namespace, saInfo.name)
-		sa = &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Namespace: saInfo.namespace, Name: saInfo.name, UID: saInfo.uid, HashKey: fuzzer.GetHashOfUUID(saInfo.uid)}}
+		klog.V(4).Infof("syncServiceAccount(%s/%s/%s), service account deleted, removing tokens", saInfo.tenant, saInfo.namespace, saInfo.name)
+		sa = &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Tenant: saInfo.tenant, Namespace: saInfo.namespace, Name: saInfo.name, UID: saInfo.uid, HashKey: fuzzer.GetHashOfUUID(saInfo.uid)}}
 		retry, err = e.deleteTokens(sa)
 		if err != nil {
-			klog.Errorf("error deleting serviceaccount tokens for %s/%s: %v", saInfo.namespace, saInfo.name, err)
+			klog.Errorf("error deleting serviceaccount tokens for %s/%s/%s: %v", saInfo.tenant, saInfo.namespace, saInfo.name, err)
 		}
 	default:
 		// ensure a token exists and is referenced by this service account
 		retry, err = e.ensureReferencedToken(sa)
 		if err != nil {
-			klog.Errorf("error synchronizing serviceaccount %s/%s: %v", saInfo.namespace, saInfo.name, err)
+			klog.Errorf("error synchronizing serviceaccount %s/%s/%s: %v", saInfo.tenant, saInfo.namespace, saInfo.name, err)
 		}
 	}
 }
@@ -284,39 +284,39 @@ func (e *TokensController) syncSecret() {
 		return
 	}
 
-	secret, err := e.getSecret(secretInfo.namespace, secretInfo.name, secretInfo.uid, false)
+	secret, err := e.getSecret(secretInfo.tenant, secretInfo.namespace, secretInfo.name, secretInfo.uid, false)
 	switch {
 	case err != nil:
 		klog.Error(err)
 		retry = true
 	case secret == nil:
 		// If the service account exists
-		if sa, saErr := e.getServiceAccount(secretInfo.namespace, secretInfo.saName, secretInfo.saUID, false); saErr == nil && sa != nil {
+		if sa, saErr := e.getServiceAccount(secretInfo.tenant, secretInfo.namespace, secretInfo.saName, secretInfo.saUID, false); saErr == nil && sa != nil {
 			// secret no longer exists, so delete references to this secret from the service account
 			if err := clientretry.RetryOnConflict(RemoveTokenBackoff, func() error {
-				return e.removeSecretReference(secretInfo.namespace, secretInfo.saName, secretInfo.saUID, secretInfo.name)
+				return e.removeSecretReference(secretInfo.tenant, secretInfo.namespace, secretInfo.saName, secretInfo.saUID, secretInfo.name)
 			}); err != nil {
 				klog.Error(err)
 			}
 		}
 	default:
 		// Ensure service account exists
-		sa, saErr := e.getServiceAccount(secretInfo.namespace, secretInfo.saName, secretInfo.saUID, true)
+		sa, saErr := e.getServiceAccount(secretInfo.tenant, secretInfo.namespace, secretInfo.saName, secretInfo.saUID, true)
 		switch {
 		case saErr != nil:
 			klog.Error(saErr)
 			retry = true
 		case sa == nil:
 			// Delete token
-			klog.V(4).Infof("syncSecret(%s/%s), service account does not exist, deleting token", secretInfo.namespace, secretInfo.name)
-			if retriable, err := e.deleteToken(secretInfo.namespace, secretInfo.name, secretInfo.uid); err != nil {
-				klog.Errorf("error deleting serviceaccount token %s/%s for service account %s: %v", secretInfo.namespace, secretInfo.name, secretInfo.saName, err)
+			klog.V(4).Infof("syncSecret(%s/%s/%s), service account does not exist, deleting token", secretInfo.tenant, secretInfo.namespace, secretInfo.name)
+			if retriable, err := e.deleteToken(secretInfo.tenant, secretInfo.namespace, secretInfo.name, secretInfo.uid); err != nil {
+				klog.Errorf("error deleting serviceaccount token %s/%s/%s for service account %s: %v", secretInfo.tenant, secretInfo.namespace, secretInfo.name, secretInfo.saName, err)
 				retry = retriable
 			}
 		default:
 			// Update token if needed
 			if retriable, err := e.generateTokenIfNeeded(sa, secret); err != nil {
-				klog.Errorf("error populating serviceaccount token %s/%s for service account %s: %v", secretInfo.namespace, secretInfo.name, secretInfo.saName, err)
+				klog.Errorf("error populating serviceaccount token %s/%s/%s for service account %s: %v", secretInfo.tenant, secretInfo.namespace, secretInfo.name, secretInfo.saName, err)
 				retry = retriable
 			}
 		}
@@ -332,7 +332,7 @@ func (e *TokensController) deleteTokens(serviceAccount *v1.ServiceAccount) ( /*r
 	retry := false
 	errs := []error{}
 	for _, token := range tokens {
-		r, err := e.deleteToken(token.Namespace, token.Name, token.UID)
+		r, err := e.deleteToken(token.Tenant, token.Namespace, token.Name, token.UID)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -343,12 +343,12 @@ func (e *TokensController) deleteTokens(serviceAccount *v1.ServiceAccount) ( /*r
 	return retry, utilerrors.NewAggregate(errs)
 }
 
-func (e *TokensController) deleteToken(ns, name string, uid types.UID) ( /*retry*/ bool, error) {
+func (e *TokensController) deleteToken(tenant, ns, name string, uid types.UID) ( /*retry*/ bool, error) {
 	var opts *metav1.DeleteOptions
 	if len(uid) > 0 {
 		opts = &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}
 	}
-	err := e.client.CoreV1().Secrets(ns).Delete(name, opts)
+	err := e.client.CoreV1().SecretsWithMultiTenancy(ns, tenant).Delete(name, opts)
 	// NotFound doesn't need a retry (it's already been deleted)
 	// Conflict doesn't need a retry (the UID precondition failed)
 	if err == nil || apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
@@ -370,7 +370,7 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 
 	// We don't want to update the cache's copy of the service account
 	// so add the secret to a freshly retrieved copy of the service account
-	serviceAccounts := e.client.CoreV1().ServiceAccounts(serviceAccount.Namespace)
+	serviceAccounts := e.client.CoreV1().ServiceAccountsWithMultiTenancy(serviceAccount.Namespace, serviceAccount.Tenant)
 	liveServiceAccount, err := serviceAccounts.Get(serviceAccount.Name, metav1.GetOptions{})
 	if err != nil {
 		// Retry if we cannot fetch the live service account (for a NotFound error, either the live lookup or our cache are stale)
@@ -404,13 +404,17 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 		return true, err
 	}
 	secret.Data[v1.ServiceAccountTokenKey] = []byte(token)
-	secret.Data[v1.ServiceAccountNamespaceKey] = []byte(serviceAccount.Namespace)
+	nsKeyContents := serviceAccount.Tenant + "/" + serviceAccount.Namespace
+	if serviceAccount.Tenant == metav1.TenantDefault {
+		nsKeyContents = serviceAccount.Namespace
+	}
+	secret.Data[v1.ServiceAccountNamespaceKey] = []byte(nsKeyContents)
 	if e.rootCA != nil && len(e.rootCA) > 0 {
 		secret.Data[v1.ServiceAccountRootCAKey] = e.rootCA
 	}
 
 	// Save the secret
-	createdToken, err := e.client.CoreV1().Secrets(serviceAccount.Namespace).Create(secret)
+	createdToken, err := e.client.CoreV1().SecretsWithMultiTenancy(serviceAccount.Namespace, serviceAccount.Tenant).Create(secret)
 	if err != nil {
 		// retriable error
 		return true, err
@@ -458,9 +462,9 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 
 	if !addedReference {
 		// we weren't able to use the token, try to clean it up.
-		klog.V(2).Infof("deleting secret %s/%s because reference couldn't be added (%v)", secret.Namespace, secret.Name, err)
+		klog.V(2).Infof("deleting secret %s/%s/%s because reference couldn't be added (%v)", secret.Tenant, secret.Namespace, secret.Name, err)
 		deleteOpts := &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &createdToken.UID}}
-		if deleteErr := e.client.CoreV1().Secrets(createdToken.Namespace).Delete(createdToken.Name, deleteOpts); deleteErr != nil {
+		if deleteErr := e.client.CoreV1().SecretsWithMultiTenancy(createdToken.Namespace, createdToken.Tenant).Delete(createdToken.Name, deleteOpts); deleteErr != nil {
 			klog.Error(deleteErr) // if we fail, just log it
 		}
 	}
@@ -518,7 +522,7 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *v1.ServiceAccou
 
 	// We don't want to update the cache's copy of the secret
 	// so add the token to a freshly retrieved copy of the secret
-	secrets := e.client.CoreV1().Secrets(cachedSecret.Namespace)
+	secrets := e.client.CoreV1().SecretsWithMultiTenancy(cachedSecret.Namespace, cachedSecret.Tenant)
 	liveSecret, err := secrets.Get(cachedSecret.Name, metav1.GetOptions{})
 	if err != nil {
 		// Retry for any error other than a NotFound
@@ -527,7 +531,7 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *v1.ServiceAccou
 	if liveSecret.ResourceVersion != cachedSecret.ResourceVersion {
 		// our view of the secret is not up to date
 		// we'll get notified of an update event later and get to try again
-		klog.V(2).Infof("secret %s/%s is not up to date, skipping token population", liveSecret.Namespace, liveSecret.Name)
+		klog.V(2).Infof("secret %s/%s/%s is not up to date, skipping token population", liveSecret.Tenant, liveSecret.Namespace, liveSecret.Name)
 		return false, nil
 	}
 
@@ -549,7 +553,12 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *v1.ServiceAccou
 	}
 	// Set the namespace
 	if needsNamespace {
-		liveSecret.Data[v1.ServiceAccountNamespaceKey] = []byte(liveSecret.Namespace)
+		nsKeyContents := liveSecret.Tenant + "/" + liveSecret.Namespace
+		if liveSecret.Tenant == metav1.TenantDefault {
+			nsKeyContents = liveSecret.Namespace
+		}
+
+		liveSecret.Data[v1.ServiceAccountNamespaceKey] = []byte(nsKeyContents)
 	}
 
 	// Generate the token
@@ -579,10 +588,10 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *v1.ServiceAccou
 }
 
 // removeSecretReference updates the given ServiceAccount to remove a reference to the given secretName if needed.
-func (e *TokensController) removeSecretReference(saNamespace string, saName string, saUID types.UID, secretName string) error {
+func (e *TokensController) removeSecretReference(saTenant, saNamespace string, saName string, saUID types.UID, secretName string) error {
 	// We don't want to update the cache's copy of the service account
 	// so remove the secret from a freshly retrieved copy of the service account
-	serviceAccounts := e.client.CoreV1().ServiceAccounts(saNamespace)
+	serviceAccounts := e.client.CoreV1().ServiceAccountsWithMultiTenancy(saNamespace, saTenant)
 	serviceAccount, err := serviceAccounts.Get(saName, metav1.GetOptions{})
 	// Ignore NotFound errors when attempting to remove a reference
 	if apierrors.IsNotFound(err) {
@@ -618,9 +627,9 @@ func (e *TokensController) removeSecretReference(saNamespace string, saName stri
 	return err
 }
 
-func (e *TokensController) getServiceAccount(ns string, name string, uid types.UID, fetchOnCacheMiss bool) (*v1.ServiceAccount, error) {
+func (e *TokensController) getServiceAccount(tenant, ns string, name string, uid types.UID, fetchOnCacheMiss bool) (*v1.ServiceAccount, error) {
 	// Look up in cache
-	sa, err := e.serviceAccounts.ServiceAccounts(ns).Get(name)
+	sa, err := e.serviceAccounts.ServiceAccountsWithMultiTenancy(ns, tenant).Get(name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
@@ -636,7 +645,7 @@ func (e *TokensController) getServiceAccount(ns string, name string, uid types.U
 	}
 
 	// Live lookup
-	sa, err = e.client.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
+	sa, err = e.client.CoreV1().ServiceAccountsWithMultiTenancy(ns, tenant).Get(name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -650,9 +659,9 @@ func (e *TokensController) getServiceAccount(ns string, name string, uid types.U
 	return nil, nil
 }
 
-func (e *TokensController) getSecret(ns string, name string, uid types.UID, fetchOnCacheMiss bool) (*v1.Secret, error) {
+func (e *TokensController) getSecret(tenant, ns string, name string, uid types.UID, fetchOnCacheMiss bool) (*v1.Secret, error) {
 	// Look up in cache
-	obj, exists, err := e.updatedSecrets.GetByKey(makeCacheKey(ns, name))
+	obj, exists, err := e.updatedSecrets.GetByKey(makeCacheKey(tenant, ns, name))
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +681,7 @@ func (e *TokensController) getSecret(ns string, name string, uid types.UID, fetc
 	}
 
 	// Live lookup
-	secret, err := e.client.CoreV1().Secrets(ns).Get(name, metav1.GetOptions{})
+	secret, err := e.client.CoreV1().SecretsWithMultiTenancy(ns, tenant).Get(name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -689,7 +698,11 @@ func (e *TokensController) getSecret(ns string, name string, uid types.UID, fetc
 // listTokenSecrets returns a list of all of the ServiceAccountToken secrets that
 // reference the given service account's name and uid
 func (e *TokensController) listTokenSecrets(serviceAccount *v1.ServiceAccount) ([]*v1.Secret, error) {
-	namespaceSecrets, err := e.updatedSecrets.ByIndex("namespace", serviceAccount.Namespace)
+	index := serviceAccount.Tenant + "/" + serviceAccount.Namespace
+	if serviceAccount.Tenant == metav1.TenantDefault {
+		index = serviceAccount.Namespace
+	}
+	namespaceSecrets, err := e.updatedSecrets.ByIndex("namespace", index)
 	if err != nil {
 		return nil, err
 	}
@@ -717,6 +730,7 @@ func getSecretReferences(serviceAccount *v1.ServiceAccount) sets.String {
 // It contains enough information to look up the cached service account,
 // or delete owned tokens if the service account no longer exists.
 type serviceAccountQueueKey struct {
+	tenant    string
 	namespace string
 	name      string
 	uid       types.UID
@@ -724,6 +738,7 @@ type serviceAccountQueueKey struct {
 
 func makeServiceAccountKey(sa *v1.ServiceAccount) interface{} {
 	return serviceAccountQueueKey{
+		tenant:    sa.Tenant,
 		namespace: sa.Namespace,
 		name:      sa.Name,
 		uid:       sa.UID,
@@ -732,7 +747,7 @@ func makeServiceAccountKey(sa *v1.ServiceAccount) interface{} {
 
 func parseServiceAccountKey(key interface{}) (serviceAccountQueueKey, error) {
 	queueKey, ok := key.(serviceAccountQueueKey)
-	if !ok || len(queueKey.namespace) == 0 || len(queueKey.name) == 0 || len(queueKey.uid) == 0 {
+	if !ok || len(queueKey.tenant) == 0 || len(queueKey.namespace) == 0 || len(queueKey.name) == 0 || len(queueKey.uid) == 0 {
 		return serviceAccountQueueKey{}, fmt.Errorf("invalid serviceaccount key: %#v", key)
 	}
 	return queueKey, nil
@@ -742,6 +757,7 @@ func parseServiceAccountKey(key interface{}) (serviceAccountQueueKey, error) {
 // It contains enough information to look up the cached service account,
 // or delete the secret reference if the secret no longer exists.
 type secretQueueKey struct {
+	tenant    string
 	namespace string
 	name      string
 	uid       types.UID
@@ -752,6 +768,7 @@ type secretQueueKey struct {
 
 func makeSecretQueueKey(secret *v1.Secret) interface{} {
 	return secretQueueKey{
+		tenant:    secret.Tenant,
 		namespace: secret.Namespace,
 		name:      secret.Name,
 		uid:       secret.UID,
@@ -762,13 +779,17 @@ func makeSecretQueueKey(secret *v1.Secret) interface{} {
 
 func parseSecretQueueKey(key interface{}) (secretQueueKey, error) {
 	queueKey, ok := key.(secretQueueKey)
-	if !ok || len(queueKey.namespace) == 0 || len(queueKey.name) == 0 || len(queueKey.uid) == 0 || len(queueKey.saName) == 0 {
+	if !ok || len(queueKey.tenant) == 0 || len(queueKey.namespace) == 0 || len(queueKey.name) == 0 || len(queueKey.uid) == 0 || len(queueKey.saName) == 0 {
 		return secretQueueKey{}, fmt.Errorf("invalid secret key: %#v", key)
 	}
 	return queueKey, nil
 }
 
 // produce the same key format as cache.MetaNamespaceKeyFunc
-func makeCacheKey(namespace, name string) string {
-	return namespace + "/" + name
+func makeCacheKey(tenant, namespace, name string) string {
+	key := tenant + "/" + namespace + "/" + name
+	if tenant == metav1.TenantDefault {
+		key = namespace + "/" + name
+	}
+	return key
 }

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -404,7 +404,7 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 		return true, err
 	}
 	secret.Data[v1.ServiceAccountTokenKey] = []byte(token)
-	nsKeyContents := serviceAccount.Tenant + "/" + serviceAccount.Namespace
+	nsKeyContents := fmt.Sprintf("%s/%s", serviceAccount.Tenant, serviceAccount.Namespace)
 	if serviceAccount.Tenant == metav1.TenantDefault {
 		nsKeyContents = serviceAccount.Namespace
 	}
@@ -553,7 +553,7 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *v1.ServiceAccou
 	}
 	// Set the namespace
 	if needsNamespace {
-		nsKeyContents := liveSecret.Tenant + "/" + liveSecret.Namespace
+		nsKeyContents := fmt.Sprintf("%s/%s", liveSecret.Tenant, liveSecret.Namespace)
 		if liveSecret.Tenant == metav1.TenantDefault {
 			nsKeyContents = liveSecret.Namespace
 		}
@@ -698,7 +698,7 @@ func (e *TokensController) getSecret(tenant, ns string, name string, uid types.U
 // listTokenSecrets returns a list of all of the ServiceAccountToken secrets that
 // reference the given service account's name and uid
 func (e *TokensController) listTokenSecrets(serviceAccount *v1.ServiceAccount) ([]*v1.Secret, error) {
-	index := serviceAccount.Tenant + "/" + serviceAccount.Namespace
+	index := fmt.Sprintf("%s/%s", serviceAccount.Tenant, serviceAccount.Namespace)
 	if serviceAccount.Tenant == metav1.TenantDefault {
 		index = serviceAccount.Namespace
 	}
@@ -787,9 +787,9 @@ func parseSecretQueueKey(key interface{}) (secretQueueKey, error) {
 
 // produce the same key format as cache.MetaNamespaceKeyFunc
 func makeCacheKey(tenant, namespace, name string) string {
-	key := tenant + "/" + namespace + "/" + name
+	key := fmt.Sprintf("%s/%s/%s", tenant, namespace, name)
 	if tenant == metav1.TenantDefault {
-		key = namespace + "/" + name
+		key = fmt.Sprintf("%s/%s", namespace, name)
 	}
 	return key
 }

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -754,8 +755,8 @@ func (adc *attachDetachController) GetNodeAllocatable() (v1.ResourceList, error)
 	return v1.ResourceList{}, nil
 }
 
-func (adc *attachDetachController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (adc *attachDetachController) GetSecretFunc() func(tenant, namespace, name string) (*v1.Secret, error) {
+	return func(_, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in attachDetachController")
 	}
 }

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -388,8 +389,8 @@ func (expc *expandController) GetNodeAllocatable() (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (expc *expandController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (expc *expandController) GetSecretFunc() func(tenant, namespace, name string) (*v1.Secret, error) {
+	return func(_, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in expandController")
 	}
 }

--- a/pkg/controller/volume/persistentvolume/volume_host.go
+++ b/pkg/controller/volume/persistentvolume/volume_host.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -92,8 +93,8 @@ func (ctrl *PersistentVolumeController) GetNodeAllocatable() (v1.ResourceList, e
 	return v1.ResourceList{}, nil
 }
 
-func (ctrl *PersistentVolumeController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (ctrl *PersistentVolumeController) GetSecretFunc() func(tenant, namespace, name string) (*v1.Secret, error) {
+	return func(_, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in PersistentVolumeController")
 	}
 }

--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -79,7 +80,7 @@ type configMapManager struct {
 }
 
 func (c *configMapManager) GetConfigMap(namespace, name string) (*v1.ConfigMap, error) {
-	object, err := c.manager.GetObject(namespace, name)
+	object, err := c.manager.GetObject(metav1.TenantDefault, namespace, name)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,7 @@ const (
 //   not there, invalidated or too old, we fetch it from apiserver and refresh the
 //   value in cache; otherwise it is just fetched from cache
 func NewCachingConfigMapManager(kubeClient clientset.Interface, getTTL manager.GetObjectTTLFunc) Manager {
-	getConfigMap := func(namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
+	getConfigMap := func(tenant, namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().ConfigMaps(namespace).Get(name, opts)
 	}
 	configMapStore := manager.NewObjectStore(getConfigMap, clock.RealClock{}, getTTL, defaultTTL)
@@ -135,10 +136,10 @@ func NewCachingConfigMapManager(kubeClient clientset.Interface, getTTL manager.G
 //   referenced objects that aren't referenced from other registered pods
 // - every GetObject() returns a value from local cache propagated via watches
 func NewWatchingConfigMapManager(kubeClient clientset.Interface) Manager {
-	listConfigMap := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
+	listConfigMap := func(tenant, namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().ConfigMaps(namespace).List(opts)
 	}
-	watchConfigMap := func(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	watchConfigMap := func(tenant, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
 		return kubeClient.CoreV1().ConfigMaps(namespace).Watch(opts)
 	}
 	newConfigMap := func() runtime.Object {

--- a/pkg/kubelet/configmap/configmap_manager_test.go
+++ b/pkg/kubelet/configmap/configmap_manager_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/configmap/configmap_manager_test.go
+++ b/pkg/kubelet/configmap/configmap_manager_test.go
@@ -34,11 +34,11 @@ import (
 )
 
 func checkObject(t *testing.T, store manager.Store, ns, name string, shouldExist bool) {
-	_, err := store.Get(ns, name)
+	_, err := store.Get(metav1.TenantDefault, ns, name)
 	if shouldExist && err != nil {
 		t.Errorf("unexpected actions: %#v", err)
 	}
-	if !shouldExist && (err == nil || !strings.Contains(err.Error(), fmt.Sprintf("object %q/%q not registered", ns, name))) {
+	if !shouldExist && (err == nil || !strings.Contains(err.Error(), fmt.Sprintf("object %q/%q/%q not registered", metav1.TenantDefault, ns, name))) {
 		t.Errorf("unexpected actions: %#v", err)
 	}
 }
@@ -48,7 +48,7 @@ func noObjectTTL() (time.Duration, bool) {
 }
 
 func getConfigMap(fakeClient clientset.Interface) manager.GetObjectFunc {
-	return func(namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
+	return func(tenant, namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
 		return fakeClient.CoreV1().ConfigMaps(namespace).Get(name, opts)
 	}
 }
@@ -66,6 +66,7 @@ type configMapsToAttach struct {
 func podWithConfigMaps(ns, podName string, toAttach configMapsToAttach) *v1.Pod {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
+			Tenant:    metav1.TenantDefault,
 			Namespace: ns,
 			Name:      podName,
 		},

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -620,7 +620,7 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 					return result, fmt.Errorf("Couldn't get secret %v/%v, no kubeClient defined", pod.Namespace, name)
 				}
 				optional := s.Optional != nil && *s.Optional
-				secret, err = kl.secretManager.GetSecret(pod.Namespace, name)
+				secret, err = kl.secretManager.GetSecret(pod.Tenant, pod.Namespace, name)
 				if err != nil {
 					if errors.IsNotFound(err) && optional {
 						// ignore error when marked optional
@@ -720,7 +720,7 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 					if kl.kubeClient == nil {
 						return result, fmt.Errorf("Couldn't get secret %v/%v, no kubeClient defined", pod.Namespace, name)
 					}
-					secret, err = kl.secretManager.GetSecret(pod.Namespace, name)
+					secret, err = kl.secretManager.GetSecret(pod.Tenant, pod.Namespace, name)
 					if err != nil {
 						if errors.IsNotFound(err) && optional {
 							// ignore error when marked optional
@@ -845,7 +845,7 @@ func (kl *Kubelet) getPullSecretsForPod(pod *v1.Pod) []v1.Secret {
 	pullSecrets := []v1.Secret{}
 
 	for _, secretRef := range pod.Spec.ImagePullSecrets {
-		secret, err := kl.secretManager.GetSecret(pod.Namespace, secretRef.Name)
+		secret, err := kl.secretManager.GetSecret(pod.Tenant, pod.Namespace, secretRef.Name)
 		if err != nil {
 			klog.Warningf("Unable to retrieve pull secret %s/%s for %s/%s due to %v.  The image pull may not succeed.", pod.Namespace, secretRef.Name, pod.Namespace, pod.Name, err)
 			continue

--- a/pkg/kubelet/secret/fake_manager.go
+++ b/pkg/kubelet/secret/fake_manager.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,7 +31,7 @@ func NewFakeManager() Manager {
 	return &fakeManager{}
 }
 
-func (s *fakeManager) GetSecret(namespace, name string) (*v1.Secret, error) {
+func (s *fakeManager) GetSecret(tenant, namespace, name string) (*v1.Secret, error) {
 	return nil, nil
 }
 

--- a/pkg/kubelet/secret/secret_manager_test.go
+++ b/pkg/kubelet/secret/secret_manager_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/secret/secret_manager_test.go
+++ b/pkg/kubelet/secret/secret_manager_test.go
@@ -33,12 +33,12 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/manager"
 )
 
-func checkObject(t *testing.T, store manager.Store, ns, name string, shouldExist bool) {
-	_, err := store.Get(ns, name)
+func checkObject(t *testing.T, store manager.Store, tenant, ns, name string, shouldExist bool) {
+	_, err := store.Get(tenant, ns, name)
 	if shouldExist && err != nil {
 		t.Errorf("unexpected actions: %#v", err)
 	}
-	if !shouldExist && (err == nil || !strings.Contains(err.Error(), fmt.Sprintf("object %q/%q not registered", ns, name))) {
+	if !shouldExist && (err == nil || !strings.Contains(err.Error(), fmt.Sprintf("object %q/%q/%q not registered", tenant, ns, name))) {
 		t.Errorf("unexpected actions: %#v", err)
 	}
 }
@@ -48,8 +48,8 @@ func noObjectTTL() (time.Duration, bool) {
 }
 
 func getSecret(fakeClient clientset.Interface) manager.GetObjectFunc {
-	return func(namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
-		return fakeClient.CoreV1().Secrets(namespace).Get(name, opts)
+	return func(tenant, namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
+		return fakeClient.CoreV1().SecretsWithMultiTenancy(namespace, tenant).Get(name, opts)
 	}
 }
 
@@ -63,9 +63,10 @@ type secretsToAttach struct {
 	containerEnvSecrets  []envSecrets
 }
 
-func podWithSecrets(ns, podName string, toAttach secretsToAttach) *v1.Pod {
+func podWithSecrets(tenant, ns, podName string, toAttach secretsToAttach) *v1.Pod {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
+			Tenant:    tenant,
 			Namespace: ns,
 			Name:      podName,
 		},
@@ -106,6 +107,14 @@ func podWithSecrets(ns, podName string, toAttach secretsToAttach) *v1.Pod {
 }
 
 func TestCacheBasedSecretManager(t *testing.T) {
+	testCacheBasedSecretManager(t, metav1.TenantDefault)
+}
+
+func TestCacheBasedSecretManagerWithMultiTenancy(t *testing.T) {
+	testCacheBasedSecretManager(t, "test-te")
+}
+
+func testCacheBasedSecretManager(t *testing.T, tenant string) {
 	fakeClient := &fake.Clientset{}
 	store := manager.NewObjectStore(getSecret(fakeClient), clock.RealClock{}, noObjectTTL, 0)
 	manager := &secretManager{
@@ -121,7 +130,7 @@ func TestCacheBasedSecretManager(t *testing.T) {
 			{envFromNames: []string{"s20"}},
 		},
 	}
-	manager.RegisterPod(podWithSecrets("ns1", "name1", s1))
+	manager.RegisterPod(podWithSecrets(tenant, "ns1", "name1", s1))
 	// Update the pod with a different secrets.
 	s2 := secretsToAttach{
 		imagePullSecretNames: []string{"s1"},
@@ -131,9 +140,9 @@ func TestCacheBasedSecretManager(t *testing.T) {
 			{envFromNames: []string{"s40"}},
 		},
 	}
-	manager.RegisterPod(podWithSecrets("ns1", "name1", s2))
+	manager.RegisterPod(podWithSecrets(tenant, "ns1", "name1", s2))
 	// Create another pod, but with same secrets in different namespace.
-	manager.RegisterPod(podWithSecrets("ns2", "name2", s2))
+	manager.RegisterPod(podWithSecrets(tenant, "ns2", "name2", s2))
 	// Create and delete a pod with some other secrets.
 	s3 := secretsToAttach{
 		imagePullSecretNames: []string{"s5"},
@@ -142,15 +151,15 @@ func TestCacheBasedSecretManager(t *testing.T) {
 			{envFromNames: []string{"s60"}},
 		},
 	}
-	manager.RegisterPod(podWithSecrets("ns3", "name", s3))
-	manager.UnregisterPod(podWithSecrets("ns3", "name", s3))
+	manager.RegisterPod(podWithSecrets(tenant, "ns3", "name", s3))
+	manager.UnregisterPod(podWithSecrets(tenant, "ns3", "name", s3))
 
 	// We should have only: s1, s3 and s4 secrets in namespaces: ns1 and ns2.
 	for _, ns := range []string{"ns1", "ns2", "ns3"} {
 		for _, secret := range []string{"s1", "s2", "s3", "s4", "s5", "s6", "s20", "s40", "s50"} {
 			shouldExist :=
 				(secret == "s1" || secret == "s3" || secret == "s4" || secret == "s40") && (ns == "ns1" || ns == "ns2")
-			checkObject(t, store, ns, secret, shouldExist)
+			checkObject(t, store, tenant, ns, secret, shouldExist)
 		}
 	}
 }

--- a/pkg/kubelet/util/manager/cache_based_manager_test.go
+++ b/pkg/kubelet/util/manager/cache_based_manager_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/util/manager/manager.go
+++ b/pkg/kubelet/util/manager/manager.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,8 +26,8 @@ import (
 // objects referenced by pods in the underlying cache and
 // extracting those from that cache if needed.
 type Manager interface {
-	// Get object by its namespace and name.
-	GetObject(namespace, name string) (runtime.Object, error)
+	// Get object by its tenant, namespace and name.
+	GetObject(tenant, namespace, name string) (runtime.Object, error)
 
 	// WARNING: Register/UnregisterPod functions should be efficient,
 	// i.e. should not block on network operations.
@@ -49,12 +50,12 @@ type Store interface {
 	// AddReference adds a reference to the object to the store.
 	// Note that multiple additions to the store has to be allowed
 	// in the implementations and effectively treated as refcounted.
-	AddReference(namespace, name string)
+	AddReference(tenant, namespace, name string)
 	// DeleteReference deletes reference to the object from the store.
 	// Note that object should be deleted only when there was a
 	// corresponding Delete call for each of Add calls (effectively
 	// when refcount was reduced to zero).
-	DeleteReference(namespace, name string)
+	DeleteReference(tenant, namespace, name string)
 	// Get an object from a store.
-	Get(namespace, name string) (runtime.Object, error)
+	Get(tenant, namespace, name string) (runtime.Object, error)
 }

--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,8 +42,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-type listObjectFunc func(string, metav1.ListOptions) (runtime.Object, error)
-type watchObjectFunc func(string, metav1.ListOptions) (watch.Interface, error)
+type listObjectFunc func(string, string, metav1.ListOptions) (runtime.Object, error)
+type watchObjectFunc func(string, string, metav1.ListOptions) (watch.Interface, error)
 type newObjectFunc func() runtime.Object
 
 // objectCacheItem is a single item stored in objectCache.
@@ -85,19 +86,19 @@ func (c *objectCache) newStore() cache.Store {
 	return cache.NewStore(cache.MetaNamespaceKeyFunc)
 }
 
-func (c *objectCache) newReflector(namespace, name string) *objectCacheItem {
+func (c *objectCache) newReflector(tenant, namespace, name string) *objectCacheItem {
 	fieldSelector := fields.Set{"metadata.name": name}.AsSelector().String()
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		options.FieldSelector = fieldSelector
-		return c.listObject(namespace, options)
+		return c.listObject(tenant, namespace, options)
 	}
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		options.FieldSelector = fieldSelector
-		return c.watchObject(namespace, options)
+		return c.watchObject(tenant, namespace, options)
 	}
 	store := c.newStore()
 	reflector := cache.NewNamedReflector(
-		fmt.Sprintf("object-%q/%q", namespace, name),
+		fmt.Sprintf("object-%q/%q/%q", tenant, namespace, name),
 		&cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc},
 		c.newObject(),
 		store,
@@ -113,8 +114,8 @@ func (c *objectCache) newReflector(namespace, name string) *objectCacheItem {
 	}
 }
 
-func (c *objectCache) AddReference(namespace, name string) {
-	key := objectKey{namespace: namespace, name: name}
+func (c *objectCache) AddReference(tenant, namespace, name string) {
+	key := objectKey{tenant: tenant, namespace: namespace, name: name}
 
 	// AddReference is called from RegisterPod thus it needs to be efficient.
 	// Thus, it is only increaisng refCount and in case of first registration
@@ -125,14 +126,14 @@ func (c *objectCache) AddReference(namespace, name string) {
 	defer c.lock.Unlock()
 	item, exists := c.items[key]
 	if !exists {
-		item = c.newReflector(namespace, name)
+		item = c.newReflector(tenant, namespace, name)
 		c.items[key] = item
 	}
 	item.refCount++
 }
 
-func (c *objectCache) DeleteReference(namespace, name string) {
-	key := objectKey{namespace: namespace, name: name}
+func (c *objectCache) DeleteReference(tenant, namespace, name string) {
+	key := objectKey{tenant: tenant, namespace: namespace, name: name}
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -148,28 +149,32 @@ func (c *objectCache) DeleteReference(namespace, name string) {
 
 // key returns key of an object with a given name and namespace.
 // This has to be in-sync with cache.MetaNamespaceKeyFunc.
-func (c *objectCache) key(namespace, name string) string {
+func (c *objectCache) key(tenant, namespace, name string) string {
+	result := name
 	if len(namespace) > 0 {
-		return namespace + "/" + name
+		result = namespace + "/" + result
 	}
-	return name
+	if len(tenant) > 0 && tenant != metav1.TenantDefault {
+		result = tenant + "/" + result
+	}
+	return result
 }
 
-func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
-	key := objectKey{namespace: namespace, name: name}
+func (c *objectCache) Get(tenant, namespace, name string) (runtime.Object, error) {
+	key := objectKey{tenant: tenant, namespace: namespace, name: name}
 
 	c.lock.Lock()
 	item, exists := c.items[key]
 	c.lock.Unlock()
 
 	if !exists {
-		return nil, fmt.Errorf("object %q/%q not registered", namespace, name)
+		return nil, fmt.Errorf("object %q/%q/%q not registered", tenant, namespace, name)
 	}
 	if err := wait.PollImmediate(10*time.Millisecond, time.Second, item.hasSynced); err != nil {
 		return nil, fmt.Errorf("couldn't propagate object cache: %v", err)
 	}
 
-	obj, exists, err := item.store.GetByKey(c.key(namespace, name))
+	obj, exists, err := item.store.GetByKey(c.key(tenant, namespace, name))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -39,14 +39,14 @@ import (
 )
 
 func listSecret(fakeClient clientset.Interface) listObjectFunc {
-	return func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
-		return fakeClient.CoreV1().Secrets(namespace).List(opts)
+	return func(tenant, namespace string, opts metav1.ListOptions) (runtime.Object, error) {
+		return fakeClient.CoreV1().SecretsWithMultiTenancy(namespace, tenant).List(opts)
 	}
 }
 
 func watchSecret(fakeClient clientset.Interface) watchObjectFunc {
-	return func(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
-		return fakeClient.CoreV1().Secrets(namespace).Watch(opts)
+	return func(tenant, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+		return fakeClient.CoreV1().SecretsWithMultiTenancy(namespace, tenant).Watch(opts)
 	}
 }
 
@@ -61,6 +61,14 @@ func newSecretCache(fakeClient clientset.Interface) *objectCache {
 }
 
 func TestSecretCache(t *testing.T) {
+	testSecretCache(t, metav1.TenantDefault)
+}
+
+func TestSecretCacheWithMultiTenancy(t *testing.T) {
+	testSecretCache(t, "test-te")
+}
+
+func testSecretCache(t *testing.T, tenant string) {
 	fakeClient := &fake.Clientset{}
 
 	listReactor := func(a core.Action) (bool, runtime.Object, error) {
@@ -77,19 +85,19 @@ func TestSecretCache(t *testing.T) {
 
 	store := newSecretCache(fakeClient)
 
-	store.AddReference("ns", "name")
-	_, err := store.Get("ns", "name")
+	store.AddReference(tenant, "ns", "name")
+	_, err := store.Get(tenant, "ns", "name")
 	if !apierrors.IsNotFound(err) {
 		t.Errorf("Expected NotFound error, got: %v", err)
 	}
 
 	// Eventually we should be able to read added secret.
 	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns", ResourceVersion: "125"},
+		ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns", Tenant: tenant, ResourceVersion: "125"},
 	}
 	fakeWatch.Add(secret)
 	getFn := func() (bool, error) {
-		object, err := store.Get("ns", "name")
+		object, err := store.Get(tenant, "ns", "name")
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -97,7 +105,7 @@ func TestSecretCache(t *testing.T) {
 			return false, err
 		}
 		secret := object.(*v1.Secret)
-		if secret == nil || secret.Name != "name" || secret.Namespace != "ns" {
+		if secret == nil || secret.Name != "name" || secret.Namespace != "ns" || secret.Tenant != tenant {
 			return false, fmt.Errorf("unexpected secret: %v", secret)
 		}
 		return true, nil
@@ -109,7 +117,7 @@ func TestSecretCache(t *testing.T) {
 	// Eventually we should observer secret deletion.
 	fakeWatch.Delete(secret)
 	getFn = func() (bool, error) {
-		_, err := store.Get("ns", "name")
+		_, err := store.Get(tenant, "ns", "name")
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return true, nil
@@ -122,14 +130,22 @@ func TestSecretCache(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	store.DeleteReference("ns", "name")
-	_, err = store.Get("ns", "name")
+	store.DeleteReference(tenant, "ns", "name")
+	_, err = store.Get(tenant, "ns", "name")
 	if err == nil || !strings.Contains(err.Error(), "not registered") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestSecretCacheMultipleRegistrations(t *testing.T) {
+	testSecretCacheMultipleRegistrations(t, metav1.TenantDefault)
+}
+
+func TestSecretCacheMultipleRegistrationsWithMultiTenancy(t *testing.T) {
+	testSecretCacheMultipleRegistrations(t, "test-te")
+}
+
+func testSecretCacheMultipleRegistrations(t *testing.T, tenant string) {
 	fakeClient := &fake.Clientset{}
 
 	listReactor := func(a core.Action) (bool, runtime.Object, error) {
@@ -146,7 +162,7 @@ func TestSecretCacheMultipleRegistrations(t *testing.T) {
 
 	store := newSecretCache(fakeClient)
 
-	store.AddReference("ns", "name")
+	store.AddReference(tenant, "ns", "name")
 	// This should trigger List and Watch actions eventually.
 	actionsFn := func() (bool, error) {
 		actions := fakeClient.Actions()
@@ -167,15 +183,15 @@ func TestSecretCacheMultipleRegistrations(t *testing.T) {
 
 	// Next registrations shouldn't trigger any new actions.
 	for i := 0; i < 20; i++ {
-		store.AddReference("ns", "name")
-		store.DeleteReference("ns", "name")
+		store.AddReference(tenant, "ns", "name")
+		store.DeleteReference(tenant, "ns", "name")
 	}
 	actions := fakeClient.Actions()
 	assert.Equal(t, 2, len(actions), "unexpected actions: %#v", actions)
 
 	// Final delete also doesn't trigger any action.
-	store.DeleteReference("ns", "name")
-	_, err := store.Get("ns", "name")
+	store.DeleteReference(tenant, "ns", "name")
+	_, err := store.Get(tenant, "ns", "name")
 	if err == nil || !strings.Contains(err.Error(), "not registered") {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -250,7 +251,7 @@ func (kvh *kubeletVolumeHost) GetNodeAllocatable() (v1.ResourceList, error) {
 	return node.Status.Allocatable, nil
 }
 
-func (kvh *kubeletVolumeHost) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
+func (kvh *kubeletVolumeHost) GetSecretFunc() func(tenant, namespace, name string) (*v1.Secret, error) {
 	return kvh.secretManager.GetSecret
 }
 

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -416,7 +417,7 @@ type VolumeHost interface {
 	GetNodeAllocatable() (v1.ResourceList, error)
 
 	// Returns a function that returns a secret.
-	GetSecretFunc() func(namespace, name string) (*v1.Secret, error)
+	GetSecretFunc() func(tenant, namespace, name string) (*v1.Secret, error)
 
 	// Returns a function that returns a configmap.
 	GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error)

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -47,7 +48,7 @@ const (
 
 type projectedPlugin struct {
 	host                      volume.VolumeHost
-	getSecret                 func(namespace, name string) (*v1.Secret, error)
+	getSecret                 func(tenant, namespace, name string) (*v1.Secret, error)
 	getConfigMap              func(namespace, name string) (*v1.ConfigMap, error)
 	getServiceAccountToken    func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	deleteServiceAccountToken func(podUID types.UID)
@@ -268,7 +269,7 @@ func (s *projectedVolumeMounter) collectData() (map[string]volumeutil.FileProjec
 		switch {
 		case source.Secret != nil:
 			optional := source.Secret.Optional != nil && *source.Secret.Optional
-			secretapi, err := s.plugin.getSecret(s.pod.Namespace, source.Secret.Name)
+			secretapi, err := s.plugin.getSecret(s.pod.Tenant, s.pod.Namespace, source.Secret.Name)
 			if err != nil {
 				if !(errors.IsNotFound(err) && optional) {
 					klog.Errorf("Couldn't get secret %v/%v: %v", s.pod.Namespace, source.Secret.Name, err)
@@ -277,6 +278,7 @@ func (s *projectedVolumeMounter) collectData() (map[string]volumeutil.FileProjec
 				}
 				secretapi = &v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
+						Tenant:    s.pod.Tenant,
 						Namespace: s.pod.Namespace,
 						Name:      source.Secret.Name,
 					},

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -45,6 +45,14 @@ import (
 )
 
 func TestCollectDataWithSecret(t *testing.T) {
+	testCollectDataWithSecret(t, metav1.TenantDefault)
+}
+
+func TestCollectDataWithSecretWithMultiTenancy(t *testing.T) {
+	testCollectDataWithSecret(t, "test-te")
+}
+
+func testCollectDataWithSecret(t *testing.T, tenant string) {
 	caseMappingMode := int32(0400)
 	cases := []struct {
 		name     string
@@ -248,7 +256,7 @@ func TestCollectDataWithSecret(t *testing.T) {
 	for _, tc := range cases {
 		testNamespace := "test_projected_namespace"
 		tc.secret.ObjectMeta = metav1.ObjectMeta{
-			Tenant:    metav1.TenantDefault,
+			Tenant:    tenant,
 			Namespace: testNamespace,
 			Name:      tc.name,
 		}
@@ -258,7 +266,7 @@ func TestCollectDataWithSecret(t *testing.T) {
 		source.Sources[0].Secret.Optional = &tc.optional
 
 		testPodUID := types.UID("test_pod_uid")
-		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Namespace: testNamespace, UID: testPodUID}}
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: tenant, Namespace: testNamespace, UID: testPodUID}}
 		client := fake.NewSimpleClientset(tc.secret)
 		_, host := newTestHost(t, client)
 

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -41,6 +41,14 @@ import (
 )
 
 func TestMakePayload(t *testing.T) {
+	testMakePayload(t, metav1.TenantDefault)
+}
+
+func TestMakePayloadWithMultiTenancy(t *testing.T) {
+	testMakePayload(t, "test-te")
+}
+
+func testMakePayload(t *testing.T, tenant string) {
 	caseMappingMode := int32(0400)
 	cases := []struct {
 		name     string
@@ -294,6 +302,14 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestPlugin(t *testing.T) {
+	testPlugin(t, metav1.TenantDefault)
+}
+
+func TestPluginWithMultiTenancy(t *testing.T) {
+	testPlugin(t, "test-te")
+}
+
+func testPlugin(t *testing.T, tenant string) {
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -301,7 +317,7 @@ func TestPlugin(t *testing.T) {
 		testName       = "test_secret_name"
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
-		secret        = secret(testNamespace, testName)
+		secret        = secret(tenant, testNamespace, testName)
 		client        = fake.NewSimpleClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
@@ -314,7 +330,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: tenant, Namespace: testNamespace, UID: testPodUID}}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{})
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -363,7 +379,15 @@ func TestPlugin(t *testing.T) {
 	}
 }
 
-func TestInvalidPathSecret(t *testing.T) {
+func TestInvalidPathsecret(t *testing.T) {
+	testInvalidPathsecret(t, metav1.TenantDefault)
+}
+
+func TestInvalidPathSecretWithMultiTenancy(t *testing.T) {
+	testInvalidPathsecret(t, "test-te")
+}
+
+func testInvalidPathsecret(t *testing.T, tenant string) {
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -371,7 +395,7 @@ func TestInvalidPathSecret(t *testing.T) {
 		testName       = "test_secret_name"
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
-		secret        = secret(testNamespace, testName)
+		secret        = secret(tenant, testNamespace, testName)
 		client        = fake.NewSimpleClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
@@ -388,7 +412,7 @@ func TestInvalidPathSecret(t *testing.T) {
 		t.Errorf("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: tenant, Namespace: testNamespace, UID: testPodUID}}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{})
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -418,6 +442,14 @@ func TestInvalidPathSecret(t *testing.T) {
 // mountpoint, which is the state the system will be in after reboot.  The dir
 // should be mounter and the secret data written to it.
 func TestPluginReboot(t *testing.T) {
+	testPluginReboot(t, metav1.TenantDefault)
+}
+
+func TestPluginRebootWithMultiTenancy(t *testing.T) {
+	testPluginReboot(t, "test-te")
+}
+
+func testPluginReboot(t *testing.T, tenant string) {
 	var (
 		testPodUID     = types.UID("test_pod_uid3")
 		testVolumeName = "test_volume_name"
@@ -425,7 +457,7 @@ func TestPluginReboot(t *testing.T) {
 		testName       = "test_secret_name"
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
-		secret        = secret(testNamespace, testName)
+		secret        = secret(tenant, testNamespace, testName)
 		client        = fake.NewSimpleClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
@@ -438,7 +470,7 @@ func TestPluginReboot(t *testing.T) {
 		t.Errorf("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: tenant, Namespace: testNamespace, UID: testPodUID}}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{})
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -471,6 +503,14 @@ func TestPluginReboot(t *testing.T) {
 }
 
 func TestPluginOptional(t *testing.T) {
+	testPluginOptional(t, metav1.TenantDefault)
+}
+
+func TestPluginOptionalWithMultiTenancy(t *testing.T) {
+	testPluginOptional(t, "test-te")
+}
+
+func testPluginOptional(t *testing.T, tenant string) {
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -492,7 +532,7 @@ func TestPluginOptional(t *testing.T) {
 		t.Errorf("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: tenant, Namespace: testNamespace, UID: testPodUID}}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{})
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -562,6 +602,14 @@ func TestPluginOptional(t *testing.T) {
 }
 
 func TestPluginOptionalKeys(t *testing.T) {
+	testPluginOptionalKeys(t, metav1.TenantDefault)
+}
+
+func TestPluginOptionalKeysWithMultiTenancy(t *testing.T) {
+	testPluginOptionalKeys(t, "test-te")
+}
+
+func testPluginOptionalKeys(t *testing.T, tenant string) {
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -570,7 +618,7 @@ func TestPluginOptionalKeys(t *testing.T) {
 		trueVal        = true
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
-		secret        = secret(testNamespace, testName)
+		secret        = secret(tenant, testNamespace, testName)
 		client        = fake.NewSimpleClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
@@ -590,7 +638,7 @@ func TestPluginOptionalKeys(t *testing.T) {
 		t.Errorf("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: metav1.TenantDefault, Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: tenant, Namespace: testNamespace, UID: testPodUID}}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{})
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -651,10 +699,10 @@ func volumeSpec(volumeName, secretName string, defaultMode int32) *v1.Volume {
 	}
 }
 
-func secret(namespace, name string) v1.Secret {
+func secret(tenant, namespace, name string) v1.Secret {
 	return v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Tenant:    metav1.TenantDefault,
+			Tenant:    tenant,
 			Namespace: namespace,
 			Name:      name,
 		},

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -197,9 +198,9 @@ func (f *fakeVolumeHost) GetNodeAllocatable() (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (f *fakeVolumeHost) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(namespace, name string) (*v1.Secret, error) {
-		return f.kubeClient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+func (f *fakeVolumeHost) GetSecretFunc() func(tenant, namespace, name string) (*v1.Secret, error) {
+	return func(tenant, namespace, name string) (*v1.Secret, error) {
+		return f.kubeClient.CoreV1().SecretsWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
 	}
 }
 


### PR DESCRIPTION
This PR fixed the issue reported in https://github.com/futurewei-cloud/arktos/issues/8.

The chnages made are:
1. Make service account controller support multi-tenancy
2. Make token controller support multi-tenancy
3. Make the process to get secret in service account support multi-tenancy

