### PR TITLE
multi-tenancy kubectl-create

### DIFF
--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -225,6 +225,11 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 		return err
 	}
 
+	cmdTenant, enforceTenant, err := f.ToRawKubeConfigLoader().Tenant()
+	if err != nil {
+		return err
+	}
+
 	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
@@ -234,8 +239,9 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 		Unstructured().
 		Schema(schema).
 		ContinueOnError().
+		TenantParam(cmdTenant).DefaultTenant().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, &o.FilenameOptions).
+		FilenameParamWithMultiTenancy(enforceTenant, enforceNamespace, &o.FilenameOptions).
 		LabelSelectorParam(o.Selector).
 		Flatten().
 		Do()
@@ -327,7 +333,7 @@ func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags
 
 // createAndRefresh creates an object from input info and refreshes info with that object
 func createAndRefresh(info *resource.Info) error {
-	obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object, nil)
+	obj, err := resource.NewHelper(info.Client, info.Mapping).CreateWithMultiTenancy(info.Tenant, info.Namespace, true, info.Object, nil)
 	if err != nil {
 		return err
 	}
@@ -359,6 +365,9 @@ type CreateSubcommandOptions struct {
 	// DryRun is true if the command should be simulated but not run against the server
 	DryRun           bool
 	CreateAnnotation bool
+
+	Tenant        string
+	EnforceTenant bool
 
 	Namespace        string
 	EnforceNamespace bool
@@ -401,6 +410,11 @@ func (o *CreateSubcommandOptions) Complete(f cmdutil.Factory, cmd *cobra.Command
 
 	o.PrintObj = func(obj kruntime.Object, out io.Writer) error {
 		return printer.PrintObj(obj, out)
+	}
+
+	o.Tenant, o.EnforceTenant, err = f.ToRawKubeConfigLoader().Tenant()
+	if err != nil {
+		return err
 	}
 
 	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
@@ -448,10 +462,13 @@ func (o *CreateSubcommandOptions) Run() error {
 		if err := scheme.Scheme.Convert(obj, asUnstructured, nil); err != nil {
 			return err
 		}
+		if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+			o.Tenant = ""
+		}
 		if mapping.Scope.Name() == meta.RESTScopeNameRoot || mapping.Scope.Name() == meta.RESTScopeNameTenant {
 			o.Namespace = ""
 		}
-		actualObject, err := o.DynamicClient.Resource(mapping.Resource).Namespace(o.Namespace).Create(asUnstructured, metav1.CreateOptions{})
+		actualObject, err := o.DynamicClient.Resource(mapping.Resource).NamespaceWithMultiTenancy(o.Namespace, o.Tenant).Create(asUnstructured, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -459,8 +476,14 @@ func (o *CreateSubcommandOptions) Run() error {
 		// ensure we pass a versioned object to the printer
 		obj = actualObject
 	} else {
-		if meta, err := meta.Accessor(obj); err == nil && o.EnforceNamespace {
-			meta.SetNamespace(o.Namespace)
+		meta, err := meta.Accessor(obj)
+		if err == nil {
+			if o.EnforceTenant {
+				meta.SetTenant(o.Tenant)
+			}
+			if o.EnforceNamespace {
+				meta.SetNamespace(o.Namespace)
+			}
 		}
 	}
 

--- a/pkg/kubectl/cmd/create/multi_tenancy_create_test.go
+++ b/pkg/kubectl/cmd/create/multi_tenancy_create_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
+)
+
+func TestExtraArgsFailWithMultiTenancy(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+
+	f := cmdtesting.NewTestFactory()
+	defer f.Cleanup()
+
+	c := NewCmdCreate(f, genericclioptions.NewTestIOStreamsDiscard())
+	options := CreateOptions{}
+	if options.ValidateArgs(c, []string{"rc"}) == nil {
+		t.Errorf("unexpected non-error")
+	}
+}
+
+func TestCreateObjectWithMultiTenancy(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	_, _, rc := cmdtesting.TestData()
+	rc.Items[0].Name = "redis-master-controller"
+
+	tf := cmdtesting.NewTestFactory().WithNamespaceWithMultiTenancy("test-ns", "test-te")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		GroupVersion:         schema.GroupVersion{Version: "v1"},
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/tenants/test-te/namespaces/test-ns/replicationcontrollers" && m == http.MethodPost:
+				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdCreate(tf, ioStreams)
+	cmd.Flags().Set("filename", "../../../../test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml")
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{})
+
+	// uses the name from the file, not the response
+	if buf.String() != "replicationcontroller/redis-master-controller\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}
+
+func TestCreateMultipleObjectWithMultiTenancy(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	_, svc, rc := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespaceWithMultiTenancy("test-ns", "test-te")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		GroupVersion:         schema.GroupVersion{Version: "v1"},
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/tenants/test-te/namespaces/test-ns/services" && m == http.MethodPost:
+				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
+			case p == "/tenants/test-te/namespaces/test-ns/replicationcontrollers" && m == http.MethodPost:
+				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdCreate(tf, ioStreams)
+	cmd.Flags().Set("filename", "../../../../test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml")
+	cmd.Flags().Set("filename", "../../../../test/e2e/testing-manifests/guestbook/frontend-service.yaml")
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{})
+
+	// Names should come from the REST response, NOT the files
+	if buf.String() != "replicationcontroller/rc1\nservice/baz\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}
+
+func TestCreateDirectoryWithMultiTenancy(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	_, _, rc := cmdtesting.TestData()
+	rc.Items[0].Name = "name"
+
+	tf := cmdtesting.NewTestFactory().WithNamespaceWithMultiTenancy("test-ns", "test-te")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		GroupVersion:         schema.GroupVersion{Version: "v1"},
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/tenants/test-te/namespaces/test-ns/replicationcontrollers" && m == http.MethodPost:
+				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdCreate(tf, ioStreams)
+	cmd.Flags().Set("filename", "../../../../test/e2e/testing-manifests/guestbook/legacy")
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{})
+
+	if buf.String() != "replicationcontroller/name\nreplicationcontroller/name\nreplicationcontroller/name\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}


### PR DESCRIPTION
Make kubectl-create support multi-tenancy. Fix issue https://github.com/futurewei-cloud/arktos/issues/7

Here is the test output from my dev box:

qianchen@qianchen-VirtualBox:~/gopath/chenqian/arktos$ cluster/kubectl.sh create -f ~/test/tenant.yaml 
tenant/scale-tenent3 created

qianchen@qianchen-VirtualBox:~/gopath/chenqian/arktos$ cluster/kubectl.sh create namespace test-ns --tenant scale-tenent2
namespace/test-ns created

qianchen@qianchen-VirtualBox:~/gopath/chenqian/arktos$ cluster/kubectl.sh get namespaces --all-tenants 
TENANT          NAME              STATUS   AGE     TENANT
default         default           Active   4m48s   default
default         kube-node-lease   Active   4m53s   default
default         kube-public       Active   4m53s   default
default         kube-system       Active   4m53s   default
scale-tenent2   test-ns           Active   16s     scale-tenent2
