### PR TITLE
Add Kubecon 2019 NA booth demo slides and update owners file

### DIFF
--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,11 +1,10 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
 reviewers:
-  - brendandburns
-  - smarterclayton
-  - thockin
+  - deepak-vij
+  - panda98004
+  - xiaoningDing
+  - zmn223
 approvers:
-  - brendandburns
-  - smarterclayton
-  - thockin
-  - pwittrock
+  - deepak-vij
+  - panda98004
+  - xiaoningDing
+  - zmn223


### PR DESCRIPTION
Changes:
 1.  To easy sharing with external teams, add the Kubecon 2019 NA booth demo slides into folder \docs\slides.   The code name in the slides has been changed from "Alkaid" to "Arktos".

 2.  Update the doc owners file (sorted alphabetically) based on the owners file under root folder.