### PR TITLE
fix kubectl create bazel BUILD file

### DIFF
--- a/pkg/kubectl/cmd/create/BUILD
+++ b/pkg/kubectl/cmd/create/BUILD
@@ -74,6 +74,7 @@ go_test(
         "create_service_test.go",
         "create_serviceaccount_test.go",
         "create_test.go",
+        "multi_tenancy_create_test.go",
     ],
     data = [
         "//test/e2e/testing-manifests:all-srcs",


### PR DESCRIPTION
Fix: add the newly added test file to the BUILD, so it will be picked up by the bazel test.