### PR TITLE
add subcommnand kubectl-create-tenant

### DIFF
--- a/pkg/kubectl/cmd/create/BUILD
+++ b/pkg/kubectl/cmd/create/BUILD
@@ -19,6 +19,7 @@ go_library(
         "create_secret.go",
         "create_service.go",
         "create_serviceaccount.go",
+        "create_tenant.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/create",
     visibility = ["//build/visible_to:pkg_kubectl_cmd_create_CONSUMERS"],

--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -133,6 +133,7 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 	o.PrintFlags.AddFlags(cmd)
 
 	// create subcommands
+	cmd.AddCommand(NewCmdCreateTenant(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateNamespace(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateQuota(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateSecret(f, ioStreams))

--- a/pkg/kubectl/cmd/create/create_namespace.go
+++ b/pkg/kubectl/cmd/create/create_namespace.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,7 +37,7 @@ var (
 	  kubectl create namespace my-namespace`))
 )
 
-// NamespaceOpts is the options for 'create namespare' sub command
+// NamespaceOpts is the options for 'create namespace' sub command
 type NamespaceOpts struct {
 	CreateSubcommandOptions *CreateSubcommandOptions
 }

--- a/pkg/kubectl/cmd/create/create_tenant.go
+++ b/pkg/kubectl/cmd/create/create_tenant.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ var (
 	  kubectl create tenant my-tenant`))
 )
 
-// TenantOpts is the options for 'create namespare' sub command
+// TenantOpts is the options for 'create namespace' sub command
 type TenantOpts struct {
 	CreateSubcommandOptions *CreateSubcommandOptions
 }

--- a/pkg/kubectl/cmd/create/create_tenant.go
+++ b/pkg/kubectl/cmd/create/create_tenant.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/generate"
+	generateversioned "k8s.io/kubernetes/pkg/kubectl/generate/versioned"
+	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
+	"k8s.io/kubernetes/pkg/kubectl/util/templates"
+)
+
+var (
+	tenantLong = templates.LongDesc(i18n.T(`
+		Create a tenant with the specified name.`))
+
+	tenantExample = templates.Examples(i18n.T(`
+	  # Create a new tenant named my-tenant
+	  kubectl create tenant my-tenant`))
+)
+
+// TenantOpts is the options for 'create namespare' sub command
+type TenantOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreateTenant is a macro command to create a new tenant
+func NewCmdCreateTenant(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &TenantOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "tenant NAME [--dry-run]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"te"},
+		Short:                 i18n.T("Create a tenant with the specified name"),
+		Long:                  tenantLong,
+		Example:               tenantExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.TenantV1GeneratorName)
+
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *TenantOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.TenantV1GeneratorName:
+		generator = &generateversioned.TenantGeneratorV1{Name: name}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in TenantOpts instance
+func (o *TenantOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/pkg/kubectl/generate/versioned/BUILD
+++ b/pkg/kubectl/generate/versioned/BUILD
@@ -21,6 +21,7 @@ go_library(
         "service.go",
         "service_basic.go",
         "serviceaccount.go",
+        "tenant.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/kubectl/generate/versioned",
     visibility = ["//visibility:public"],
@@ -72,6 +73,7 @@ go_test(
         "service_basic_test.go",
         "service_test.go",
         "serviceaccount_test.go",
+        "tenant_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/kubectl/generate/versioned/generator.go
+++ b/pkg/kubectl/generate/versioned/generator.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubectl/generate/versioned/generator.go
+++ b/pkg/kubectl/generate/versioned/generator.go
@@ -59,6 +59,7 @@ const (
 	CronJobV2Alpha1GeneratorName            = "cronjob/v2alpha1"
 	CronJobV1Beta1GeneratorName             = "cronjob/v1beta1"
 	NamespaceV1GeneratorName                = "namespace/v1"
+	TenantV1GeneratorName                   = "tenant/v1"
 	ResourceQuotaV1GeneratorName            = "resourcequotas/v1"
 	SecretV1GeneratorName                   = "secret/v1"
 	SecretForDockerRegistryV1GeneratorName  = "secret-for-docker-registry/v1"
@@ -116,6 +117,10 @@ func DefaultGenerators(cmdName string) map[string]generate.Generator {
 	case "namespace":
 		generator = map[string]generate.Generator{
 			NamespaceV1GeneratorName: NamespaceGeneratorV1{},
+		}
+	case "tenant":
+		generator = map[string]generate.Generator{
+			TenantV1GeneratorName: TenantGeneratorV1{},
 		}
 	case "quota":
 		generator = map[string]generate.Generator{

--- a/pkg/kubectl/generate/versioned/tenant.go
+++ b/pkg/kubectl/generate/versioned/tenant.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/kubectl/generate"
+)
+
+// TenantGeneratorV1 supports stable generation of a Tenant
+type TenantGeneratorV1 struct {
+	// Name of Tenant
+	Name string
+}
+
+// Ensure it supports the generator pattern that uses parameter injection
+var _ generate.Generator = &TenantGeneratorV1{}
+
+// Ensure it supports the generator pattern that uses parameters specified during construction
+var _ generate.StructuredGenerator = &TenantGeneratorV1{}
+
+// Generate returns a Tenant using the specified parameters
+func (g TenantGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := generate.ValidateParams(g.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate := &TenantGeneratorV1{Name: params["name"]}
+	return delegate.StructuredGenerate()
+}
+
+// ParamNames returns the set of supported input parameters when using the parameter injection generator pattern
+func (g TenantGeneratorV1) ParamNames() []generate.GeneratorParam {
+	return []generate.GeneratorParam{
+		{Name: "name", Required: true},
+	}
+}
+
+// StructuredGenerate outputs a Tenant object using the configured fields
+func (g *TenantGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := g.validate(); err != nil {
+		return nil, err
+	}
+	Tenant := &v1.Tenant{}
+	Tenant.Name = g.Name
+	return Tenant, nil
+}
+
+// validate validates required fields are set to support structured generation
+func (g *TenantGeneratorV1) validate() error {
+	if len(g.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	return nil
+}

--- a/pkg/kubectl/generate/versioned/tenant.go
+++ b/pkg/kubectl/generate/versioned/tenant.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubectl/generate/versioned/tenant_test.go
+++ b/pkg/kubectl/generate/versioned/tenant_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTenantGenerate(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    map[string]interface{}
+		expected  *v1.Tenant
+		expectErr bool
+	}{
+		{
+			name: "test1",
+			params: map[string]interface{}{
+				"name": "foo",
+			},
+			expected: &v1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:      "test2",
+			params:    map[string]interface{}{},
+			expectErr: true,
+		},
+		{
+			name: "test3",
+			params: map[string]interface{}{
+				"name": 1,
+			},
+			expectErr: true,
+		},
+		{
+			name: "test4",
+			params: map[string]interface{}{
+				"name": "",
+			},
+			expectErr: true,
+		},
+		{
+			name: "test5",
+			params: map[string]interface{}{
+				"name": nil,
+			},
+			expectErr: true,
+		},
+		{
+			name: "test6",
+			params: map[string]interface{}{
+				"name_wrong_key": "some_value",
+			},
+			expectErr: true,
+		},
+		{
+			name: "test7",
+			params: map[string]interface{}{
+				"NAME": "some_value",
+			},
+			expectErr: true,
+		},
+	}
+	generator := TenantGeneratorV1{}
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj, err := generator.Generate(tt.params)
+			switch {
+			case tt.expectErr && err != nil:
+				return // loop, since there's no output to check
+			case tt.expectErr && err == nil:
+				t.Errorf("%v: expected error and didn't get one", index)
+				return // loop, no expected output object
+			case !tt.expectErr && err != nil:
+				t.Errorf("%v: unexpected error %v", index, err)
+				return // loop, no output object
+			case !tt.expectErr && err == nil:
+				// do nothing and drop through
+			}
+			if !reflect.DeepEqual(obj.(*v1.Tenant), tt.expected) {
+				t.Errorf("\nexpected:\n%#v\nsaw:\n%#v", tt.expected, obj.(*v1.Tenant))
+			}
+		})
+	}
+}

--- a/pkg/kubectl/generate/versioned/tenant_test.go
+++ b/pkg/kubectl/generate/versioned/tenant_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds a kubectl subcommand. "kubectl create tenant". So users now create a tenant using command "kubectl create tenant [tenant_name]", instead of having to create a yaml file and run "kubectl create -f [tenant.yaml]".

test output: 

qianchen@qianchen-VirtualBox: ~/gopath/chenqian/arktos$ cluster/kubectl.sh create tenant sample-test-tenant
tenant/sample-test-tenant created
qianchen@qianchen-VirtualBox: ~/gopath/chenqian/arktos$ cluster/kubectl.sh get tenants
NAME                 STATUS   AGE
sample-test-tenant   Active   2s
