### PR TITLE
Fixed the unbounded watcher range bug

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -263,7 +263,7 @@ func GetKeyAndOptFromPartitionConfig(key string, partitionConfig map[string]stor
 				opt = clientv3.WithRange(key + val.End)
 				// If the interval begin is empty, update the key by adding the interval begin, such as [key+val.Begin, ∞)
 			} else {
-				opt = clientv3.WithFromKey()
+				opt = clientv3.WithRange(clientv3.GetPrefixRangeEnd(key))
 			}
 		} else {
 			// The interval begin is empty and the end is not empty. So that the key remains unchanged, such as [key, key + val.End)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -462,6 +462,42 @@ func TestGetKeyAndOptFromPartitionConfig(t *testing.T) {
 			expectedKey:       "registry/demonset/",
 			expectedOpt:       nil,
 		},
+		{
+			name: "opt with left unbounded",
+			key:  "registry/pods/",
+			partitionedConfig: map[string]storage.Interval{
+				"registry/pods/": {
+					Begin: "",
+					End:   "tenant2",
+				},
+			},
+			expectedKey: "registry/pods/",
+			expectedOpt: clientv3.WithRange("registry/pods/tenant2"),
+		},
+		{
+			name: "opt with right unbounded",
+			key:  "registry/pods/",
+			partitionedConfig: map[string]storage.Interval{
+				"registry/pods/": {
+					Begin: "tenant2",
+					End:   "",
+				},
+			},
+			expectedKey: "registry/pods/tenant2",
+			expectedOpt: clientv3.WithRange("registry/pods0"),
+		},
+		{
+			name: "opt unbounded",
+			key:  "registry/pods/",
+			partitionedConfig: map[string]storage.Interval{
+				"registry/pods/": {
+					Begin: "",
+					End:   "",
+				},
+			},
+			expectedKey: "registry/pods/",
+			expectedOpt: nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			updatedKey, opt := GetKeyAndOptFromPartitionConfig(tc.key, tc.partitionedConfig)


### PR DESCRIPTION
There is an issue with optionWithFromKey which converted key to "0x00". In that case the watchers with that opt pick up all the events.  Have to fix it by changing 0x00 to the least biggest string of the key which is implemented by GetPrefixRangeEnd