### PR TITLE
added x509 and rbac check for tenant

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -454,10 +454,11 @@ function kube::util::create_client_certkey {
     local SEP=""
     shift 5
     while [ -n "${1:-}" ]; do
-        groups+="${SEP}{\"O\":\"$1\"}"
+        groups+="${SEP}{\"OU\":\"$1\"}"
         SEP=","
         shift 1
     done
+    groups+="${SEP}{\"O\":\"system\"}"
     ${sudo} /usr/bin/env bash -e <<EOF
     cd ${dest_dir}
     echo '{"CN":"${cn}","names":[${groups}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | ${CFSSL_BIN} gencert -ca=${ca}.crt -ca-key=${ca}.key -config=${ca}-config.json - | ${CFSSLJSON_BIN} -bare client-${id}

--- a/pkg/apis/apps/v1/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1/zz_generated.defaults.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/apps/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.defaults.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/apps/v1beta2/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.defaults.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/batch/v1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1/zz_generated.defaults.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/batch/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.defaults.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/batch/v2alpha1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v2alpha1/zz_generated.defaults.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/core/v1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1/zz_generated.conversion.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/core/v1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1/zz_generated.defaults.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/extensions/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.defaults.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/serviceaccount/util.go
+++ b/pkg/serviceaccount/util.go
@@ -50,6 +50,7 @@ func (sa *ServiceAccountInfo) UserInfo() user.Info {
 		Name:   apiserverserviceaccount.MakeUsername(sa.Namespace, sa.Name),
 		UID:    sa.UID,
 		Groups: apiserverserviceaccount.MakeGroupNames(sa.Namespace),
+		Tenant: "system",
 	}
 	if sa.PodName != "" && sa.PodUID != "" {
 		info.Extra = map[string][]string{

--- a/plugin/pkg/auth/authorizer/rbac/rbac.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac.go
@@ -74,6 +74,11 @@ func (v *authorizingVisitor) visit(source fmt.Stringer, rule *rbacv1.PolicyRule,
 func (r *RBACAuthorizer) Authorize(requestAttributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	ruleCheckingVisitor := &authorizingVisitor{requestAttributes: requestAttributes}
 
+	userTenant := requestAttributes.GetUser().GetTenant()
+	if userTenant != "system" && userTenant != requestAttributes.GetTenant() {
+		return authorizer.DecisionDeny, ruleCheckingVisitor.reason, nil
+	}
+
 	r.authorizationRuleResolver.VisitRulesFor(requestAttributes.GetUser(), requestAttributes.GetNamespace(), ruleCheckingVisitor.visit)
 	if ruleCheckingVisitor.allowed {
 		return authorizer.DecisionAllow, ruleCheckingVisitor.reason, nil

--- a/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -289,6 +289,8 @@ type ObjectReference struct {
 type UserInfo struct {
 	// The name that uniquely identifies this user among all active users.
 	Username string
+	// The tenant the user belongs to 
+	Tenant string
 	// A unique value that identifies this user across time. If this user is
 	// deleted and another user by the same name is added, they will have
 	// different UIDs.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/zz_generated.conversion.go
@@ -121,7 +121,16 @@ func autoConvert_v1_Event_To_audit_Event(in *Event, out *audit.Event, s conversi
 	if err := s.Convert(&in.User, &out.User, 0); err != nil {
 		return err
 	}
-	out.ImpersonatedUser = (*audit.UserInfo)(unsafe.Pointer(in.ImpersonatedUser))
+	if in.ImpersonatedUser != nil {
+		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
+		*out = new(audit.UserInfo)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImpersonatedUser = nil
+	}
 	out.SourceIPs = *(*[]string)(unsafe.Pointer(&in.SourceIPs))
 	out.UserAgent = in.UserAgent
 	out.ObjectRef = (*audit.ObjectReference)(unsafe.Pointer(in.ObjectRef))
@@ -149,7 +158,16 @@ func autoConvert_audit_Event_To_v1_Event(in *audit.Event, out *Event, s conversi
 	if err := s.Convert(&in.User, &out.User, 0); err != nil {
 		return err
 	}
-	out.ImpersonatedUser = (*authenticationv1.UserInfo)(unsafe.Pointer(in.ImpersonatedUser))
+	if in.ImpersonatedUser != nil {
+		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
+		*out = new(authenticationv1.UserInfo)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImpersonatedUser = nil
+	}
 	out.SourceIPs = *(*[]string)(unsafe.Pointer(&in.SourceIPs))
 	out.UserAgent = in.UserAgent
 	out.ObjectRef = (*ObjectReference)(unsafe.Pointer(in.ObjectRef))
@@ -169,7 +187,17 @@ func Convert_audit_Event_To_v1_Event(in *audit.Event, out *Event, s conversion.S
 
 func autoConvert_v1_EventList_To_audit_EventList(in *EventList, out *audit.EventList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]audit.Event)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]audit.Event, len(*in))
+		for i := range *in {
+			if err := Convert_v1_Event_To_audit_Event(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -180,7 +208,17 @@ func Convert_v1_EventList_To_audit_EventList(in *EventList, out *audit.EventList
 
 func autoConvert_audit_EventList_To_v1_EventList(in *audit.EventList, out *EventList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Event, len(*in))
+		for i := range *in {
+			if err := Convert_audit_Event_To_v1_Event(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/zz_generated.conversion.go
@@ -143,7 +143,16 @@ func autoConvert_v1alpha1_Event_To_audit_Event(in *Event, out *audit.Event, s co
 	if err := s.Convert(&in.User, &out.User, 0); err != nil {
 		return err
 	}
-	out.ImpersonatedUser = (*audit.UserInfo)(unsafe.Pointer(in.ImpersonatedUser))
+	if in.ImpersonatedUser != nil {
+		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
+		*out = new(audit.UserInfo)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImpersonatedUser = nil
+	}
 	out.SourceIPs = *(*[]string)(unsafe.Pointer(&in.SourceIPs))
 	out.UserAgent = in.UserAgent
 	if in.ObjectRef != nil {
@@ -174,7 +183,16 @@ func autoConvert_audit_Event_To_v1alpha1_Event(in *audit.Event, out *Event, s co
 	if err := s.Convert(&in.User, &out.User, 0); err != nil {
 		return err
 	}
-	out.ImpersonatedUser = (*authenticationv1.UserInfo)(unsafe.Pointer(in.ImpersonatedUser))
+	if in.ImpersonatedUser != nil {
+		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
+		*out = new(authenticationv1.UserInfo)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImpersonatedUser = nil
+	}
 	out.SourceIPs = *(*[]string)(unsafe.Pointer(&in.SourceIPs))
 	out.UserAgent = in.UserAgent
 	if in.ObjectRef != nil {

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/zz_generated.conversion.go
@@ -133,7 +133,16 @@ func autoConvert_v1beta1_Event_To_audit_Event(in *Event, out *audit.Event, s con
 	if err := s.Convert(&in.User, &out.User, 0); err != nil {
 		return err
 	}
-	out.ImpersonatedUser = (*audit.UserInfo)(unsafe.Pointer(in.ImpersonatedUser))
+	if in.ImpersonatedUser != nil {
+		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
+		*out = new(audit.UserInfo)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImpersonatedUser = nil
+	}
 	out.SourceIPs = *(*[]string)(unsafe.Pointer(&in.SourceIPs))
 	out.UserAgent = in.UserAgent
 	out.ObjectRef = (*audit.ObjectReference)(unsafe.Pointer(in.ObjectRef))
@@ -156,7 +165,16 @@ func autoConvert_audit_Event_To_v1beta1_Event(in *audit.Event, out *Event, s con
 	if err := s.Convert(&in.User, &out.User, 0); err != nil {
 		return err
 	}
-	out.ImpersonatedUser = (*authenticationv1.UserInfo)(unsafe.Pointer(in.ImpersonatedUser))
+	if in.ImpersonatedUser != nil {
+		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
+		*out = new(authenticationv1.UserInfo)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImpersonatedUser = nil
+	}
 	out.SourceIPs = *(*[]string)(unsafe.Pointer(&in.SourceIPs))
 	out.UserAgent = in.UserAgent
 	out.ObjectRef = (*ObjectReference)(unsafe.Pointer(in.ObjectRef))

--- a/staging/src/k8s.io/apiserver/pkg/audit/event/attributes.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/event/attributes.go
@@ -32,6 +32,7 @@ var _ authorizer.Attributes = &attributes{}
 type attributes struct {
 	event *audit.Event
 	path  string
+	Tenant string
 }
 
 // NewAttributes returns a new attributes struct and parsed request uri
@@ -125,8 +126,16 @@ func (a *attributes) GetPath() string {
 	return a.path
 }
 
+
+// GetPath returns the path uri accessed
+func (a *attributes) GetTenant() string {
+	return a.Tenant
+}
 // user represents the event user
 type user audit.UserInfo
+
+// GetName returns the user name
+func (u user) GetTenant() string { return u.Tenant }
 
 // GetName returns the user name
 func (u user) GetName() string { return u.Username }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
@@ -54,6 +54,7 @@ func (g *AuthenticatedGroupAdder) AuthenticateRequest(req *http.Request) (*authe
 	r.User = &user.DefaultInfo{
 		Name:   r.User.GetName(),
 		UID:    r.User.GetUID(),
+		Tenant: r.User.GetTenant(),
 		Groups: append(r.User.GetGroups(), user.AllAuthenticated),
 		Extra:  r.User.GetExtra(),
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
@@ -35,6 +35,7 @@ func NewAuthenticator() authenticator.Request {
 		return &authenticator.Response{
 			User: &user.DefaultInfo{
 				Name:   anonymousUser,
+				Tenant: "system",
 				Groups: []string{unauthenticatedGroup},
 			},
 			Audiences: auds,

--- a/staging/src/k8s.io/apiserver/pkg/authentication/user/user.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/user/user.go
@@ -22,6 +22,8 @@ type Info interface {
 	// GetName returns the name that uniquely identifies this user among all
 	// other active users.
 	GetName() string
+	// GetName returns the tenant that the user belongs to
+	GetTenant() string
 	// GetUID returns a unique value for a particular user that will change
 	// if the user is removed from the system and another user is added with
 	// the same name.
@@ -47,8 +49,13 @@ type Info interface {
 type DefaultInfo struct {
 	Name   string
 	UID    string
+	Tenant string
 	Groups []string
 	Extra  map[string][]string
+}
+
+func (i *DefaultInfo) GetTenant() string {
+	return i.Tenant
 }
 
 func (i *DefaultInfo) GetName() string {

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
@@ -61,6 +61,9 @@ type Attributes interface {
 
 	// GetPath returns the path of the request
 	GetPath() string
+
+	// GetTenant returns the tenant of the requested resource
+	GetTenant() string
 }
 
 // Authorizer makes an authorization decision based on information gained by making
@@ -99,6 +102,11 @@ type AttributesRecord struct {
 	Name            string
 	ResourceRequest bool
 	Path            string
+	Tenant		string
+}
+
+func (a AttributesRecord) GetTenant() string {
+	return a.Tenant
 }
 
 func (a AttributesRecord) GetUser() user.Info {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
@@ -101,6 +101,7 @@ func GetAuthorizerAttributes(ctx context.Context) (authorizer.Attributes, error)
 	attribs.Subresource = requestInfo.Subresource
 	attribs.Namespace = requestInfo.Namespace
 	attribs.Name = requestInfo.Name
+	attribs.Tenant = requestInfo.Tenant
 
 	return &attribs, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/testing/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/testing/zz_generated.deepcopy.go
@@ -2,7 +2,6 @@
 
 /*
 Copyright The Kubernetes Authors.
-Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2/zz_generated.conversion.go
@@ -163,7 +163,17 @@ func Convert_custom_metrics_MetricValue_To_v1beta2_MetricValue(in *custommetrics
 
 func autoConvert_v1beta2_MetricValueList_To_custom_metrics_MetricValueList(in *MetricValueList, out *custommetrics.MetricValueList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]custommetrics.MetricValue)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]custommetrics.MetricValue, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_MetricValue_To_custom_metrics_MetricValue(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -174,7 +184,17 @@ func Convert_v1beta2_MetricValueList_To_custom_metrics_MetricValueList(in *Metri
 
 func autoConvert_custom_metrics_MetricValueList_To_v1beta2_MetricValueList(in *custommetrics.MetricValueList, out *MetricValueList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]MetricValue)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]MetricValue, len(*in))
+		for i := range *in {
+			if err := Convert_custom_metrics_MetricValue_To_v1beta2_MetricValue(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR is for initial review. DO NOT MERGE.

https://github.com/futurewei-cloud/arktos/issues/20
https://github.com/futurewei-cloud/arktos/issues/69 (modified for x509)
https://github.com/futurewei-cloud/arktos/issues/38

Added tenant check from x509 certificate. 

- Tenant info is extracted from x509 cert and compared with the tenant of the requested resource. Reject if they don't match or the user tenant is not system tenant. 
- Added check tenant check for role binding and system role binding
- Changed to use \O for tenant and \OU for groups in cert
- Added tenant for several system users

Known issue: 
- service account from the system needs to be of "system" tenant. This is hardcoded. Will update shortly for the right solution
- unit tests failure is being fixed
