### PR TITLE
multi-tenancy resource discovery

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -191,7 +191,7 @@ func (c *DiscoveryController) sync(version schema.GroupVersion) error {
 		c.versionHandler.unsetDiscovery(version)
 		return nil
 	}
-	c.versionHandler.setDiscovery(version, discovery.NewAPIVersionHandler(Codecs, version, discovery.APIResourceListerFunc(func() []metav1.APIResource {
+	c.versionHandler.setDiscovery(version, discovery.NewAPIVersionHandler(Codecs, version, discovery.APIResourceListerFunc(func(filter func(metav1.APIResource) bool) []metav1.APIResource {
 		return apiResourcesForDiscovery
 	})))
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -119,8 +120,20 @@ type staticLister struct {
 	list []metav1.APIResource
 }
 
-func (s staticLister) ListAPIResources() []metav1.APIResource {
-	return s.list
+func (s staticLister) ListAPIResources(filter func(metav1.APIResource) bool) []metav1.APIResource {
+	if filter == nil {
+		return s.list
+	}
+
+	ret := []metav1.APIResource{}
+
+	for _, resource := range s.list {
+		if filter(resource) {
+			ret = append(ret, resource)
+		}
+	}
+
+	return ret
 }
 
 var _ discovery.APIResourceLister = &staticLister{}


### PR DESCRIPTION
Display different resource types for system-tenant user and regular tenant user.

Test output:
When the context is for a regular-tenant user ( only tenant-scope resources are shown)
qianchen@qianchen-VirtualBox:~/gopath/chenqian/arktos$ cluster/kubectl.sh --context=local api-resources
NAME                         SHORTNAMES   APIGROUP                    TENANTED   NAMESPACED   KIND
actions                      ac                                       true       true         Action
bindings                                                              true       true         Binding
configmaps                   cm                                       true       true         ConfigMap
endpoints                    ep                                       true       true         Endpoints
events                       ev                                       true       true         Event
limitranges                  limits                                   true       true         LimitRange
namespaces                   ns                                       true       false        Namespace
persistentvolumeclaims       pvc                                      true       true         PersistentVolumeClaim
persistentvolumes            pv                                       true       false        PersistentVolume
pods                         po                                       true       true         Pod
podtemplates                                                          true       true         PodTemplate
replicationcontrollers       rc                                       true       true         ReplicationController
resourcequotas               quota                                    true       true         ResourceQuota
secrets                                                               true       true         Secret
serviceaccounts              sa                                       true       true         ServiceAccount
services                     svc                                      true       true         Service
controllerrevisions                       apps                        true       true         ControllerRevision
daemonsets                   ds           apps                        true       true         DaemonSet
deployments                  deploy       apps                        true       true         Deployment
replicasets                  rs           apps                        true       true         ReplicaSet
statefulsets                 sts          apps                        true       true         StatefulSet
tokenreviews                              authentication.k8s.io       true       false        TokenReview
localsubjectaccessreviews                 authorization.k8s.io        true       true         LocalSubjectAccessReview
selfsubjectaccessreviews                  authorization.k8s.io        true       false        SelfSubjectAccessReview
selfsubjectrulesreviews                   authorization.k8s.io        true       false        SelfSubjectRulesReview

.....
_______________________________________________

Test output for system tenant (all resource types are displayed)

cluster/kubectl.sh --context=local api-resources
NAME                              SHORTNAMES   APIGROUP                       TENANTED   NAMESPACED   KIND
actions                           ac                                          true       true         Action
bindings                                                                      true       true         Binding
componentstatuses                 cs                                          false      false        ComponentStatus
configmaps                        cm                                          true       true         ConfigMap
controllerinstances               co                                          false      false        ControllerInstance
endpoints                         ep                                          true       true         Endpoints
events                            ev                                          true       true         Event
limitranges                       limits                                      true       true         LimitRange
namespaces                        ns                                          true       false        Namespace
nodes                             no                                          false      false        Node
persistentvolumeclaims            pvc                                         true       true         PersistentVolumeClaim
persistentvolumes                 pv                                          true       false        PersistentVolume
pods                              po                                          true       true         Pod
podtemplates                                                                  true       true         PodTemplate
replicationcontrollers            rc                                          true       true         ReplicationController
resourcequotas                    quota                                       true       true         ResourceQuota
secrets                                                                       true       true         Secret
serviceaccounts                   sa                                          true       true         ServiceAccount
services                          svc                                         true       true         Service

....