### PR TITLE
fix make upadte issue with zz_generated.conversion.go

### DIFF
--- a/pkg/controller/apis/config/v1alpha1/doc.go
+++ b/pkg/controller/apis/config/v1alpha1/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,6 +34,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/resourcequota/config/v1alpha1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/service/config/v1alpha1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/serviceaccount/config/v1alpha1
+// +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/tenant/config/v1alpha1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/ttlafterfinished/config/v1alpha1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/volume/attachdetach/config/v1alpha1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/volume/persistentvolume/config/v1alpha1

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -91,7 +91,7 @@ type runtimeService struct {
 	// primary runtime service the runtime service for cluster daemonset workload types
 	// default to container runtime service
 	// from runtime's perspective, nodeReady when the primary runtime service ready on the node
-	isPrimary    bool
+	isPrimary bool
 }
 
 type imageService struct {


### PR DESCRIPTION
Fixed make update issue that caused the following error:

pkg/controller/apis/config/v1alpha1/zz_generated.conversion.go:351:12: undefined: Convert_v1alpha1_TenantControllerConfiguration_To_config_TenantControllerConfiguration
pkg/controller/apis/config/v1alpha1/zz_generated.conversion.go:429:12: undefined: Convert_config_TenantControllerConfiguration_To_v1alpha1_TenantControllerConfiguration

make update completed successfully on my test box
```bash
Running update-bazel
Running update-gofmt
Running copyright check for repo: /root/code/src/k8s.io/arktos, logging to /root/code/src/k8s.io/arktos/_output/ArktosCopyrightTool.log
~/code/src/k8s.io/arktos ~/code/src/k8s.io/arktos
warning: inexact rename detection was skipped due to too many files.
warning: you may want to set your diff.renameLimit variable to at least 480 and retry the command.
~/code/src/k8s.io/arktos
~/code/src/k8s.io/arktos ~/code/src/k8s.io/arktos
warning: inexact rename detection was skipped due to too many files.
warning: you may want to set your diff.renameLimit variable to at least 480 and retry the command.
~/code/src/k8s.io/arktos
Inspecting copyright files, writing logs to /root/code/src/k8s.io/arktos/_output/ArktosCopyrightTool.log
Done.
Update scripts completed successfully
```