### PR TITLE
Remove redundant call for copyright

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -92,7 +92,6 @@ all:
 else
 all: generated_files
 	hack/make-rules/build.sh $(WHAT)
-	hack/arktos_copyright.sh $(PWD) $(OUT_DIR)
 endif
 
 define GINKGO_HELP_INFO


### PR DESCRIPTION
This is to remove redundant call for copyright. Rule "all" depends on rule "generated_files" which will invoke same copyright script. Hence current copyright script will always be invoked twice.
