### PR TITLE
add tenant to JWT bearer token authentication

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,8 +38,10 @@ import (
 // ServiceAccountTokenGetter defines functions to retrieve a named service account and secret
 type ServiceAccountTokenGetter interface {
 	GetServiceAccount(namespace, name string) (*v1.ServiceAccount, error)
+	GetServiceAccountWithMultiTenancy(tenant, namespace, name string) (*v1.ServiceAccount, error)
 	GetPod(namespace, name string) (*v1.Pod, error)
 	GetSecret(namespace, name string) (*v1.Secret, error)
+	GetSecretWithMultiTenancy(tenant, namespace, name string) (*v1.Secret, error)
 }
 
 type TokenGenerator interface {

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -117,21 +117,21 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 			Name:      "my-service-account",
 			UID:       "12345",
 			Namespace: "test",
-			Tenant:    metav1.TenantDefault,
+			Tenant:    "tenant1",
 		},
 	}
 	rsaSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-rsa-secret",
 			Namespace: "test",
-			Tenant:    metav1.TenantDefault,
+			Tenant:    "tenant1",
 		},
 	}
 	ecdsaSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-ecdsa-secret",
 			Namespace: "test",
-			Tenant:    metav1.TenantDefault,
+			Tenant:    "tenant1",
 		},
 	}
 
@@ -256,10 +256,20 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 			ExpectedUserUID:  expectedUserUID,
 			ExpectedGroups:   []string{"system:serviceaccounts", "system:serviceaccounts:test"},
 		},
-		"valid lookup": {
+		"valid lookup (rsa)": {
 			Token:            rsaToken,
 			Client:           fake.NewSimpleClientset(serviceAccount, rsaSecret, ecdsaSecret),
 			Keys:             []interface{}{getPublicKey(rsaPublicKey)},
+			ExpectedErr:      false,
+			ExpectedOK:       true,
+			ExpectedUserName: expectedUserName,
+			ExpectedUserUID:  expectedUserUID,
+			ExpectedGroups:   []string{"system:serviceaccounts", "system:serviceaccounts:test"},
+		},
+		"valid lookup (ecdsa)": {
+			Token:            ecdsaToken,
+			Client:           fake.NewSimpleClientset(serviceAccount, ecdsaSecret),
+			Keys:             []interface{}{getPublicKey(ecdsaPublicKey)},
 			ExpectedErr:      false,
 			ExpectedOK:       true,
 			ExpectedUserName: expectedUserName,

--- a/pkg/serviceaccount/legacy.go
+++ b/pkg/serviceaccount/legacy.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,6 +37,7 @@ func LegacyClaims(serviceAccount v1.ServiceAccount, secret v1.Secret) (*jwt.Clai
 			ServiceAccountName: serviceAccount.Name,
 			ServiceAccountUID:  string(serviceAccount.UID),
 			SecretName:         secret.Name,
+			Tenant:             secret.Tenant,
 		}
 }
 
@@ -46,6 +48,7 @@ type legacyPrivateClaims struct {
 	ServiceAccountUID  string `json:"kubernetes.io/serviceaccount/service-account.uid"`
 	SecretName         string `json:"kubernetes.io/serviceaccount/secret.name"`
 	Namespace          string `json:"kubernetes.io/serviceaccount/namespace"`
+	Tenant             string `json:"kubernetes.io/serviceaccount/tenant"`
 }
 
 func NewLegacyValidator(lookup bool, getter ServiceAccountTokenGetter) Validator {
@@ -77,6 +80,10 @@ func (v *legacyValidator) Validate(tokenData string, public *jwt.Claims, private
 	if len(namespace) == 0 {
 		return nil, errors.New("namespace claim is missing")
 	}
+	tenant := private.Tenant
+	if len(tenant) == 0 {
+		return nil, errors.New("tenant claim is missing")
+	}
 	secretName := private.SecretName
 	if len(secretName) == 0 {
 		return nil, errors.New("secretName claim is missing")
@@ -97,9 +104,9 @@ func (v *legacyValidator) Validate(tokenData string, public *jwt.Claims, private
 
 	if v.lookup {
 		// Make sure token hasn't been invalidated by deletion of the secret
-		secret, err := v.getter.GetSecret(namespace, secretName)
+		secret, err := v.getter.GetSecretWithMultiTenancy(tenant, namespace, secretName)
 		if err != nil {
-			klog.V(4).Infof("Could not retrieve token %s/%s for service account %s/%s: %v", namespace, secretName, namespace, serviceAccountName, err)
+			klog.V(4).Infof("Could not retrieve secret %s/%s/%s for service account %s/%s/%s: %v", tenant, namespace, secretName, tenant, namespace, serviceAccountName, err)
 			return nil, errors.New("Token has been invalidated")
 		}
 		if secret.DeletionTimestamp != nil {
@@ -112,9 +119,9 @@ func (v *legacyValidator) Validate(tokenData string, public *jwt.Claims, private
 		}
 
 		// Make sure service account still exists (name and UID)
-		serviceAccount, err := v.getter.GetServiceAccount(namespace, serviceAccountName)
+		serviceAccount, err := v.getter.GetServiceAccountWithMultiTenancy(tenant, namespace, serviceAccountName)
 		if err != nil {
-			klog.V(4).Infof("Could not retrieve service account %s/%s: %v", namespace, serviceAccountName, err)
+			klog.V(4).Infof("Could not retrieve service account %s/%s/%s: %v", tenant, namespace, serviceAccountName, err)
 			return nil, err
 		}
 		if serviceAccount.DeletionTimestamp != nil {
@@ -131,6 +138,7 @@ func (v *legacyValidator) Validate(tokenData string, public *jwt.Claims, private
 		Namespace: private.Namespace,
 		Name:      private.ServiceAccountName,
 		UID:       private.ServiceAccountUID,
+		Tenant:    private.Tenant,
 	}, nil
 }
 

--- a/pkg/serviceaccount/util_test.go
+++ b/pkg/serviceaccount/util_test.go
@@ -31,6 +31,7 @@ func TestIsServiceAccountToken(t *testing.T) {
 			Namespace:       "default",
 			UID:             "23456",
 			ResourceVersion: "1",
+			Tenant:          "tenant",
 			Annotations: map[string]string{
 				v1.ServiceAccountNameKey: "default",
 				v1.ServiceAccountUIDKey:  "12345",
@@ -50,6 +51,7 @@ func TestIsServiceAccountToken(t *testing.T) {
 			Namespace:       "default",
 			UID:             "23456",
 			ResourceVersion: "1",
+			Tenant:          "tenant",
 			Annotations: map[string]string{
 				v1.ServiceAccountNameKey: "default",
 				v1.ServiceAccountUIDKey:  "12345",
@@ -64,6 +66,17 @@ func TestIsServiceAccountToken(t *testing.T) {
 			UID:             "12345",
 			Namespace:       "default",
 			ResourceVersion: "1",
+			Tenant:          "tenant",
+		},
+	}
+
+	saInsTenantNotEqual := &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "default",
+			UID:             "12345",
+			Namespace:       "default",
+			ResourceVersion: "1",
+			Tenant:          "another_tenant",
 		},
 	}
 
@@ -73,6 +86,7 @@ func TestIsServiceAccountToken(t *testing.T) {
 			UID:             "12345",
 			Namespace:       "default",
 			ResourceVersion: "1",
+			Tenant:          "tenant",
 		},
 	}
 
@@ -82,6 +96,7 @@ func TestIsServiceAccountToken(t *testing.T) {
 			UID:             "67890",
 			Namespace:       "default",
 			ResourceVersion: "1",
+			Tenant:          "tenant",
 		},
 	}
 
@@ -94,6 +109,11 @@ func TestIsServiceAccountToken(t *testing.T) {
 			secret: secretIns,
 			sa:     saIns,
 			expect: true,
+		},
+		"service account tenant not match": {
+			secret: secretIns,
+			sa:     saInsTenantNotEqual,
+			expect: false,
 		},
 		"service account name not equal": {
 			secret: secretIns,

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -211,7 +212,7 @@ func (p *Plugin) computeSecurityContext(a admission.Attributes, pod *api.Pod, sp
 	klog.V(4).Infof("getting pod security policies for pod %s (generate: %s)", pod.Name, pod.GenerateName)
 	var saInfo user.Info
 	if len(pod.Spec.ServiceAccountName) > 0 {
-		saInfo = serviceaccount.UserInfo(a.GetNamespace(), pod.Spec.ServiceAccountName, "")
+		saInfo = serviceaccount.UserInfo(a.GetNamespace(), pod.Spec.ServiceAccountName, "", a.GetTenant())
 	}
 
 	policies, err := p.lister.List(labels.Everything())


### PR DESCRIPTION
Part 2 of https://github.com/futurewei-cloud/arktos/issues/38

JWT bearer token is used by service account (SA) authentication. A token is stored as part of the secret generated for a SA. Tenant was missing when a token is generated and as a result during authentication, SA and secrets were fetched only for the "default" tenant. This change does the following:

- add tenant info to the token
- change the authentication to fetch SA and secrets using tenant parsed from token