### PR TITLE
add public ip support to arktos-up.sh

### DIFF
--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -559,7 +559,7 @@ function generate_certs {
     kube::util::create_signing_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" request-header '"client auth"'
 
     # serving cert for kube-apiserver
-    kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "server-ca" kube-apiserver kubernetes.default kubernetes.default.svc "localhost" "${API_HOST_IP}" "${API_HOST}" "${FIRST_SERVICE_CLUSTER_IP}"
+    kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "server-ca" kube-apiserver kubernetes.default kubernetes.default.svc "localhost" "${API_HOST_IP}" "${API_HOST}" "${FIRST_SERVICE_CLUSTER_IP}" "${PUBLIC_IP:-}"
 
     # Create client certs signed with client-ca, given id, given CN and a number of groups
     kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' controller system:kube-controller-manager
@@ -736,7 +736,8 @@ EOF
 
     # Create kubeconfigs for all components, using client certs
     # TODO: Each api server has it own configuration files. However, since clients, such as controller, scheduler and etc do not support mutilple apiservers,admin.kubeconfig is kept for compability.
-    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "$secureport" admin
+    ADMIN_CONFIG_API_HOST=${PUBLIC_IP:-${API_HOST}}
+    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${ADMIN_CONFIG_API_HOST}" "$secureport" admin
     ${CONTROLPLANE_SUDO} chown "${USER}" "${CERT_DIR}/client-admin.key" # make readable for kubectl
     kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "$secureport" controller
     kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "$secureport" scheduler


### PR DESCRIPTION
This change allows a cluster started by arktos-up.sh to be access from other host through its public ip address (for example, in an AWS instance).

If a public ip address is defined using environment variable PUBLIC_IP,  this ip will be added to the generated apiserver cert as an additional host, and to admin.kubeconfig as the server ip. If the env variable is not defined, it works the same way as before.

Tested by starting up a cluster using arktos-up.sh with and without PUBLIC_IP defined on the cluster host. Verified remote access through public ip is only working when PUBLIC_IP is defined, for example, from a client host, with PUBLIC_IP being 34.216.168.43  on the server host:

```bash
root@ip-172-31-29-112:~# kubectl get pods --all-namespaces
NAMESPACE     NAME                        HASHKEY               READY   STATUS    RESTARTS   AGE
kube-system   kube-dns-6f5bc58688-8rl85   3357003551846957778   3/3     Running   0          39s
kube-system   virtlet-5r5cp               8286830039038982180   2/3     Running   0          13s
```

And if PUBLIC_IP is unset, it'll show:
```bash
root@ip-172-31-29-112:~# kubectl get pods --all-namespaces
Unable to connect to the server: x509: certificate is valid for 0.0.0.0, 10.0.0.1, not 34.216.168.43
```
