### PR TITLE
removed color from kata-setup output

### DIFF
--- a/hack/install-kata.sh
+++ b/hack/install-kata.sh
@@ -37,7 +37,9 @@ function install_kata_components {
 	sudo snap install kata-containers --classic
 
 	# Check if system support Kata
-	local kata_check_msg=`$kata_snap_path/bin/kata-runtime kata-check`
+	echo "* Checking Kata compatibility"
+	local kata_check_msg=`$kata_snap_path/bin/kata-runtime kata-check 2>&1`
+	echo $kata_check_msg
 	if ! echo $kata_check_msg | grep -q "System is capable of running Kata Containers"; then
 		echo "Aborted. Current system does not support Kata Containers."
 		exit


### PR DESCRIPTION
Remove color (red especially) from the output of kata-setup to prevent user from treating this as an error.

Actual output when machine is not Kata campatible:
```bash
* Checking Kata compatibility
time="2020-03-31T03:04:01Z" level=error msg="CPU property not found" arch=amd64 description="Virtualization support" name=vmx pid=11991 source=runtime type=flag time="2020-03-31T03:04:0
1Z" level=warning msg="modprobe insert module failed: modprobe: ERROR: could not insert 'kvm_intel': Operation not supported\n" arch=amd64 error="exit status 1" module=kvm_intel name=ka
ta-runtime pid=11991 source=runtime time="2020-03-31T03:04:01Z" level=error msg="kernel property not found" arch=amd64 description="Intel KVM" name=kvm_intel pid=11991 source=runtime ty
pe=module time="2020-03-31T03:04:01Z" level=error msg="ERROR: System is not capable of running Kata Containers" arch=amd64 name=kata-runtime pid=11991 source=runtime ERROR: System is no
t capable of running Kata Containers
Aborted. Current system does not support Kata Containers.
Kata Setup done.
```