### PR TITLE
fixed a few issues for multi-tenancy access control

### DIFF
--- a/pkg/registry/rbac/role/registry.go
+++ b/pkg/registry/rbac/role/registry.go
@@ -65,3 +65,8 @@ type AuthorizerAdapter struct {
 func (a AuthorizerAdapter) GetRole(namespace, name string) (*rbacv1.Role, error) {
 	return a.Registry.GetRole(genericapirequest.WithNamespace(genericapirequest.NewContext(), namespace), name, &metav1.GetOptions{})
 }
+
+// GetRoleWithMultiTenancy returns the corresponding Role by name in specified namespace and tenant
+func (a AuthorizerAdapter) GetRoleWithMultiTenancy(tenant, namespace, name string) (*rbacv1.Role, error) {
+	return a.Registry.GetRole(genericapirequest.WithTenantAndNamespace(genericapirequest.NewContext(), tenant, namespace), name, &metav1.GetOptions{})
+}

--- a/pkg/registry/rbac/validation/rule_test.go
+++ b/pkg/registry/rbac/validation/rule_test.go
@@ -76,7 +76,7 @@ func TestDefaultRuleResolver(t *testing.T) {
 	staticRoles1 := StaticRoles{
 		roles: []*rbacv1.Role{
 			{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "namespace1", Name: "readthings"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "namespace1", Name: "readthings", Tenant: metav1.TenantSystem},
 				Rules:      []rbacv1.PolicyRule{ruleReadPods, ruleReadServices},
 			},
 		},

--- a/plugin/pkg/auth/authorizer/rbac/BUILD
+++ b/plugin/pkg/auth/authorizer/rbac/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/apis/rbac/v1:go_default_library",
         "//pkg/registry/rbac/validation:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/role.go
@@ -59,7 +59,7 @@ func (s *roleLister) Roles(namespace string) RoleNamespaceLister {
 	return roleNamespaceLister{indexer: s.indexer, namespace: namespace, tenant: "default"}
 }
 
-func (s *roleLister) RolesWithMultiTenancy(namespace string, tenant string) RoleNamespaceLister {
+func (s *roleLister) RolesWithMultiTenancy(tenant, namespace string) RoleNamespaceLister {
 	return roleNamespaceLister{indexer: s.indexer, namespace: namespace, tenant: tenant}
 }
 


### PR DESCRIPTION
Fixed a few issues exposed through further test (for demo).

1. service accounts created by the control plane is still using the default tenant. This will cause failure when such service account try to make changes to other tenant such as the case where tenant-controller tries to create namespaces for non-default tenant. 

2. GetRole requires both tenant and namespace