### PR TITLE
Backward client go

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -129,8 +129,14 @@ func (c *examples) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 // Create takes the representation of a example and creates it.  Returns the server's representation of the example, and an error, if there is any.
 func (c *examples) Create(example *v1.Example) (result *v1.Example, err error) {
 	result = &v1.Example{}
+
+	objectTenant := example.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("examples").
 		Body(example).
@@ -143,8 +149,14 @@ func (c *examples) Create(example *v1.Example) (result *v1.Example, err error) {
 // Update takes the representation of a example and updates it. Returns the server's representation of the example, and an error, if there is any.
 func (c *examples) Update(example *v1.Example) (result *v1.Example, err error) {
 	result = &v1.Example{}
+
+	objectTenant := example.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("examples").
 		Name(example.Name).

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -116,6 +116,7 @@ func (c *customResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedW
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *customResourceDefinitions) Create(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
+
 	err = c.client.Post().
 		Resource("customresourcedefinitions").
 		Body(customResourceDefinition).
@@ -128,6 +129,7 @@ func (c *customResourceDefinitions) Create(customResourceDefinition *v1beta1.Cus
 // Update takes the representation of a customResourceDefinition and updates it. Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *customResourceDefinitions) Update(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
+
 	err = c.client.Put().
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
@@ -143,6 +145,7 @@ func (c *customResourceDefinitions) Update(customResourceDefinition *v1beta1.Cus
 
 func (c *customResourceDefinitions) UpdateStatus(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
+
 	err = c.client.Put().
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
@@ -116,6 +116,7 @@ func (c *customResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedW
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *customResourceDefinitions) Create(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
 	result = &apiextensions.CustomResourceDefinition{}
+
 	err = c.client.Post().
 		Resource("customresourcedefinitions").
 		Body(customResourceDefinition).
@@ -128,6 +129,7 @@ func (c *customResourceDefinitions) Create(customResourceDefinition *apiextensio
 // Update takes the representation of a customResourceDefinition and updates it. Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *customResourceDefinitions) Update(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
 	result = &apiextensions.CustomResourceDefinition{}
+
 	err = c.client.Put().
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
@@ -143,6 +145,7 @@ func (c *customResourceDefinitions) Update(customResourceDefinition *apiextensio
 
 func (c *customResourceDefinitions) UpdateStatus(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
 	result = &apiextensions.CustomResourceDefinition{}
+
 	err = c.client.Put().
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -115,6 +115,7 @@ func (c *mutatingWebhookConfigurations) Watch(opts v1.ListOptions) watch.Aggrega
 // Create takes the representation of a mutatingWebhookConfiguration and creates it.  Returns the server's representation of the mutatingWebhookConfiguration, and an error, if there is any.
 func (c *mutatingWebhookConfigurations) Create(mutatingWebhookConfiguration *v1beta1.MutatingWebhookConfiguration) (result *v1beta1.MutatingWebhookConfiguration, err error) {
 	result = &v1beta1.MutatingWebhookConfiguration{}
+
 	err = c.client.Post().
 		Resource("mutatingwebhookconfigurations").
 		Body(mutatingWebhookConfiguration).
@@ -127,6 +128,7 @@ func (c *mutatingWebhookConfigurations) Create(mutatingWebhookConfiguration *v1b
 // Update takes the representation of a mutatingWebhookConfiguration and updates it. Returns the server's representation of the mutatingWebhookConfiguration, and an error, if there is any.
 func (c *mutatingWebhookConfigurations) Update(mutatingWebhookConfiguration *v1beta1.MutatingWebhookConfiguration) (result *v1beta1.MutatingWebhookConfiguration, err error) {
 	result = &v1beta1.MutatingWebhookConfiguration{}
+
 	err = c.client.Put().
 		Resource("mutatingwebhookconfigurations").
 		Name(mutatingWebhookConfiguration.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -115,6 +115,7 @@ func (c *validatingWebhookConfigurations) Watch(opts v1.ListOptions) watch.Aggre
 // Create takes the representation of a validatingWebhookConfiguration and creates it.  Returns the server's representation of the validatingWebhookConfiguration, and an error, if there is any.
 func (c *validatingWebhookConfigurations) Create(validatingWebhookConfiguration *v1beta1.ValidatingWebhookConfiguration) (result *v1beta1.ValidatingWebhookConfiguration, err error) {
 	result = &v1beta1.ValidatingWebhookConfiguration{}
+
 	err = c.client.Post().
 		Resource("validatingwebhookconfigurations").
 		Body(validatingWebhookConfiguration).
@@ -127,6 +128,7 @@ func (c *validatingWebhookConfigurations) Create(validatingWebhookConfiguration 
 // Update takes the representation of a validatingWebhookConfiguration and updates it. Returns the server's representation of the validatingWebhookConfiguration, and an error, if there is any.
 func (c *validatingWebhookConfigurations) Update(validatingWebhookConfiguration *v1beta1.ValidatingWebhookConfiguration) (result *v1beta1.ValidatingWebhookConfiguration, err error) {
 	result = &v1beta1.ValidatingWebhookConfiguration{}
+
 	err = c.client.Put().
 		Resource("validatingwebhookconfigurations").
 		Name(validatingWebhookConfiguration.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -129,8 +129,14 @@ func (c *controllerRevisions) Watch(opts metav1.ListOptions) watch.AggregatedWat
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *controllerRevisions) Create(controllerRevision *v1.ControllerRevision) (result *v1.ControllerRevision, err error) {
 	result = &v1.ControllerRevision{}
+
+	objectTenant := controllerRevision.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Body(controllerRevision).
@@ -143,8 +149,14 @@ func (c *controllerRevisions) Create(controllerRevision *v1.ControllerRevision) 
 // Update takes the representation of a controllerRevision and updates it. Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *controllerRevisions) Update(controllerRevision *v1.ControllerRevision) (result *v1.ControllerRevision, err error) {
 	result = &v1.ControllerRevision{}
+
+	objectTenant := controllerRevision.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -130,8 +130,14 @@ func (c *daemonSets) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfa
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Create(daemonSet *v1.DaemonSet) (result *v1.DaemonSet, err error) {
 	result = &v1.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Body(daemonSet).
@@ -144,8 +150,14 @@ func (c *daemonSets) Create(daemonSet *v1.DaemonSet) (result *v1.DaemonSet, err 
 // Update takes the representation of a daemonSet and updates it. Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Update(daemonSet *v1.DaemonSet) (result *v1.DaemonSet, err error) {
 	result = &v1.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
@@ -161,8 +173,14 @@ func (c *daemonSets) Update(daemonSet *v1.DaemonSet) (result *v1.DaemonSet, err 
 
 func (c *daemonSets) UpdateStatus(daemonSet *v1.DaemonSet) (result *v1.DaemonSet, err error) {
 	result = &v1.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Name(daemonSet.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -134,8 +134,14 @@ func (c *deployments) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterf
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *v1.Deployment) (result *v1.Deployment, err error) {
 	result = &v1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Body(deployment).
@@ -148,8 +154,14 @@ func (c *deployments) Create(deployment *v1.Deployment) (result *v1.Deployment, 
 // Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Update(deployment *v1.Deployment) (result *v1.Deployment, err error) {
 	result = &v1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deployment.Name).
@@ -165,8 +177,14 @@ func (c *deployments) Update(deployment *v1.Deployment) (result *v1.Deployment, 
 
 func (c *deployments) UpdateStatus(deployment *v1.Deployment) (result *v1.Deployment, err error) {
 	result = &v1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deployment.Name).
@@ -242,8 +260,14 @@ func (c *deployments) GetScale(deploymentName string, options metav1.GetOptions)
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *deployments) UpdateScale(deploymentName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
+
+	objectTenant := scale.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deploymentName).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -134,8 +134,14 @@ func (c *replicaSets) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterf
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Create(replicaSet *v1.ReplicaSet) (result *v1.ReplicaSet, err error) {
 	result = &v1.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Body(replicaSet).
@@ -148,8 +154,14 @@ func (c *replicaSets) Create(replicaSet *v1.ReplicaSet) (result *v1.ReplicaSet, 
 // Update takes the representation of a replicaSet and updates it. Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Update(replicaSet *v1.ReplicaSet) (result *v1.ReplicaSet, err error) {
 	result = &v1.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Name(replicaSet.Name).
@@ -165,8 +177,14 @@ func (c *replicaSets) Update(replicaSet *v1.ReplicaSet) (result *v1.ReplicaSet, 
 
 func (c *replicaSets) UpdateStatus(replicaSet *v1.ReplicaSet) (result *v1.ReplicaSet, err error) {
 	result = &v1.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Name(replicaSet.Name).
@@ -242,8 +260,14 @@ func (c *replicaSets) GetScale(replicaSetName string, options metav1.GetOptions)
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *replicaSets) UpdateScale(replicaSetName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
+
+	objectTenant := scale.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Name(replicaSetName).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -134,8 +134,14 @@ func (c *statefulSets) Watch(opts metav1.ListOptions) watch.AggregatedWatchInter
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Create(statefulSet *v1.StatefulSet) (result *v1.StatefulSet, err error) {
 	result = &v1.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Body(statefulSet).
@@ -148,8 +154,14 @@ func (c *statefulSets) Create(statefulSet *v1.StatefulSet) (result *v1.StatefulS
 // Update takes the representation of a statefulSet and updates it. Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Update(statefulSet *v1.StatefulSet) (result *v1.StatefulSet, err error) {
 	result = &v1.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
@@ -165,8 +177,14 @@ func (c *statefulSets) Update(statefulSet *v1.StatefulSet) (result *v1.StatefulS
 
 func (c *statefulSets) UpdateStatus(statefulSet *v1.StatefulSet) (result *v1.StatefulSet, err error) {
 	result = &v1.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
@@ -242,8 +260,14 @@ func (c *statefulSets) GetScale(statefulSetName string, options metav1.GetOption
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *statefulSets) UpdateScale(statefulSetName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
+
+	objectTenant := scale.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Name(statefulSetName).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -129,8 +129,14 @@ func (c *controllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *controllerRevisions) Create(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
 	result = &v1beta1.ControllerRevision{}
+
+	objectTenant := controllerRevision.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Body(controllerRevision).
@@ -143,8 +149,14 @@ func (c *controllerRevisions) Create(controllerRevision *v1beta1.ControllerRevis
 // Update takes the representation of a controllerRevision and updates it. Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *controllerRevisions) Update(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
 	result = &v1beta1.ControllerRevision{}
+
+	objectTenant := controllerRevision.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -130,8 +130,14 @@ func (c *deployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Body(deployment).
@@ -144,8 +150,14 @@ func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.De
 // Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deployment.Name).
@@ -161,8 +173,14 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 
 func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deployment.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -130,8 +130,14 @@ func (c *statefulSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Create(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	result = &v1beta1.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Body(statefulSet).
@@ -144,8 +150,14 @@ func (c *statefulSets) Create(statefulSet *v1beta1.StatefulSet) (result *v1beta1
 // Update takes the representation of a statefulSet and updates it. Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Update(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	result = &v1beta1.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
@@ -161,8 +173,14 @@ func (c *statefulSets) Update(statefulSet *v1beta1.StatefulSet) (result *v1beta1
 
 func (c *statefulSets) UpdateStatus(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	result = &v1beta1.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Name(statefulSet.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -129,8 +129,14 @@ func (c *controllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *controllerRevisions) Create(controllerRevision *v1beta2.ControllerRevision) (result *v1beta2.ControllerRevision, err error) {
 	result = &v1beta2.ControllerRevision{}
+
+	objectTenant := controllerRevision.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Body(controllerRevision).
@@ -143,8 +149,14 @@ func (c *controllerRevisions) Create(controllerRevision *v1beta2.ControllerRevis
 // Update takes the representation of a controllerRevision and updates it. Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *controllerRevisions) Update(controllerRevision *v1beta2.ControllerRevision) (result *v1beta2.ControllerRevision, err error) {
 	result = &v1beta2.ControllerRevision{}
+
+	objectTenant := controllerRevision.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -130,8 +130,14 @@ func (c *daemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Create(daemonSet *v1beta2.DaemonSet) (result *v1beta2.DaemonSet, err error) {
 	result = &v1beta2.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Body(daemonSet).
@@ -144,8 +150,14 @@ func (c *daemonSets) Create(daemonSet *v1beta2.DaemonSet) (result *v1beta2.Daemo
 // Update takes the representation of a daemonSet and updates it. Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Update(daemonSet *v1beta2.DaemonSet) (result *v1beta2.DaemonSet, err error) {
 	result = &v1beta2.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
@@ -161,8 +173,14 @@ func (c *daemonSets) Update(daemonSet *v1beta2.DaemonSet) (result *v1beta2.Daemo
 
 func (c *daemonSets) UpdateStatus(daemonSet *v1beta2.DaemonSet) (result *v1beta2.DaemonSet, err error) {
 	result = &v1beta2.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Name(daemonSet.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -130,8 +130,14 @@ func (c *deployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
 	result = &v1beta2.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Body(deployment).
@@ -144,8 +150,14 @@ func (c *deployments) Create(deployment *v1beta2.Deployment) (result *v1beta2.De
 // Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Update(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
 	result = &v1beta2.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deployment.Name).
@@ -161,8 +173,14 @@ func (c *deployments) Update(deployment *v1beta2.Deployment) (result *v1beta2.De
 
 func (c *deployments) UpdateStatus(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
 	result = &v1beta2.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deployment.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -130,8 +130,14 @@ func (c *replicaSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Create(replicaSet *v1beta2.ReplicaSet) (result *v1beta2.ReplicaSet, err error) {
 	result = &v1beta2.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Body(replicaSet).
@@ -144,8 +150,14 @@ func (c *replicaSets) Create(replicaSet *v1beta2.ReplicaSet) (result *v1beta2.Re
 // Update takes the representation of a replicaSet and updates it. Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Update(replicaSet *v1beta2.ReplicaSet) (result *v1beta2.ReplicaSet, err error) {
 	result = &v1beta2.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Name(replicaSet.Name).
@@ -161,8 +173,14 @@ func (c *replicaSets) Update(replicaSet *v1beta2.ReplicaSet) (result *v1beta2.Re
 
 func (c *replicaSets) UpdateStatus(replicaSet *v1beta2.ReplicaSet) (result *v1beta2.ReplicaSet, err error) {
 	result = &v1beta2.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Name(replicaSet.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -133,8 +133,14 @@ func (c *statefulSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Create(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
 	result = &v1beta2.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Body(statefulSet).
@@ -147,8 +153,14 @@ func (c *statefulSets) Create(statefulSet *v1beta2.StatefulSet) (result *v1beta2
 // Update takes the representation of a statefulSet and updates it. Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Update(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
 	result = &v1beta2.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
@@ -164,8 +176,14 @@ func (c *statefulSets) Update(statefulSet *v1beta2.StatefulSet) (result *v1beta2
 
 func (c *statefulSets) UpdateStatus(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
 	result = &v1beta2.StatefulSet{}
+
+	objectTenant := statefulSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Name(statefulSet.Name).
@@ -241,8 +259,14 @@ func (c *statefulSets) GetScale(statefulSetName string, options v1.GetOptions) (
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *statefulSets) UpdateScale(statefulSetName string, scale *v1beta2.Scale) (result *v1beta2.Scale, err error) {
 	result = &v1beta2.Scale{}
+
+	objectTenant := scale.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Name(statefulSetName).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditsink.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditsink.go
@@ -125,8 +125,14 @@ func (c *auditSinks) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a auditSink and creates it.  Returns the server's representation of the auditSink, and an error, if there is any.
 func (c *auditSinks) Create(auditSink *v1alpha1.AuditSink) (result *v1alpha1.AuditSink, err error) {
 	result = &v1alpha1.AuditSink{}
+
+	objectTenant := auditSink.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("auditsinks").
 		Body(auditSink).
 		Do().
@@ -138,8 +144,14 @@ func (c *auditSinks) Create(auditSink *v1alpha1.AuditSink) (result *v1alpha1.Aud
 // Update takes the representation of a auditSink and updates it. Returns the server's representation of the auditSink, and an error, if there is any.
 func (c *auditSinks) Update(auditSink *v1alpha1.AuditSink) (result *v1alpha1.AuditSink, err error) {
 	result = &v1alpha1.AuditSink{}
+
+	objectTenant := auditSink.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("auditsinks").
 		Name(auditSink.Name).
 		Body(auditSink).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -130,8 +130,14 @@ func (c *horizontalPodAutoscalers) Watch(opts metav1.ListOptions) watch.Aggregat
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Body(horizontalPodAutoscaler).
@@ -144,8 +150,14 @@ func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v1.Horizontal
 // Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
@@ -161,8 +173,14 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v1.Horizontal
 
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -130,8 +130,14 @@ func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWa
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2beta1.HorizontalPodAutoscaler) (result *v2beta1.HorizontalPodAutoscaler, err error) {
 	result = &v2beta1.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Body(horizontalPodAutoscaler).
@@ -144,8 +150,14 @@ func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2beta1.Horiz
 // Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2beta1.HorizontalPodAutoscaler) (result *v2beta1.HorizontalPodAutoscaler, err error) {
 	result = &v2beta1.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
@@ -161,8 +173,14 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2beta1.Horiz
 
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v2beta1.HorizontalPodAutoscaler) (result *v2beta1.HorizontalPodAutoscaler, err error) {
 	result = &v2beta1.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -130,8 +130,14 @@ func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWa
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2beta2.HorizontalPodAutoscaler) (result *v2beta2.HorizontalPodAutoscaler, err error) {
 	result = &v2beta2.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Body(horizontalPodAutoscaler).
@@ -144,8 +150,14 @@ func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2beta2.Horiz
 // Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2beta2.HorizontalPodAutoscaler) (result *v2beta2.HorizontalPodAutoscaler, err error) {
 	result = &v2beta2.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
@@ -161,8 +173,14 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2beta2.Horiz
 
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v2beta2.HorizontalPodAutoscaler) (result *v2beta2.HorizontalPodAutoscaler, err error) {
 	result = &v2beta2.HorizontalPodAutoscaler{}
+
+	objectTenant := horizontalPodAutoscaler.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -130,8 +130,14 @@ func (c *jobs) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
 func (c *jobs) Create(job *v1.Job) (result *v1.Job, err error) {
 	result = &v1.Job{}
+
+	objectTenant := job.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("jobs").
 		Body(job).
@@ -144,8 +150,14 @@ func (c *jobs) Create(job *v1.Job) (result *v1.Job, err error) {
 // Update takes the representation of a job and updates it. Returns the server's representation of the job, and an error, if there is any.
 func (c *jobs) Update(job *v1.Job) (result *v1.Job, err error) {
 	result = &v1.Job{}
+
+	objectTenant := job.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("jobs").
 		Name(job.Name).
@@ -161,8 +173,14 @@ func (c *jobs) Update(job *v1.Job) (result *v1.Job, err error) {
 
 func (c *jobs) UpdateStatus(job *v1.Job) (result *v1.Job, err error) {
 	result = &v1.Job{}
+
+	objectTenant := job.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("jobs").
 		Name(job.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -130,8 +130,14 @@ func (c *cronJobs) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.
 func (c *cronJobs) Create(cronJob *v1beta1.CronJob) (result *v1beta1.CronJob, err error) {
 	result = &v1beta1.CronJob{}
+
+	objectTenant := cronJob.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("cronjobs").
 		Body(cronJob).
@@ -144,8 +150,14 @@ func (c *cronJobs) Create(cronJob *v1beta1.CronJob) (result *v1beta1.CronJob, er
 // Update takes the representation of a cronJob and updates it. Returns the server's representation of the cronJob, and an error, if there is any.
 func (c *cronJobs) Update(cronJob *v1beta1.CronJob) (result *v1beta1.CronJob, err error) {
 	result = &v1beta1.CronJob{}
+
+	objectTenant := cronJob.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("cronjobs").
 		Name(cronJob.Name).
@@ -161,8 +173,14 @@ func (c *cronJobs) Update(cronJob *v1beta1.CronJob) (result *v1beta1.CronJob, er
 
 func (c *cronJobs) UpdateStatus(cronJob *v1beta1.CronJob) (result *v1beta1.CronJob, err error) {
 	result = &v1beta1.CronJob{}
+
+	objectTenant := cronJob.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("cronjobs").
 		Name(cronJob.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
@@ -130,8 +130,14 @@ func (c *cronJobs) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.
 func (c *cronJobs) Create(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	result = &v2alpha1.CronJob{}
+
+	objectTenant := cronJob.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("cronjobs").
 		Body(cronJob).
@@ -144,8 +150,14 @@ func (c *cronJobs) Create(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, 
 // Update takes the representation of a cronJob and updates it. Returns the server's representation of the cronJob, and an error, if there is any.
 func (c *cronJobs) Update(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	result = &v2alpha1.CronJob{}
+
+	objectTenant := cronJob.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("cronjobs").
 		Name(cronJob.Name).
@@ -161,8 +173,14 @@ func (c *cronJobs) Update(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, 
 
 func (c *cronJobs) UpdateStatus(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	result = &v2alpha1.CronJob{}
+
+	objectTenant := cronJob.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("cronjobs").
 		Name(cronJob.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -126,8 +126,14 @@ func (c *certificateSigningRequests) Watch(opts v1.ListOptions) watch.Aggregated
 // Create takes the representation of a certificateSigningRequest and creates it.  Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
 func (c *certificateSigningRequests) Create(certificateSigningRequest *v1beta1.CertificateSigningRequest) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
+
+	objectTenant := certificateSigningRequest.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("certificatesigningrequests").
 		Body(certificateSigningRequest).
 		Do().
@@ -139,8 +145,14 @@ func (c *certificateSigningRequests) Create(certificateSigningRequest *v1beta1.C
 // Update takes the representation of a certificateSigningRequest and updates it. Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
 func (c *certificateSigningRequests) Update(certificateSigningRequest *v1beta1.CertificateSigningRequest) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
+
+	objectTenant := certificateSigningRequest.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
 		Body(certificateSigningRequest).
@@ -155,8 +167,14 @@ func (c *certificateSigningRequests) Update(certificateSigningRequest *v1beta1.C
 
 func (c *certificateSigningRequests) UpdateStatus(certificateSigningRequest *v1beta1.CertificateSigningRequest) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
+
+	objectTenant := certificateSigningRequest.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -129,8 +129,14 @@ func (c *leases) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a lease and creates it.  Returns the server's representation of the lease, and an error, if there is any.
 func (c *leases) Create(lease *v1.Lease) (result *v1.Lease, err error) {
 	result = &v1.Lease{}
+
+	objectTenant := lease.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("leases").
 		Body(lease).
@@ -143,8 +149,14 @@ func (c *leases) Create(lease *v1.Lease) (result *v1.Lease, err error) {
 // Update takes the representation of a lease and updates it. Returns the server's representation of the lease, and an error, if there is any.
 func (c *leases) Update(lease *v1.Lease) (result *v1.Lease, err error) {
 	result = &v1.Lease{}
+
+	objectTenant := lease.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("leases").
 		Name(lease.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -129,8 +129,14 @@ func (c *leases) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a lease and creates it.  Returns the server's representation of the lease, and an error, if there is any.
 func (c *leases) Create(lease *v1beta1.Lease) (result *v1beta1.Lease, err error) {
 	result = &v1beta1.Lease{}
+
+	objectTenant := lease.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("leases").
 		Body(lease).
@@ -143,8 +149,14 @@ func (c *leases) Create(lease *v1beta1.Lease) (result *v1beta1.Lease, err error)
 // Update takes the representation of a lease and updates it. Returns the server's representation of the lease, and an error, if there is any.
 func (c *leases) Update(lease *v1beta1.Lease) (result *v1beta1.Lease, err error) {
 	result = &v1beta1.Lease{}
+
+	objectTenant := lease.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("leases").
 		Name(lease.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/action.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/action.go
@@ -129,8 +129,14 @@ func (c *actions) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a action and creates it.  Returns the server's representation of the action, and an error, if there is any.
 func (c *actions) Create(action *v1.Action) (result *v1.Action, err error) {
 	result = &v1.Action{}
+
+	objectTenant := action.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("actions").
 		Body(action).
@@ -143,8 +149,14 @@ func (c *actions) Create(action *v1.Action) (result *v1.Action, err error) {
 // Update takes the representation of a action and updates it. Returns the server's representation of the action, and an error, if there is any.
 func (c *actions) Update(action *v1.Action) (result *v1.Action, err error) {
 	result = &v1.Action{}
+
+	objectTenant := action.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("actions").
 		Name(action.Name).
@@ -160,8 +172,14 @@ func (c *actions) Update(action *v1.Action) (result *v1.Action, err error) {
 
 func (c *actions) UpdateStatus(action *v1.Action) (result *v1.Action, err error) {
 	result = &v1.Action{}
+
+	objectTenant := action.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("actions").
 		Name(action.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -115,6 +115,7 @@ func (c *componentStatuses) Watch(opts metav1.ListOptions) watch.AggregatedWatch
 // Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.
 func (c *componentStatuses) Create(componentStatus *v1.ComponentStatus) (result *v1.ComponentStatus, err error) {
 	result = &v1.ComponentStatus{}
+
 	err = c.client.Post().
 		Resource("componentstatuses").
 		Body(componentStatus).
@@ -127,6 +128,7 @@ func (c *componentStatuses) Create(componentStatus *v1.ComponentStatus) (result 
 // Update takes the representation of a componentStatus and updates it. Returns the server's representation of the componentStatus, and an error, if there is any.
 func (c *componentStatuses) Update(componentStatus *v1.ComponentStatus) (result *v1.ComponentStatus, err error) {
 	result = &v1.ComponentStatus{}
+
 	err = c.client.Put().
 		Resource("componentstatuses").
 		Name(componentStatus.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -129,8 +129,14 @@ func (c *configMaps) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfa
 // Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
 func (c *configMaps) Create(configMap *v1.ConfigMap) (result *v1.ConfigMap, err error) {
 	result = &v1.ConfigMap{}
+
+	objectTenant := configMap.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("configmaps").
 		Body(configMap).
@@ -143,8 +149,14 @@ func (c *configMaps) Create(configMap *v1.ConfigMap) (result *v1.ConfigMap, err 
 // Update takes the representation of a configMap and updates it. Returns the server's representation of the configMap, and an error, if there is any.
 func (c *configMaps) Update(configMap *v1.ConfigMap) (result *v1.ConfigMap, err error) {
 	result = &v1.ConfigMap{}
+
+	objectTenant := configMap.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("configmaps").
 		Name(configMap.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/controllerinstance.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/controllerinstance.go
@@ -114,6 +114,7 @@ func (c *controllerInstances) Watch(opts metav1.ListOptions) watch.AggregatedWat
 // Create takes the representation of a controllerInstance and creates it.  Returns the server's representation of the controllerInstance, and an error, if there is any.
 func (c *controllerInstances) Create(controllerInstance *v1.ControllerInstance) (result *v1.ControllerInstance, err error) {
 	result = &v1.ControllerInstance{}
+
 	err = c.client.Post().
 		Resource("controllerinstances").
 		Body(controllerInstance).
@@ -126,6 +127,7 @@ func (c *controllerInstances) Create(controllerInstance *v1.ControllerInstance) 
 // Update takes the representation of a controllerInstance and updates it. Returns the server's representation of the controllerInstance, and an error, if there is any.
 func (c *controllerInstances) Update(controllerInstance *v1.ControllerInstance) (result *v1.ControllerInstance, err error) {
 	result = &v1.ControllerInstance{}
+
 	err = c.client.Put().
 		Resource("controllerinstances").
 		Name(controllerInstance.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/datapartitionconfig.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/datapartitionconfig.go
@@ -114,6 +114,7 @@ func (c *dataPartitionConfigs) Watch(opts metav1.ListOptions) watch.AggregatedWa
 // Create takes the representation of a dataPartitionConfig and creates it.  Returns the server's representation of the dataPartitionConfig, and an error, if there is any.
 func (c *dataPartitionConfigs) Create(dataPartitionConfig *v1.DataPartitionConfig) (result *v1.DataPartitionConfig, err error) {
 	result = &v1.DataPartitionConfig{}
+
 	err = c.client.Post().
 		Resource("datapartitionconfigs").
 		Body(dataPartitionConfig).
@@ -126,6 +127,7 @@ func (c *dataPartitionConfigs) Create(dataPartitionConfig *v1.DataPartitionConfi
 // Update takes the representation of a dataPartitionConfig and updates it. Returns the server's representation of the dataPartitionConfig, and an error, if there is any.
 func (c *dataPartitionConfigs) Update(dataPartitionConfig *v1.DataPartitionConfig) (result *v1.DataPartitionConfig, err error) {
 	result = &v1.DataPartitionConfig{}
+
 	err = c.client.Put().
 		Resource("datapartitionconfigs").
 		Name(dataPartitionConfig.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -129,8 +129,14 @@ func (c *endpoints) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 // Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.
 func (c *endpoints) Create(endpoints *v1.Endpoints) (result *v1.Endpoints, err error) {
 	result = &v1.Endpoints{}
+
+	objectTenant := endpoints.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("endpoints").
 		Body(endpoints).
@@ -143,8 +149,14 @@ func (c *endpoints) Create(endpoints *v1.Endpoints) (result *v1.Endpoints, err e
 // Update takes the representation of a endpoints and updates it. Returns the server's representation of the endpoints, and an error, if there is any.
 func (c *endpoints) Update(endpoints *v1.Endpoints) (result *v1.Endpoints, err error) {
 	result = &v1.Endpoints{}
+
+	objectTenant := endpoints.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("endpoints").
 		Name(endpoints.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -129,8 +129,14 @@ func (c *events) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(event *v1.Event) (result *v1.Event, err error) {
 	result = &v1.Event{}
+
+	objectTenant := event.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("events").
 		Body(event).
@@ -143,8 +149,14 @@ func (c *events) Create(event *v1.Event) (result *v1.Event, err error) {
 // Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Update(event *v1.Event) (result *v1.Event, err error) {
 	result = &v1.Event{}
+
+	objectTenant := event.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("events").
 		Name(event.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -129,8 +129,14 @@ func (c *limitRanges) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterf
 // Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.
 func (c *limitRanges) Create(limitRange *v1.LimitRange) (result *v1.LimitRange, err error) {
 	result = &v1.LimitRange{}
+
+	objectTenant := limitRange.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("limitranges").
 		Body(limitRange).
@@ -143,8 +149,14 @@ func (c *limitRanges) Create(limitRange *v1.LimitRange) (result *v1.LimitRange, 
 // Update takes the representation of a limitRange and updates it. Returns the server's representation of the limitRange, and an error, if there is any.
 func (c *limitRanges) Update(limitRange *v1.LimitRange) (result *v1.LimitRange, err error) {
 	result = &v1.LimitRange{}
+
+	objectTenant := limitRange.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("limitranges").
 		Name(limitRange.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -125,8 +125,14 @@ func (c *namespaces) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfa
 // Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
 func (c *namespaces) Create(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
+
+	objectTenant := namespace.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("namespaces").
 		Body(namespace).
 		Do().
@@ -138,8 +144,14 @@ func (c *namespaces) Create(namespace *v1.Namespace) (result *v1.Namespace, err 
 // Update takes the representation of a namespace and updates it. Returns the server's representation of the namespace, and an error, if there is any.
 func (c *namespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
+
+	objectTenant := namespace.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("namespaces").
 		Name(namespace.Name).
 		Body(namespace).
@@ -154,8 +166,14 @@ func (c *namespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err 
 
 func (c *namespaces) UpdateStatus(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
+
+	objectTenant := namespace.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("namespaces").
 		Name(namespace.Name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -116,6 +116,7 @@ func (c *nodes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.
 func (c *nodes) Create(node *v1.Node) (result *v1.Node, err error) {
 	result = &v1.Node{}
+
 	err = c.client.Post().
 		Resource("nodes").
 		Body(node).
@@ -128,6 +129,7 @@ func (c *nodes) Create(node *v1.Node) (result *v1.Node, err error) {
 // Update takes the representation of a node and updates it. Returns the server's representation of the node, and an error, if there is any.
 func (c *nodes) Update(node *v1.Node) (result *v1.Node, err error) {
 	result = &v1.Node{}
+
 	err = c.client.Put().
 		Resource("nodes").
 		Name(node.Name).
@@ -143,6 +145,7 @@ func (c *nodes) Update(node *v1.Node) (result *v1.Node, err error) {
 
 func (c *nodes) UpdateStatus(node *v1.Node) (result *v1.Node, err error) {
 	result = &v1.Node{}
+
 	err = c.client.Put().
 		Resource("nodes").
 		Name(node.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -126,8 +126,14 @@ func (c *persistentVolumes) Watch(opts metav1.ListOptions) watch.AggregatedWatch
 // Create takes the representation of a persistentVolume and creates it.  Returns the server's representation of the persistentVolume, and an error, if there is any.
 func (c *persistentVolumes) Create(persistentVolume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
+
+	objectTenant := persistentVolume.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("persistentvolumes").
 		Body(persistentVolume).
 		Do().
@@ -139,8 +145,14 @@ func (c *persistentVolumes) Create(persistentVolume *v1.PersistentVolume) (resul
 // Update takes the representation of a persistentVolume and updates it. Returns the server's representation of the persistentVolume, and an error, if there is any.
 func (c *persistentVolumes) Update(persistentVolume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
+
+	objectTenant := persistentVolume.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("persistentvolumes").
 		Name(persistentVolume.Name).
 		Body(persistentVolume).
@@ -155,8 +167,14 @@ func (c *persistentVolumes) Update(persistentVolume *v1.PersistentVolume) (resul
 
 func (c *persistentVolumes) UpdateStatus(persistentVolume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
+
+	objectTenant := persistentVolume.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("persistentvolumes").
 		Name(persistentVolume.Name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -130,8 +130,14 @@ func (c *persistentVolumeClaims) Watch(opts metav1.ListOptions) watch.Aggregated
 // Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
 func (c *persistentVolumeClaims) Create(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
 	result = &v1.PersistentVolumeClaim{}
+
+	objectTenant := persistentVolumeClaim.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("persistentvolumeclaims").
 		Body(persistentVolumeClaim).
@@ -144,8 +150,14 @@ func (c *persistentVolumeClaims) Create(persistentVolumeClaim *v1.PersistentVolu
 // Update takes the representation of a persistentVolumeClaim and updates it. Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
 func (c *persistentVolumeClaims) Update(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
 	result = &v1.PersistentVolumeClaim{}
+
+	objectTenant := persistentVolumeClaim.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("persistentvolumeclaims").
 		Name(persistentVolumeClaim.Name).
@@ -161,8 +173,14 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *v1.PersistentVolu
 
 func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
 	result = &v1.PersistentVolumeClaim{}
+
+	objectTenant := persistentVolumeClaim.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("persistentvolumeclaims").
 		Name(persistentVolumeClaim.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -130,8 +130,14 @@ func (c *pods) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
 func (c *pods) Create(pod *v1.Pod) (result *v1.Pod, err error) {
 	result = &v1.Pod{}
+
+	objectTenant := pod.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("pods").
 		Body(pod).
@@ -144,8 +150,14 @@ func (c *pods) Create(pod *v1.Pod) (result *v1.Pod, err error) {
 // Update takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
 func (c *pods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
 	result = &v1.Pod{}
+
+	objectTenant := pod.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("pods").
 		Name(pod.Name).
@@ -161,8 +173,14 @@ func (c *pods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
 
 func (c *pods) UpdateStatus(pod *v1.Pod) (result *v1.Pod, err error) {
 	result = &v1.Pod{}
+
+	objectTenant := pod.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("pods").
 		Name(pod.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -129,8 +129,14 @@ func (c *podTemplates) Watch(opts metav1.ListOptions) watch.AggregatedWatchInter
 // Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.
 func (c *podTemplates) Create(podTemplate *v1.PodTemplate) (result *v1.PodTemplate, err error) {
 	result = &v1.PodTemplate{}
+
+	objectTenant := podTemplate.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("podtemplates").
 		Body(podTemplate).
@@ -143,8 +149,14 @@ func (c *podTemplates) Create(podTemplate *v1.PodTemplate) (result *v1.PodTempla
 // Update takes the representation of a podTemplate and updates it. Returns the server's representation of the podTemplate, and an error, if there is any.
 func (c *podTemplates) Update(podTemplate *v1.PodTemplate) (result *v1.PodTemplate, err error) {
 	result = &v1.PodTemplate{}
+
+	objectTenant := podTemplate.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("podtemplates").
 		Name(podTemplate.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -134,8 +134,14 @@ func (c *replicationControllers) Watch(opts metav1.ListOptions) watch.Aggregated
 // Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.
 func (c *replicationControllers) Create(replicationController *v1.ReplicationController) (result *v1.ReplicationController, err error) {
 	result = &v1.ReplicationController{}
+
+	objectTenant := replicationController.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
 		Body(replicationController).
@@ -148,8 +154,14 @@ func (c *replicationControllers) Create(replicationController *v1.ReplicationCon
 // Update takes the representation of a replicationController and updates it. Returns the server's representation of the replicationController, and an error, if there is any.
 func (c *replicationControllers) Update(replicationController *v1.ReplicationController) (result *v1.ReplicationController, err error) {
 	result = &v1.ReplicationController{}
+
+	objectTenant := replicationController.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
 		Name(replicationController.Name).
@@ -165,8 +177,14 @@ func (c *replicationControllers) Update(replicationController *v1.ReplicationCon
 
 func (c *replicationControllers) UpdateStatus(replicationController *v1.ReplicationController) (result *v1.ReplicationController, err error) {
 	result = &v1.ReplicationController{}
+
+	objectTenant := replicationController.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
 		Name(replicationController.Name).
@@ -242,8 +260,14 @@ func (c *replicationControllers) GetScale(replicationControllerName string, opti
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *replicationControllers) UpdateScale(replicationControllerName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
+
+	objectTenant := scale.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
 		Name(replicationControllerName).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -130,8 +130,14 @@ func (c *resourceQuotas) Watch(opts metav1.ListOptions) watch.AggregatedWatchInt
 // Create takes the representation of a resourceQuota and creates it.  Returns the server's representation of the resourceQuota, and an error, if there is any.
 func (c *resourceQuotas) Create(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
 	result = &v1.ResourceQuota{}
+
+	objectTenant := resourceQuota.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("resourcequotas").
 		Body(resourceQuota).
@@ -144,8 +150,14 @@ func (c *resourceQuotas) Create(resourceQuota *v1.ResourceQuota) (result *v1.Res
 // Update takes the representation of a resourceQuota and updates it. Returns the server's representation of the resourceQuota, and an error, if there is any.
 func (c *resourceQuotas) Update(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
 	result = &v1.ResourceQuota{}
+
+	objectTenant := resourceQuota.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("resourcequotas").
 		Name(resourceQuota.Name).
@@ -161,8 +173,14 @@ func (c *resourceQuotas) Update(resourceQuota *v1.ResourceQuota) (result *v1.Res
 
 func (c *resourceQuotas) UpdateStatus(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
 	result = &v1.ResourceQuota{}
+
+	objectTenant := resourceQuota.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("resourcequotas").
 		Name(resourceQuota.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -129,8 +129,14 @@ func (c *secrets) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
 func (c *secrets) Create(secret *v1.Secret) (result *v1.Secret, err error) {
 	result = &v1.Secret{}
+
+	objectTenant := secret.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("secrets").
 		Body(secret).
@@ -143,8 +149,14 @@ func (c *secrets) Create(secret *v1.Secret) (result *v1.Secret, err error) {
 // Update takes the representation of a secret and updates it. Returns the server's representation of the secret, and an error, if there is any.
 func (c *secrets) Update(secret *v1.Secret) (result *v1.Secret, err error) {
 	result = &v1.Secret{}
+
+	objectTenant := secret.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("secrets").
 		Name(secret.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -129,8 +129,14 @@ func (c *services) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 // Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
 func (c *services) Create(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}
+
+	objectTenant := service.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("services").
 		Body(service).
@@ -143,8 +149,14 @@ func (c *services) Create(service *v1.Service) (result *v1.Service, err error) {
 // Update takes the representation of a service and updates it. Returns the server's representation of the service, and an error, if there is any.
 func (c *services) Update(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}
+
+	objectTenant := service.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("services").
 		Name(service.Name).
@@ -160,8 +172,14 @@ func (c *services) Update(service *v1.Service) (result *v1.Service, err error) {
 
 func (c *services) UpdateStatus(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}
+
+	objectTenant := service.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("services").
 		Name(service.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -129,8 +129,14 @@ func (c *serviceAccounts) Watch(opts metav1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.
 func (c *serviceAccounts) Create(serviceAccount *v1.ServiceAccount) (result *v1.ServiceAccount, err error) {
 	result = &v1.ServiceAccount{}
+
+	objectTenant := serviceAccount.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("serviceaccounts").
 		Body(serviceAccount).
@@ -143,8 +149,14 @@ func (c *serviceAccounts) Create(serviceAccount *v1.ServiceAccount) (result *v1.
 // Update takes the representation of a serviceAccount and updates it. Returns the server's representation of the serviceAccount, and an error, if there is any.
 func (c *serviceAccounts) Update(serviceAccount *v1.ServiceAccount) (result *v1.ServiceAccount, err error) {
 	result = &v1.ServiceAccount{}
+
+	objectTenant := serviceAccount.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("serviceaccounts").
 		Name(serviceAccount.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/tenant.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/tenant.go
@@ -114,6 +114,7 @@ func (c *tenants) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a tenant and creates it.  Returns the server's representation of the tenant, and an error, if there is any.
 func (c *tenants) Create(tenant *v1.Tenant) (result *v1.Tenant, err error) {
 	result = &v1.Tenant{}
+
 	err = c.client.Post().
 		Resource("tenants").
 		Body(tenant).
@@ -126,6 +127,7 @@ func (c *tenants) Create(tenant *v1.Tenant) (result *v1.Tenant, err error) {
 // Update takes the representation of a tenant and updates it. Returns the server's representation of the tenant, and an error, if there is any.
 func (c *tenants) Update(tenant *v1.Tenant) (result *v1.Tenant, err error) {
 	result = &v1.Tenant{}
+
 	err = c.client.Put().
 		Resource("tenants").
 		Name(tenant.Name).
@@ -141,6 +143,7 @@ func (c *tenants) Update(tenant *v1.Tenant) (result *v1.Tenant, err error) {
 
 func (c *tenants) UpdateStatus(tenant *v1.Tenant) (result *v1.Tenant, err error) {
 	result = &v1.Tenant{}
+
 	err = c.client.Put().
 		Resource("tenants").
 		Name(tenant.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -129,8 +129,14 @@ func (c *events) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(event *v1beta1.Event) (result *v1beta1.Event, err error) {
 	result = &v1beta1.Event{}
+
+	objectTenant := event.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("events").
 		Body(event).
@@ -143,8 +149,14 @@ func (c *events) Create(event *v1beta1.Event) (result *v1beta1.Event, err error)
 // Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Update(event *v1beta1.Event) (result *v1beta1.Event, err error) {
 	result = &v1beta1.Event{}
+
+	objectTenant := event.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("events").
 		Name(event.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -130,8 +130,14 @@ func (c *daemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Body(daemonSet).
@@ -144,8 +150,14 @@ func (c *daemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.Daemo
 // Update takes the representation of a daemonSet and updates it. Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Name(daemonSet.Name).
@@ -161,8 +173,14 @@ func (c *daemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.Daemo
 
 func (c *daemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
+
+	objectTenant := daemonSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Name(daemonSet.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -133,8 +133,14 @@ func (c *deployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Body(deployment).
@@ -147,8 +153,14 @@ func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.De
 // Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deployment.Name).
@@ -164,8 +176,14 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 
 func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
+
+	objectTenant := deployment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deployment.Name).
@@ -241,8 +259,14 @@ func (c *deployments) GetScale(deploymentName string, options v1.GetOptions) (re
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *deployments) UpdateScale(deploymentName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
 	result = &v1beta1.Scale{}
+
+	objectTenant := scale.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("deployments").
 		Name(deploymentName).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -130,8 +130,14 @@ func (c *ingresses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
 func (c *ingresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
+
+	objectTenant := ingress.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("ingresses").
 		Body(ingress).
@@ -144,8 +150,14 @@ func (c *ingresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 // Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
 func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
+
+	objectTenant := ingress.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("ingresses").
 		Name(ingress.Name).
@@ -161,8 +173,14 @@ func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 
 func (c *ingresses) UpdateStatus(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
+
+	objectTenant := ingress.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("ingresses").
 		Name(ingress.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -129,8 +129,14 @@ func (c *networkPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchInterf
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *networkPolicies) Create(networkPolicy *v1beta1.NetworkPolicy) (result *v1beta1.NetworkPolicy, err error) {
 	result = &v1beta1.NetworkPolicy{}
+
+	objectTenant := networkPolicy.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("networkpolicies").
 		Body(networkPolicy).
@@ -143,8 +149,14 @@ func (c *networkPolicies) Create(networkPolicy *v1beta1.NetworkPolicy) (result *
 // Update takes the representation of a networkPolicy and updates it. Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *networkPolicies) Update(networkPolicy *v1beta1.NetworkPolicy) (result *v1beta1.NetworkPolicy, err error) {
 	result = &v1beta1.NetworkPolicy{}
+
+	objectTenant := networkPolicy.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("networkpolicies").
 		Name(networkPolicy.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -125,8 +125,14 @@ func (c *podSecurityPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
 func (c *podSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
+
+	objectTenant := podSecurityPolicy.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("podsecuritypolicies").
 		Body(podSecurityPolicy).
 		Do().
@@ -138,8 +144,14 @@ func (c *podSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolic
 // Update takes the representation of a podSecurityPolicy and updates it. Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
 func (c *podSecurityPolicies) Update(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
+
+	objectTenant := podSecurityPolicy.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("podsecuritypolicies").
 		Name(podSecurityPolicy.Name).
 		Body(podSecurityPolicy).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -133,8 +133,14 @@ func (c *replicaSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Body(replicaSet).
@@ -147,8 +153,14 @@ func (c *replicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.Re
 // Update takes the representation of a replicaSet and updates it. Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Name(replicaSet.Name).
@@ -164,8 +176,14 @@ func (c *replicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.Re
 
 func (c *replicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
+
+	objectTenant := replicaSet.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Name(replicaSet.Name).
@@ -241,8 +259,14 @@ func (c *replicaSets) GetScale(replicaSetName string, options v1.GetOptions) (re
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *replicaSets) UpdateScale(replicaSetName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
 	result = &v1beta1.Scale{}
+
+	objectTenant := scale.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("replicasets").
 		Name(replicaSetName).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -129,8 +129,14 @@ func (c *networkPolicies) Watch(opts metav1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *networkPolicies) Create(networkPolicy *v1.NetworkPolicy) (result *v1.NetworkPolicy, err error) {
 	result = &v1.NetworkPolicy{}
+
+	objectTenant := networkPolicy.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("networkpolicies").
 		Body(networkPolicy).
@@ -143,8 +149,14 @@ func (c *networkPolicies) Create(networkPolicy *v1.NetworkPolicy) (result *v1.Ne
 // Update takes the representation of a networkPolicy and updates it. Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *networkPolicies) Update(networkPolicy *v1.NetworkPolicy) (result *v1.NetworkPolicy, err error) {
 	result = &v1.NetworkPolicy{}
+
+	objectTenant := networkPolicy.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("networkpolicies").
 		Name(networkPolicy.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -130,8 +130,14 @@ func (c *ingresses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
 func (c *ingresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
+
+	objectTenant := ingress.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("ingresses").
 		Body(ingress).
@@ -144,8 +150,14 @@ func (c *ingresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 // Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
 func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
+
+	objectTenant := ingress.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("ingresses").
 		Name(ingress.Name).
@@ -161,8 +173,14 @@ func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 
 func (c *ingresses) UpdateStatus(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
+
+	objectTenant := ingress.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("ingresses").
 		Name(ingress.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -115,6 +115,7 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.
 func (c *runtimeClasses) Create(runtimeClass *v1alpha1.RuntimeClass) (result *v1alpha1.RuntimeClass, err error) {
 	result = &v1alpha1.RuntimeClass{}
+
 	err = c.client.Post().
 		Resource("runtimeclasses").
 		Body(runtimeClass).
@@ -127,6 +128,7 @@ func (c *runtimeClasses) Create(runtimeClass *v1alpha1.RuntimeClass) (result *v1
 // Update takes the representation of a runtimeClass and updates it. Returns the server's representation of the runtimeClass, and an error, if there is any.
 func (c *runtimeClasses) Update(runtimeClass *v1alpha1.RuntimeClass) (result *v1alpha1.RuntimeClass, err error) {
 	result = &v1alpha1.RuntimeClass{}
+
 	err = c.client.Put().
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -115,6 +115,7 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.
 func (c *runtimeClasses) Create(runtimeClass *v1beta1.RuntimeClass) (result *v1beta1.RuntimeClass, err error) {
 	result = &v1beta1.RuntimeClass{}
+
 	err = c.client.Post().
 		Resource("runtimeclasses").
 		Body(runtimeClass).
@@ -127,6 +128,7 @@ func (c *runtimeClasses) Create(runtimeClass *v1beta1.RuntimeClass) (result *v1b
 // Update takes the representation of a runtimeClass and updates it. Returns the server's representation of the runtimeClass, and an error, if there is any.
 func (c *runtimeClasses) Update(runtimeClass *v1beta1.RuntimeClass) (result *v1beta1.RuntimeClass, err error) {
 	result = &v1beta1.RuntimeClass{}
+
 	err = c.client.Put().
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -130,8 +130,14 @@ func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) watch.AggregatedWatchI
 // Create takes the representation of a podDisruptionBudget and creates it.  Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
 func (c *podDisruptionBudgets) Create(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	result = &v1beta1.PodDisruptionBudget{}
+
+	objectTenant := podDisruptionBudget.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("poddisruptionbudgets").
 		Body(podDisruptionBudget).
@@ -144,8 +150,14 @@ func (c *podDisruptionBudgets) Create(podDisruptionBudget *v1beta1.PodDisruption
 // Update takes the representation of a podDisruptionBudget and updates it. Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
 func (c *podDisruptionBudgets) Update(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	result = &v1beta1.PodDisruptionBudget{}
+
+	objectTenant := podDisruptionBudget.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("poddisruptionbudgets").
 		Name(podDisruptionBudget.Name).
@@ -161,8 +173,14 @@ func (c *podDisruptionBudgets) Update(podDisruptionBudget *v1beta1.PodDisruption
 
 func (c *podDisruptionBudgets) UpdateStatus(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	result = &v1beta1.PodDisruptionBudget{}
+
+	objectTenant := podDisruptionBudget.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("poddisruptionbudgets").
 		Name(podDisruptionBudget.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
@@ -125,8 +125,14 @@ func (c *podSecurityPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
 func (c *podSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
+
+	objectTenant := podSecurityPolicy.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("podsecuritypolicies").
 		Body(podSecurityPolicy).
 		Do().
@@ -138,8 +144,14 @@ func (c *podSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolic
 // Update takes the representation of a podSecurityPolicy and updates it. Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
 func (c *podSecurityPolicies) Update(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
+
+	objectTenant := podSecurityPolicy.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("podsecuritypolicies").
 		Name(podSecurityPolicy.Name).
 		Body(podSecurityPolicy).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -125,8 +125,14 @@ func (c *clusterRoles) Watch(opts metav1.ListOptions) watch.AggregatedWatchInter
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Create(clusterRole *v1.ClusterRole) (result *v1.ClusterRole, err error) {
 	result = &v1.ClusterRole{}
+
+	objectTenant := clusterRole.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterroles").
 		Body(clusterRole).
 		Do().
@@ -138,8 +144,14 @@ func (c *clusterRoles) Create(clusterRole *v1.ClusterRole) (result *v1.ClusterRo
 // Update takes the representation of a clusterRole and updates it. Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Update(clusterRole *v1.ClusterRole) (result *v1.ClusterRole, err error) {
 	result = &v1.ClusterRole{}
+
+	objectTenant := clusterRole.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		Body(clusterRole).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -125,8 +125,14 @@ func (c *clusterRoleBindings) Watch(opts metav1.ListOptions) watch.AggregatedWat
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Create(clusterRoleBinding *v1.ClusterRoleBinding) (result *v1.ClusterRoleBinding, err error) {
 	result = &v1.ClusterRoleBinding{}
+
+	objectTenant := clusterRoleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterrolebindings").
 		Body(clusterRoleBinding).
 		Do().
@@ -138,8 +144,14 @@ func (c *clusterRoleBindings) Create(clusterRoleBinding *v1.ClusterRoleBinding) 
 // Update takes the representation of a clusterRoleBinding and updates it. Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Update(clusterRoleBinding *v1.ClusterRoleBinding) (result *v1.ClusterRoleBinding, err error) {
 	result = &v1.ClusterRoleBinding{}
+
+	objectTenant := clusterRoleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		Body(clusterRoleBinding).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -129,8 +129,14 @@ func (c *roles) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Create(role *v1.Role) (result *v1.Role, err error) {
 	result = &v1.Role{}
+
+	objectTenant := role.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("roles").
 		Body(role).
@@ -143,8 +149,14 @@ func (c *roles) Create(role *v1.Role) (result *v1.Role, err error) {
 // Update takes the representation of a role and updates it. Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Update(role *v1.Role) (result *v1.Role, err error) {
 	result = &v1.Role{}
+
+	objectTenant := role.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("roles").
 		Name(role.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -129,8 +129,14 @@ func (c *roleBindings) Watch(opts metav1.ListOptions) watch.AggregatedWatchInter
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Create(roleBinding *v1.RoleBinding) (result *v1.RoleBinding, err error) {
 	result = &v1.RoleBinding{}
+
+	objectTenant := roleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Body(roleBinding).
@@ -143,8 +149,14 @@ func (c *roleBindings) Create(roleBinding *v1.RoleBinding) (result *v1.RoleBindi
 // Update takes the representation of a roleBinding and updates it. Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Update(roleBinding *v1.RoleBinding) (result *v1.RoleBinding, err error) {
 	result = &v1.RoleBinding{}
+
+	objectTenant := roleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Name(roleBinding.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -125,8 +125,14 @@ func (c *clusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
 	result = &v1alpha1.ClusterRole{}
+
+	objectTenant := clusterRole.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterroles").
 		Body(clusterRole).
 		Do().
@@ -138,8 +144,14 @@ func (c *clusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alph
 // Update takes the representation of a clusterRole and updates it. Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Update(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
 	result = &v1alpha1.ClusterRole{}
+
+	objectTenant := clusterRole.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		Body(clusterRole).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -125,8 +125,14 @@ func (c *clusterRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
 	result = &v1alpha1.ClusterRoleBinding{}
+
+	objectTenant := clusterRoleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterrolebindings").
 		Body(clusterRoleBinding).
 		Do().
@@ -138,8 +144,14 @@ func (c *clusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBin
 // Update takes the representation of a clusterRoleBinding and updates it. Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Update(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
 	result = &v1alpha1.ClusterRoleBinding{}
+
+	objectTenant := clusterRoleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		Body(clusterRoleBinding).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -129,8 +129,14 @@ func (c *roles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 	result = &v1alpha1.Role{}
+
+	objectTenant := role.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("roles").
 		Body(role).
@@ -143,8 +149,14 @@ func (c *roles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 // Update takes the representation of a role and updates it. Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Update(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 	result = &v1alpha1.Role{}
+
+	objectTenant := role.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("roles").
 		Name(role.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -129,8 +129,14 @@ func (c *roleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
 	result = &v1alpha1.RoleBinding{}
+
+	objectTenant := roleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Body(roleBinding).
@@ -143,8 +149,14 @@ func (c *roleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alph
 // Update takes the representation of a roleBinding and updates it. Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Update(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
 	result = &v1alpha1.RoleBinding{}
+
+	objectTenant := roleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Name(roleBinding.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -125,8 +125,14 @@ func (c *clusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
 	result = &v1beta1.ClusterRole{}
+
+	objectTenant := clusterRole.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterroles").
 		Body(clusterRole).
 		Do().
@@ -138,8 +144,14 @@ func (c *clusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1
 // Update takes the representation of a clusterRole and updates it. Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Update(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
 	result = &v1beta1.ClusterRole{}
+
+	objectTenant := clusterRole.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		Body(clusterRole).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -125,8 +125,14 @@ func (c *clusterRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
 	result = &v1beta1.ClusterRoleBinding{}
+
+	objectTenant := clusterRoleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterrolebindings").
 		Body(clusterRoleBinding).
 		Do().
@@ -138,8 +144,14 @@ func (c *clusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBind
 // Update takes the representation of a clusterRoleBinding and updates it. Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Update(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
 	result = &v1beta1.ClusterRoleBinding{}
+
+	objectTenant := clusterRoleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		Body(clusterRoleBinding).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -129,8 +129,14 @@ func (c *roles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 	result = &v1beta1.Role{}
+
+	objectTenant := role.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("roles").
 		Body(role).
@@ -143,8 +149,14 @@ func (c *roles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 // Update takes the representation of a role and updates it. Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Update(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 	result = &v1beta1.Role{}
+
+	objectTenant := role.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("roles").
 		Name(role.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -129,8 +129,14 @@ func (c *roleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
 	result = &v1beta1.RoleBinding{}
+
+	objectTenant := roleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Body(roleBinding).
@@ -143,8 +149,14 @@ func (c *roleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1
 // Update takes the representation of a roleBinding and updates it. Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Update(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
 	result = &v1beta1.RoleBinding{}
+
+	objectTenant := roleBinding.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Name(roleBinding.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -115,6 +115,7 @@ func (c *priorityClasses) Watch(opts metav1.ListOptions) watch.AggregatedWatchIn
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
 func (c *priorityClasses) Create(priorityClass *v1.PriorityClass) (result *v1.PriorityClass, err error) {
 	result = &v1.PriorityClass{}
+
 	err = c.client.Post().
 		Resource("priorityclasses").
 		Body(priorityClass).
@@ -127,6 +128,7 @@ func (c *priorityClasses) Create(priorityClass *v1.PriorityClass) (result *v1.Pr
 // Update takes the representation of a priorityClass and updates it. Returns the server's representation of the priorityClass, and an error, if there is any.
 func (c *priorityClasses) Update(priorityClass *v1.PriorityClass) (result *v1.PriorityClass, err error) {
 	result = &v1.PriorityClass{}
+
 	err = c.client.Put().
 		Resource("priorityclasses").
 		Name(priorityClass.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -115,6 +115,7 @@ func (c *priorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterf
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
 func (c *priorityClasses) Create(priorityClass *v1alpha1.PriorityClass) (result *v1alpha1.PriorityClass, err error) {
 	result = &v1alpha1.PriorityClass{}
+
 	err = c.client.Post().
 		Resource("priorityclasses").
 		Body(priorityClass).
@@ -127,6 +128,7 @@ func (c *priorityClasses) Create(priorityClass *v1alpha1.PriorityClass) (result 
 // Update takes the representation of a priorityClass and updates it. Returns the server's representation of the priorityClass, and an error, if there is any.
 func (c *priorityClasses) Update(priorityClass *v1alpha1.PriorityClass) (result *v1alpha1.PriorityClass, err error) {
 	result = &v1alpha1.PriorityClass{}
+
 	err = c.client.Put().
 		Resource("priorityclasses").
 		Name(priorityClass.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -115,6 +115,7 @@ func (c *priorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterf
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
 func (c *priorityClasses) Create(priorityClass *v1beta1.PriorityClass) (result *v1beta1.PriorityClass, err error) {
 	result = &v1beta1.PriorityClass{}
+
 	err = c.client.Post().
 		Resource("priorityclasses").
 		Body(priorityClass).
@@ -127,6 +128,7 @@ func (c *priorityClasses) Create(priorityClass *v1beta1.PriorityClass) (result *
 // Update takes the representation of a priorityClass and updates it. Returns the server's representation of the priorityClass, and an error, if there is any.
 func (c *priorityClasses) Update(priorityClass *v1beta1.PriorityClass) (result *v1beta1.PriorityClass, err error) {
 	result = &v1beta1.PriorityClass{}
+
 	err = c.client.Put().
 		Resource("priorityclasses").
 		Name(priorityClass.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
@@ -129,8 +129,14 @@ func (c *podPresets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a podPreset and creates it.  Returns the server's representation of the podPreset, and an error, if there is any.
 func (c *podPresets) Create(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
 	result = &v1alpha1.PodPreset{}
+
+	objectTenant := podPreset.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("podpresets").
 		Body(podPreset).
@@ -143,8 +149,14 @@ func (c *podPresets) Create(podPreset *v1alpha1.PodPreset) (result *v1alpha1.Pod
 // Update takes the representation of a podPreset and updates it. Returns the server's representation of the podPreset, and an error, if there is any.
 func (c *podPresets) Update(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
 	result = &v1alpha1.PodPreset{}
+
+	objectTenant := podPreset.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("podpresets").
 		Name(podPreset.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -115,6 +115,7 @@ func (c *storageClasses) Watch(opts metav1.ListOptions) watch.AggregatedWatchInt
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *storageClasses) Create(storageClass *v1.StorageClass) (result *v1.StorageClass, err error) {
 	result = &v1.StorageClass{}
+
 	err = c.client.Post().
 		Resource("storageclasses").
 		Body(storageClass).
@@ -127,6 +128,7 @@ func (c *storageClasses) Create(storageClass *v1.StorageClass) (result *v1.Stora
 // Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *storageClasses) Update(storageClass *v1.StorageClass) (result *v1.StorageClass, err error) {
 	result = &v1.StorageClass{}
+
 	err = c.client.Put().
 		Resource("storageclasses").
 		Name(storageClass.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -126,8 +126,14 @@ func (c *volumeAttachments) Watch(opts metav1.ListOptions) watch.AggregatedWatch
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.
 func (c *volumeAttachments) Create(volumeAttachment *v1.VolumeAttachment) (result *v1.VolumeAttachment, err error) {
 	result = &v1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Body(volumeAttachment).
 		Do().
@@ -139,8 +145,14 @@ func (c *volumeAttachments) Create(volumeAttachment *v1.VolumeAttachment) (resul
 // Update takes the representation of a volumeAttachment and updates it. Returns the server's representation of the volumeAttachment, and an error, if there is any.
 func (c *volumeAttachments) Update(volumeAttachment *v1.VolumeAttachment) (result *v1.VolumeAttachment, err error) {
 	result = &v1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		Body(volumeAttachment).
@@ -155,8 +167,14 @@ func (c *volumeAttachments) Update(volumeAttachment *v1.VolumeAttachment) (resul
 
 func (c *volumeAttachments) UpdateStatus(volumeAttachment *v1.VolumeAttachment) (result *v1.VolumeAttachment, err error) {
 	result = &v1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -126,8 +126,14 @@ func (c *volumeAttachments) Watch(opts v1.ListOptions) watch.AggregatedWatchInte
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.
 func (c *volumeAttachments) Create(volumeAttachment *v1alpha1.VolumeAttachment) (result *v1alpha1.VolumeAttachment, err error) {
 	result = &v1alpha1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Body(volumeAttachment).
 		Do().
@@ -139,8 +145,14 @@ func (c *volumeAttachments) Create(volumeAttachment *v1alpha1.VolumeAttachment) 
 // Update takes the representation of a volumeAttachment and updates it. Returns the server's representation of the volumeAttachment, and an error, if there is any.
 func (c *volumeAttachments) Update(volumeAttachment *v1alpha1.VolumeAttachment) (result *v1alpha1.VolumeAttachment, err error) {
 	result = &v1alpha1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		Body(volumeAttachment).
@@ -155,8 +167,14 @@ func (c *volumeAttachments) Update(volumeAttachment *v1alpha1.VolumeAttachment) 
 
 func (c *volumeAttachments) UpdateStatus(volumeAttachment *v1alpha1.VolumeAttachment) (result *v1alpha1.VolumeAttachment, err error) {
 	result = &v1alpha1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		SubResource("status").

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -115,6 +115,7 @@ func (c *cSIDrivers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a cSIDriver and creates it.  Returns the server's representation of the cSIDriver, and an error, if there is any.
 func (c *cSIDrivers) Create(cSIDriver *v1beta1.CSIDriver) (result *v1beta1.CSIDriver, err error) {
 	result = &v1beta1.CSIDriver{}
+
 	err = c.client.Post().
 		Resource("csidrivers").
 		Body(cSIDriver).
@@ -127,6 +128,7 @@ func (c *cSIDrivers) Create(cSIDriver *v1beta1.CSIDriver) (result *v1beta1.CSIDr
 // Update takes the representation of a cSIDriver and updates it. Returns the server's representation of the cSIDriver, and an error, if there is any.
 func (c *cSIDrivers) Update(cSIDriver *v1beta1.CSIDriver) (result *v1beta1.CSIDriver, err error) {
 	result = &v1beta1.CSIDriver{}
+
 	err = c.client.Put().
 		Resource("csidrivers").
 		Name(cSIDriver.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -115,6 +115,7 @@ func (c *cSINodes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a cSINode and creates it.  Returns the server's representation of the cSINode, and an error, if there is any.
 func (c *cSINodes) Create(cSINode *v1beta1.CSINode) (result *v1beta1.CSINode, err error) {
 	result = &v1beta1.CSINode{}
+
 	err = c.client.Post().
 		Resource("csinodes").
 		Body(cSINode).
@@ -127,6 +128,7 @@ func (c *cSINodes) Create(cSINode *v1beta1.CSINode) (result *v1beta1.CSINode, er
 // Update takes the representation of a cSINode and updates it. Returns the server's representation of the cSINode, and an error, if there is any.
 func (c *cSINodes) Update(cSINode *v1beta1.CSINode) (result *v1beta1.CSINode, err error) {
 	result = &v1beta1.CSINode{}
+
 	err = c.client.Put().
 		Resource("csinodes").
 		Name(cSINode.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -115,6 +115,7 @@ func (c *storageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *storageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
+
 	err = c.client.Post().
 		Resource("storageclasses").
 		Body(storageClass).
@@ -127,6 +128,7 @@ func (c *storageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1b
 // Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *storageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
+
 	err = c.client.Put().
 		Resource("storageclasses").
 		Name(storageClass.Name).

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -126,8 +126,14 @@ func (c *volumeAttachments) Watch(opts v1.ListOptions) watch.AggregatedWatchInte
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.
 func (c *volumeAttachments) Create(volumeAttachment *v1beta1.VolumeAttachment) (result *v1beta1.VolumeAttachment, err error) {
 	result = &v1beta1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Body(volumeAttachment).
 		Do().
@@ -139,8 +145,14 @@ func (c *volumeAttachments) Create(volumeAttachment *v1beta1.VolumeAttachment) (
 // Update takes the representation of a volumeAttachment and updates it. Returns the server's representation of the volumeAttachment, and an error, if there is any.
 func (c *volumeAttachments) Update(volumeAttachment *v1beta1.VolumeAttachment) (result *v1beta1.VolumeAttachment, err error) {
 	result = &v1beta1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		Body(volumeAttachment).
@@ -155,8 +167,14 @@ func (c *volumeAttachments) Update(volumeAttachment *v1beta1.VolumeAttachment) (
 
 func (c *volumeAttachments) UpdateStatus(volumeAttachment *v1beta1.VolumeAttachment) (result *v1beta1.VolumeAttachment, err error) {
 	result = &v1beta1.VolumeAttachment{}
+
+	objectTenant := volumeAttachment.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		SubResource("status").

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -120,6 +120,7 @@ func (c *clusterTestTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchI
 // Create takes the representation of a clusterTestType and creates it.  Returns the server's representation of the clusterTestType, and an error, if there is any.
 func (c *clusterTestTypes) Create(clusterTestType *v1.ClusterTestType) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
+
 	err = c.client.Post().
 		Resource("clustertesttypes").
 		Body(clusterTestType).
@@ -132,6 +133,7 @@ func (c *clusterTestTypes) Create(clusterTestType *v1.ClusterTestType) (result *
 // Update takes the representation of a clusterTestType and updates it. Returns the server's representation of the clusterTestType, and an error, if there is any.
 func (c *clusterTestTypes) Update(clusterTestType *v1.ClusterTestType) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
+
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
@@ -147,6 +149,7 @@ func (c *clusterTestTypes) Update(clusterTestType *v1.ClusterTestType) (result *
 
 func (c *clusterTestTypes) UpdateStatus(clusterTestType *v1.ClusterTestType) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
+
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
@@ -214,6 +217,7 @@ func (c *clusterTestTypes) GetScale(clusterTestTypeName string, options metav1.G
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *clusterTestTypes) UpdateScale(clusterTestTypeName string, scale *autoscaling.Scale) (result *autoscaling.Scale, err error) {
 	result = &autoscaling.Scale{}
+
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -130,8 +130,14 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
@@ -144,8 +150,14 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 // Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
@@ -161,8 +173,14 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 
 func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
@@ -130,8 +130,14 @@ func (c *testTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Create(testType *example.TestType) (result *example.TestType, err error) {
 	result = &example.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
@@ -144,8 +150,14 @@ func (c *testTypes) Create(testType *example.TestType) (result *example.TestType
 // Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Update(testType *example.TestType) (result *example.TestType, err error) {
 	result = &example.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
@@ -161,8 +173,14 @@ func (c *testTypes) Update(testType *example.TestType) (result *example.TestType
 
 func (c *testTypes) UpdateStatus(testType *example.TestType) (result *example.TestType, err error) {
 	result = &example.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
@@ -130,8 +130,14 @@ func (c *testTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Create(testType *example2.TestType) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
@@ -144,8 +150,14 @@ func (c *testTypes) Create(testType *example2.TestType) (result *example2.TestTy
 // Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Update(testType *example2.TestType) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
@@ -161,8 +173,14 @@ func (c *testTypes) Update(testType *example2.TestType) (result *example2.TestTy
 
 func (c *testTypes) UpdateStatus(testType *example2.TestType) (result *example2.TestType, err error) {
 	result = &example2.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -130,8 +130,14 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
@@ -144,8 +150,14 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 // Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
@@ -161,8 +173,14 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 
 func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -130,8 +130,14 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
@@ -144,8 +150,14 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 // Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
@@ -161,8 +173,14 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 
 func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -120,6 +120,7 @@ func (c *clusterTestTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchI
 // Create takes the representation of a clusterTestType and creates it.  Returns the server's representation of the clusterTestType, and an error, if there is any.
 func (c *clusterTestTypes) Create(clusterTestType *v1.ClusterTestType) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
+
 	err = c.client.Post().
 		Resource("clustertesttypes").
 		Body(clusterTestType).
@@ -132,6 +133,7 @@ func (c *clusterTestTypes) Create(clusterTestType *v1.ClusterTestType) (result *
 // Update takes the representation of a clusterTestType and updates it. Returns the server's representation of the clusterTestType, and an error, if there is any.
 func (c *clusterTestTypes) Update(clusterTestType *v1.ClusterTestType) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
+
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
@@ -147,6 +149,7 @@ func (c *clusterTestTypes) Update(clusterTestType *v1.ClusterTestType) (result *
 
 func (c *clusterTestTypes) UpdateStatus(clusterTestType *v1.ClusterTestType) (result *v1.ClusterTestType, err error) {
 	result = &v1.ClusterTestType{}
+
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
@@ -214,6 +217,7 @@ func (c *clusterTestTypes) GetScale(clusterTestTypeName string, options metav1.G
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
 func (c *clusterTestTypes) UpdateScale(clusterTestTypeName string, scale *autoscaling.Scale) (result *autoscaling.Scale, err error) {
 	result = &autoscaling.Scale{}
+
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -130,8 +130,14 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
@@ -144,8 +150,14 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 // Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
@@ -161,8 +173,14 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 
 func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -130,8 +130,14 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
@@ -144,8 +150,14 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 // Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).
@@ -161,8 +173,14 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 
 func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, err error) {
 	result = &v1.TestType{}
+
+	objectTenant := testType.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("testtypes").
 		Name(testType.Name).

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -566,10 +566,22 @@ var createSubresourceTemplate = `
 // Create takes the representation of a $.inputType|private$ and creates it.  Returns the server's representation of the $.resultType|private$, and an error, if there is any.
 func (c *$.type|privatePlural$) Create($.type|private$Name string, $.inputType|private$ *$.inputType|raw$) (result *$.resultType|raw$, err error) {
 	result = &$.resultType|raw${}
+	$if .tenanted$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$	
+	$if .namespaced$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$	
 	err = c.client.Post().
-		$if .namespaced$Tenant(c.te).
+		$if .namespaced$Tenant(objectTenant).
 		Namespace(c.ns).$end$
-		$if .tenanted$Tenant(c.te).$end$
+		$if .tenanted$Tenant(objectTenant).$end$
 		Resource("$.type|resource$").
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
@@ -585,10 +597,22 @@ var createTemplate = `
 // Create takes the representation of a $.inputType|private$ and creates it.  Returns the server's representation of the $.resultType|private$, and an error, if there is any.
 func (c *$.type|privatePlural$) Create($.inputType|private$ *$.inputType|raw$) (result *$.resultType|raw$, err error) {
 	result = &$.resultType|raw${}
+	$if .tenanted$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$	
+	$if .namespaced$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$	
 	err = c.client.Post().
-		$if .namespaced$Tenant(c.te).
+		$if .namespaced$Tenant(objectTenant).
 		Namespace(c.ns).$end$
-		$if .tenanted$Tenant(c.te).$end$
+		$if .tenanted$Tenant(objectTenant).$end$
 		Resource("$.type|resource$").
 		Body($.inputType|private$).
 		Do().
@@ -602,10 +626,22 @@ var updateSubresourceTemplate = `
 // Update takes the top resource name and the representation of a $.inputType|private$ and updates it. Returns the server's representation of the $.resultType|private$, and an error, if there is any.
 func (c *$.type|privatePlural$) Update($.type|private$Name string, $.inputType|private$ *$.inputType|raw$) (result *$.resultType|raw$, err error) {
 	result = &$.resultType|raw${}
+	$if .tenanted$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$
+	$if .namespaced$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$		
 	err = c.client.Put().
-		$if .namespaced$Tenant(c.te).
+		$if .namespaced$Tenant(objectTenant).
 		Namespace(c.ns).$end$
-		$if .tenanted$Tenant(c.te).$end$
+		$if .tenanted$Tenant(objectTenant).$end$
 		Resource("$.type|resource$").
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
@@ -621,10 +657,22 @@ var updateTemplate = `
 // Update takes the representation of a $.inputType|private$ and updates it. Returns the server's representation of the $.resultType|private$, and an error, if there is any.
 func (c *$.type|privatePlural$) Update($.inputType|private$ *$.inputType|raw$) (result *$.resultType|raw$, err error) {
 	result = &$.resultType|raw${}
+	$if .tenanted$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$	
+	$if .namespaced$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$	
 	err = c.client.Put().
-		$if .namespaced$Tenant(c.te).
+		$if .namespaced$Tenant(objectTenant).
 		Namespace(c.ns).$end$
-		$if .tenanted$Tenant(c.te).$end$
+		$if .tenanted$Tenant(objectTenant).$end$
 		Resource("$.type|resource$").
 		Name($.inputType|private$.Name).
 		Body($.inputType|private$).
@@ -641,10 +689,22 @@ var updateStatusTemplate = `
 
 func (c *$.type|privatePlural$) UpdateStatus($.type|private$ *$.type|raw$) (result *$.type|raw$, err error) {
 	result = &$.type|raw${}
+	$if .tenanted$
+	objectTenant := $.type|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$	
+	$if .namespaced$
+	objectTenant := $.inputType|private$.ObjectMeta.Tenant 
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+	$end$	
 	err = c.client.Put().
-		$if .namespaced$Tenant(c.te).
+		$if .namespaced$Tenant(objectTenant).
 		Namespace(c.ns).$end$
-		$if .tenanted$Tenant(c.te).$end$
+		$if .tenanted$Tenant(objectTenant).$end$
 		Resource("$.type|resource$").
 		Name($.type|private$.Name).
 		SubResource("status").

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -116,6 +116,7 @@ func (c *aPIServices) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterf
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
 func (c *aPIServices) Create(aPIService *v1.APIService) (result *v1.APIService, err error) {
 	result = &v1.APIService{}
+
 	err = c.client.Post().
 		Resource("apiservices").
 		Body(aPIService).
@@ -128,6 +129,7 @@ func (c *aPIServices) Create(aPIService *v1.APIService) (result *v1.APIService, 
 // Update takes the representation of a aPIService and updates it. Returns the server's representation of the aPIService, and an error, if there is any.
 func (c *aPIServices) Update(aPIService *v1.APIService) (result *v1.APIService, err error) {
 	result = &v1.APIService{}
+
 	err = c.client.Put().
 		Resource("apiservices").
 		Name(aPIService.Name).
@@ -143,6 +145,7 @@ func (c *aPIServices) Update(aPIService *v1.APIService) (result *v1.APIService, 
 
 func (c *aPIServices) UpdateStatus(aPIService *v1.APIService) (result *v1.APIService, err error) {
 	result = &v1.APIService{}
+
 	err = c.client.Put().
 		Resource("apiservices").
 		Name(aPIService.Name).

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -116,6 +116,7 @@ func (c *aPIServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
 func (c *aPIServices) Create(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
+
 	err = c.client.Post().
 		Resource("apiservices").
 		Body(aPIService).
@@ -128,6 +129,7 @@ func (c *aPIServices) Create(aPIService *v1beta1.APIService) (result *v1beta1.AP
 // Update takes the representation of a aPIService and updates it. Returns the server's representation of the aPIService, and an error, if there is any.
 func (c *aPIServices) Update(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
+
 	err = c.client.Put().
 		Resource("apiservices").
 		Name(aPIService.Name).
@@ -143,6 +145,7 @@ func (c *aPIServices) Update(aPIService *v1beta1.APIService) (result *v1beta1.AP
 
 func (c *aPIServices) UpdateStatus(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
+
 	err = c.client.Put().
 		Resource("apiservices").
 		Name(aPIService.Name).

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
@@ -116,6 +116,7 @@ func (c *aPIServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
 func (c *aPIServices) Create(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
 	result = &apiregistration.APIService{}
+
 	err = c.client.Post().
 		Resource("apiservices").
 		Body(aPIService).
@@ -128,6 +129,7 @@ func (c *aPIServices) Create(aPIService *apiregistration.APIService) (result *ap
 // Update takes the representation of a aPIService and updates it. Returns the server's representation of the aPIService, and an error, if there is any.
 func (c *aPIServices) Update(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
 	result = &apiregistration.APIService{}
+
 	err = c.client.Put().
 		Resource("apiservices").
 		Name(aPIService.Name).
@@ -143,6 +145,7 @@ func (c *aPIServices) Update(aPIService *apiregistration.APIService) (result *ap
 
 func (c *aPIServices) UpdateStatus(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
 	result = &apiregistration.APIService{}
+
 	err = c.client.Put().
 		Resource("apiservices").
 		Name(aPIService.Name).

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
@@ -115,6 +115,7 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.
 func (c *runtimeClasses) Create(runtimeClass *v1alpha1.RuntimeClass) (result *v1alpha1.RuntimeClass, err error) {
 	result = &v1alpha1.RuntimeClass{}
+
 	err = c.client.Post().
 		Resource("runtimeclasses").
 		Body(runtimeClass).
@@ -127,6 +128,7 @@ func (c *runtimeClasses) Create(runtimeClass *v1alpha1.RuntimeClass) (result *v1
 // Update takes the representation of a runtimeClass and updates it. Returns the server's representation of the runtimeClass, and an error, if there is any.
 func (c *runtimeClasses) Update(runtimeClass *v1alpha1.RuntimeClass) (result *v1alpha1.RuntimeClass, err error) {
 	result = &v1alpha1.RuntimeClass{}
+
 	err = c.client.Put().
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
@@ -115,6 +115,7 @@ func (c *fischers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a fischer and creates it.  Returns the server's representation of the fischer, and an error, if there is any.
 func (c *fischers) Create(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, err error) {
 	result = &v1alpha1.Fischer{}
+
 	err = c.client.Post().
 		Resource("fischers").
 		Body(fischer).
@@ -127,6 +128,7 @@ func (c *fischers) Create(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, 
 // Update takes the representation of a fischer and updates it. Returns the server's representation of the fischer, and an error, if there is any.
 func (c *fischers) Update(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, err error) {
 	result = &v1alpha1.Fischer{}
+
 	err = c.client.Put().
 		Resource("fischers").
 		Name(fischer.Name).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
@@ -130,8 +130,14 @@ func (c *flunders) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.
 func (c *flunders) Create(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
 	result = &v1alpha1.Flunder{}
+
+	objectTenant := flunder.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("flunders").
 		Body(flunder).
@@ -144,8 +150,14 @@ func (c *flunders) Create(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, 
 // Update takes the representation of a flunder and updates it. Returns the server's representation of the flunder, and an error, if there is any.
 func (c *flunders) Update(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
 	result = &v1alpha1.Flunder{}
+
+	objectTenant := flunder.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("flunders").
 		Name(flunder.Name).
@@ -161,8 +173,14 @@ func (c *flunders) Update(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, 
 
 func (c *flunders) UpdateStatus(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
 	result = &v1alpha1.Flunder{}
+
+	objectTenant := flunder.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("flunders").
 		Name(flunder.Name).

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -130,8 +130,14 @@ func (c *flunders) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.
 func (c *flunders) Create(flunder *v1beta1.Flunder) (result *v1beta1.Flunder, err error) {
 	result = &v1beta1.Flunder{}
+
+	objectTenant := flunder.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("flunders").
 		Body(flunder).
@@ -144,8 +150,14 @@ func (c *flunders) Create(flunder *v1beta1.Flunder) (result *v1beta1.Flunder, er
 // Update takes the representation of a flunder and updates it. Returns the server's representation of the flunder, and an error, if there is any.
 func (c *flunders) Update(flunder *v1beta1.Flunder) (result *v1beta1.Flunder, err error) {
 	result = &v1beta1.Flunder{}
+
+	objectTenant := flunder.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("flunders").
 		Name(flunder.Name).
@@ -161,8 +173,14 @@ func (c *flunders) Update(flunder *v1beta1.Flunder) (result *v1beta1.Flunder, er
 
 func (c *flunders) UpdateStatus(flunder *v1beta1.Flunder) (result *v1beta1.Flunder, err error) {
 	result = &v1beta1.Flunder{}
+
+	objectTenant := flunder.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("flunders").
 		Name(flunder.Name).

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
@@ -130,8 +130,14 @@ func (c *foos) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 // Create takes the representation of a foo and creates it.  Returns the server's representation of the foo, and an error, if there is any.
 func (c *foos) Create(foo *v1alpha1.Foo) (result *v1alpha1.Foo, err error) {
 	result = &v1alpha1.Foo{}
+
+	objectTenant := foo.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("foos").
 		Body(foo).
@@ -144,8 +150,14 @@ func (c *foos) Create(foo *v1alpha1.Foo) (result *v1alpha1.Foo, err error) {
 // Update takes the representation of a foo and updates it. Returns the server's representation of the foo, and an error, if there is any.
 func (c *foos) Update(foo *v1alpha1.Foo) (result *v1alpha1.Foo, err error) {
 	result = &v1alpha1.Foo{}
+
+	objectTenant := foo.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("foos").
 		Name(foo.Name).
@@ -161,8 +173,14 @@ func (c *foos) Update(foo *v1alpha1.Foo) (result *v1alpha1.Foo, err error) {
 
 func (c *foos) UpdateStatus(foo *v1alpha1.Foo) (result *v1alpha1.Foo, err error) {
 	result = &v1alpha1.Foo{}
+
+	objectTenant := foo.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
-		Tenant(c.te).
+		Tenant(objectTenant).
 		Namespace(c.ns).
 		Resource("foos").
 		Name(foo.Name).


### PR DESCRIPTION
For the convenience of reviews, this PR is split into two commits:
1. The change to the codegen template file, named "update type generator template", where only one file is involved. 
2. The files which are auto-updated by codegen based on the template changes. 101 files are involved.

Reviewers can browse through the files changes in the second commit quickly.