### PR TITLE
Allow api server instance from other service group to remove expired …

### DIFF
--- a/pkg/master/reconcilers/lease_test.go
+++ b/pkg/master/reconcilers/lease_test.go
@@ -32,26 +32,49 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+type fakeLeaseEntry struct {
+	updated        bool
+	serviceGroupId string
+	ip             string
+}
+
 type fakeLeases struct {
-	keys map[string]bool
+	keys map[string]*fakeLeaseEntry
 }
 
 var _ Leases = &fakeLeases{}
 
 func newFakeLeases() *fakeLeases {
-	return &fakeLeases{make(map[string]bool)}
+	return &fakeLeases{keys: make(map[string]*fakeLeaseEntry)}
 }
 
-func (f *fakeLeases) ListLeases(serviceGroupId string) ([]string, error) {
-	res := make([]string, 0, len(f.keys))
-	for ip := range f.keys {
-		res = append(res, ip)
+func (f *fakeLeases) ListLeases() (map[string][]string, error) {
+	serviceGroupIdToIps := make(map[string][]string)
+
+	for ip, leaseEntry := range f.keys {
+		existedIps, isOK := serviceGroupIdToIps[leaseEntry.serviceGroupId]
+		if !isOK {
+			serviceGroupIdToIps[leaseEntry.serviceGroupId] = []string{ip}
+		} else {
+			serviceGroupIdToIps[leaseEntry.serviceGroupId] = append(existedIps, ip)
+		}
+
 	}
-	return res, nil
+
+	return serviceGroupIdToIps, nil
 }
 
 func (f *fakeLeases) UpdateLease(ip string, serviceGroupId string) error {
-	f.keys[ip] = true
+	_, isOK := f.keys[ip]
+	if !isOK {
+		f.keys[ip] = &fakeLeaseEntry{
+			updated:        true,
+			serviceGroupId: serviceGroupId,
+			ip:             ip,
+		}
+	} else {
+		f.keys[ip].updated = true
+	}
 	return nil
 }
 
@@ -60,20 +83,33 @@ func (f *fakeLeases) RemoveLease(ip string) error {
 	return nil
 }
 
-func (f *fakeLeases) SetKeys(keys []string) {
-	for _, ip := range keys {
-		f.keys[ip] = false
+func (f *fakeLeases) SetKeys(keys map[string]string) {
+	for ip := range keys {
+		f.keys[ip] = &fakeLeaseEntry{
+			updated:        false,
+			serviceGroupId: keys[ip],
+			ip:             ip,
+		}
 	}
 }
 
 func (f *fakeLeases) GetUpdatedKeys() []string {
 	res := []string{}
-	for ip, updated := range f.keys {
-		if updated {
+	for ip, entry := range f.keys {
+		if entry.updated {
 			res = append(res, ip)
 		}
 	}
 	return res
+}
+
+func convertIpToMap(endpointsKeys []string, serviceGroupId string) map[string]string {
+	m := make(map[string]string)
+	for _, ip := range endpointsKeys {
+		m[ip] = serviceGroupId
+	}
+
+	return m
 }
 
 func TestLeaseEndpointReconciler(t *testing.T) {
@@ -417,7 +453,7 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 	}
 	for _, test := range reconcileTests {
 		fakeLeases := newFakeLeases()
-		fakeLeases.SetKeys(test.endpointKeys)
+		fakeLeases.SetKeys(convertIpToMap(test.endpointKeys, ""))
 		clientset := fake.NewSimpleClientset()
 		if test.endpoints != nil {
 			for _, ep := range test.endpoints.Items {
@@ -524,7 +560,7 @@ func TestLeaseEndpointNonReconcile(t *testing.T) {
 	for _, test := range nonReconcileTests {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeLeases := newFakeLeases()
-			fakeLeases.SetKeys(test.endpointKeys)
+			fakeLeases.SetKeys(convertIpToMap(test.endpointKeys, ""))
 			clientset := fake.NewSimpleClientset()
 			if test.endpoints != nil {
 				for _, ep := range test.endpoints.Items {
@@ -552,6 +588,492 @@ func TestLeaseEndpointNonReconcile(t *testing.T) {
 				t.Errorf("case %q: expected the master's IP to be refreshed, but the following IPs were refreshed instead: %v", test.testName, updatedKeys)
 			}
 		})
+	}
+}
+
+func TestMultipleEndpointSubsetsReconcile(t *testing.T) {
+	ns := corev1.NamespaceDefault
+	om := func(name string) metav1.ObjectMeta {
+		return metav1.ObjectMeta{Tenant: metav1.TenantDefault, Namespace: ns, Name: name}
+	}
+
+	reconcileTests := []struct {
+		testName       string
+		serviceName    string
+		ip             string // current master ip
+		serviceGroupId string // service group id of current master instance
+		endpointPorts  []corev1.EndpointPort
+		endpointKeys   map[string]string     // all master leases
+		endpoints      *corev1.EndpointsList // endpoints in registry
+		expectUpdate   *corev1.Endpoints     // nil means none expected
+	}{
+		{
+			testName:       "no existing endpoints",
+			serviceName:    "foo",
+			ip:             "1.2.3.4",
+			serviceGroupId: "1",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints:      nil,
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("foo"),
+				Subsets: []corev1.EndpointSubset{{
+					Addresses:      []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					ServiceGroupId: "1",
+				}},
+			},
+		},
+		{
+			testName:       "existing endpoints satisfy",
+			serviceName:    "foo",
+			ip:             "1.2.3.4",
+			serviceGroupId: "2",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("foo"),
+					Subsets: []corev1.EndpointSubset{{
+						Addresses:      []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "2",
+					}},
+				}},
+			},
+		},
+		{
+			testName:       "add a new instance to existing service group",
+			serviceName:    "bar",
+			ip:             "2.1.1.2",
+			serviceGroupId: "1",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"2.1.1.2": "1", "4.3.2.1": "1"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					}},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "2.1.1.2"},
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+				},
+			},
+		},
+		{
+			testName:       "add a new instance for new service group",
+			serviceName:    "bar",
+			ip:             "2.1.1.2",
+			serviceGroupId: "2",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"2.1.1.2": "2", "4.3.2.1": "1"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					}},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "2.1.1.2"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "2",
+					},
+				},
+			},
+		},
+		{
+			testName:       "add a new instance for existing service group",
+			serviceName:    "bar",
+			ip:             "2.1.1.2",
+			serviceGroupId: "2",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"2.1.1.2": "2", "4.3.2.1": "1", "4.3.2.4": "2"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.1"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "1",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.4"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "2",
+						},
+					},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "2.1.1.2"},
+							{IP: "4.3.2.4"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "2",
+					},
+				},
+			},
+		},
+		{
+			testName:       "remove an instance from service group that has another instance - update from different service group",
+			serviceName:    "bar",
+			ip:             "4.3.2.1",
+			serviceGroupId: "1",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"4.3.2.1": "1", "4.3.2.4": "2"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.1"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "1",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.4"},
+								{IP: "2.1.2.4"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "2",
+						},
+					},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.4"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "2",
+					},
+				},
+			},
+		},
+		{
+			testName:       "remove an instance from service group that has another instance - update from same service group",
+			serviceName:    "bar",
+			ip:             "4.3.2.4",
+			serviceGroupId: "2",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"4.3.2.1": "1", "4.3.2.4": "2"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.1"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "1",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.4"},
+								{IP: "2.1.2.4"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "2",
+						},
+					},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.4"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "2",
+					},
+				},
+			},
+		},
+		{
+			testName:       "remove an instance from service group that has no other instance - update from another service group",
+			serviceName:    "bar",
+			ip:             "4.3.2.1",
+			serviceGroupId: "1",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"4.3.2.1": "1"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.1"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "1",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "2.1.2.4"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "2",
+						},
+					},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+				},
+			},
+		},
+		{
+			testName:       "remove two instances from service group that has no other instance - update from another service group",
+			serviceName:    "bar",
+			ip:             "4.3.2.1",
+			serviceGroupId: "1",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"4.3.2.1": "1"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.1"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "1",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "2.1.2.4"},
+								{IP: "2.1.2.5"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "2",
+						},
+					},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+				},
+			},
+		},
+		{
+			testName:       "remove multiple instances from multiple service groups that has no other instance - update from another service group",
+			serviceName:    "bar",
+			ip:             "4.3.2.1",
+			serviceGroupId: "1",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"4.3.2.1": "1"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.1"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "1",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "2.1.2.4"},
+								{IP: "2.1.2.5"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "2",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "3.1.2.4"},
+								{IP: "3.1.2.5"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "3",
+						},
+					},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+				},
+			},
+		},
+		{
+			testName:       "remove multiple instances from multiple service groups that has no other instance and missing instance from same service group",
+			serviceName:    "bar",
+			ip:             "4.3.2.1",
+			serviceGroupId: "1",
+			endpointPorts:  []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:   map[string]string{"4.3.2.1": "1"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("bar"),
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "4.3.2.1"},
+								{IP: "4.3.2.2"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "1",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "2.1.2.4"},
+								{IP: "2.1.2.5"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "2",
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{IP: "3.1.2.4"},
+								{IP: "3.1.2.5"},
+							},
+							Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+							ServiceGroupId: "3",
+						},
+					},
+				}},
+			},
+			expectUpdate: &corev1.Endpoints{
+				ObjectMeta: om("bar"),
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports:          []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						ServiceGroupId: "1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range reconcileTests {
+		fakeLeases := newFakeLeases()
+		fakeLeases.SetKeys(test.endpointKeys)
+		clientset := fake.NewSimpleClientset()
+		if test.endpoints != nil {
+			for _, ep := range test.endpoints.Items {
+				if _, err := clientset.CoreV1().Endpoints(ep.Namespace).Create(&ep); err != nil {
+					t.Errorf("case %q: unexpected error: %v", test.testName, err)
+					continue
+				}
+			}
+		}
+		r := NewLeaseEndpointReconciler(clientset.CoreV1(), fakeLeases)
+		err := r.ReconcileEndpoints(test.serviceName, test.serviceGroupId, net.ParseIP(test.ip), test.endpointPorts, true)
+		if err != nil {
+			t.Errorf("case %q: unexpected error: %v", test.testName, err)
+		}
+		actualEndpoints, err := clientset.CoreV1().Endpoints(corev1.NamespaceDefault).Get(test.serviceName, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("case %q: unexpected error: %v", test.testName, err)
+		}
+		if test.expectUpdate != nil {
+			if e, a := test.expectUpdate, actualEndpoints; !reflect.DeepEqual(e, a) {
+				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
+			}
+		}
+		if updatedKeys := fakeLeases.GetUpdatedKeys(); len(updatedKeys) != 1 || updatedKeys[0] != test.ip {
+			t.Errorf("case %q: expected the master's IP to be refreshed, but the following IPs were refreshed instead: %v", test.testName, updatedKeys)
+		}
 	}
 }
 
@@ -626,7 +1148,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 	for _, test := range stopTests {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeLeases := newFakeLeases()
-			fakeLeases.SetKeys(test.endpointKeys)
+			fakeLeases.SetKeys(convertIpToMap(test.endpointKeys, ""))
 			clientset := fake.NewSimpleClientset()
 			for _, ep := range test.endpoints.Items {
 				if _, err := clientset.CoreV1().Endpoints(ep.Namespace).Create(&ep); err != nil {

--- a/pkg/master/reconcilers/mastercount.go
+++ b/pkg/master/reconcilers/mastercount.go
@@ -42,6 +42,9 @@ type masterCountEndpointReconciler struct {
 
 // NewMasterCountEndpointReconciler creates a new EndpointReconciler that reconciles based on a
 // specified expected number of masters.
+// MasterCount reconciler is only used in integration test. It does not have unit test and not
+//		used in api server start up path. Also have a lot of duplicated code in reconcile function.
+//		Not sure whether this is meaningful to maintain - 2020/04/10
 func NewMasterCountEndpointReconciler(masterCount int, endpointClient corev1client.EndpointsGetter) EndpointReconciler {
 	return &masterCountEndpointReconciler{
 		masterCount:    masterCount,

--- a/pkg/registry/rbac/validation/BUILD
+++ b/pkg/registry/rbac/validation/BUILD
@@ -18,7 +18,6 @@ go_test(
         "//pkg/apis/rbac/v1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
     ],
 )

--- a/pkg/registry/rbac/validation/rule_test.go
+++ b/pkg/registry/rbac/validation/rule_test.go
@@ -168,7 +168,7 @@ func TestDefaultRuleResolver(t *testing.T) {
 		namespace      string
 		effectiveRules []rbacv1.PolicyRule
 	}{
-		{	// the following cases for system tenant
+		{ // the following cases for system tenant
 			StaticRoles: staticRolesWithSystemTenant,
 			user: &user.DefaultInfo{
 				Name:   "foobar",
@@ -202,7 +202,7 @@ func TestDefaultRuleResolver(t *testing.T) {
 			},
 			effectiveRules: nil,
 		},
-		{	// the following cases for regular tenant
+		{ // the following cases for regular tenant
 			StaticRoles: staticRolesWithRegularTenant,
 			user: &user.DefaultInfo{
 				Name:   "johndoe",


### PR DESCRIPTION
Allow api server instance from other service group to remove expired lease - to support the case of single api server instance in a service group.

Tested with arktos-up.sh and arktos-apiserver-partition.sh
