### PR TITLE
Workload controller manager needs to die sooner #174

### DIFF
--- a/cmd/workload-controller-manager/app/config/config.go
+++ b/cmd/workload-controller-manager/app/config/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	EventRecorder record.EventRecorder
 
 	// the controller type config
-	ControllerTypeConfig ControllerConfig
+	ControllerConfigMap ControllerConfigMap
 }
 
 type completedConfig struct {

--- a/cmd/workload-controller-manager/app/config/controllerconfig.go
+++ b/cmd/workload-controller-manager/app/config/controllerconfig.go
@@ -27,41 +27,48 @@ type controllerTypes struct {
 }
 
 type controllerType struct {
-	Type    string `json:"type"`
-	Workers int    `json:"workers"`
+	Type                         string `json:"type"`
+	Workers                      int    `json:"workers"`
+	ReportHealthIntervalInSecond int    `json:"reportHealthIntervalInSecond"`
 }
 
-// ControllerConfig is the config to load controller configurations
+// ControllerConfigMap is the config map to load controller configurations
+type ControllerConfigMap struct {
+	typemap map[string]ControllerConfig
+}
+
+// ControllerConfig stores configured values for a controller
 type ControllerConfig struct {
-	typemap map[string]int
+	Workers                      int
+	ReportHealthIntervalInSecond int
 }
 
-// NewControllerConfig to load configuration from a local file
-func NewControllerConfig(filePath string) (ControllerConfig, error) {
+// NewControllerConfigMap to load configuration from a local file
+func NewControllerConfigMap(filePath string) (ControllerConfigMap, error) {
 	jsonFile, err := os.Open(filePath)
 	if err != nil {
-		return ControllerConfig{}, err
+		return ControllerConfigMap{}, err
 	}
 	defer jsonFile.Close()
 
 	byteValue, err := ioutil.ReadAll(jsonFile)
 	if err != nil {
-		return ControllerConfig{}, err
+		return ControllerConfigMap{}, err
 	}
 
 	var types controllerTypes
 
 	json.Unmarshal([]byte(byteValue), &types)
 
-	var controllerMap map[string]int
-	controllerMap = make(map[string]int)
+	var controllerMap map[string]ControllerConfig
+	controllerMap = make(map[string]ControllerConfig)
 	for _, controllerType := range types.Types {
-		controllerMap[controllerType.Type] = controllerType.Workers
+		controllerMap[controllerType.Type] = ControllerConfig{Workers: controllerType.Workers, ReportHealthIntervalInSecond: controllerType.ReportHealthIntervalInSecond}
 	}
-	return ControllerConfig{typemap: controllerMap}, nil
+	return ControllerConfigMap{typemap: controllerMap}, nil
 }
 
-func (c *ControllerConfig) GetWorkerNumber(controllerType string) (int, bool) {
-	workerNumber, isOK := c.typemap[controllerType]
-	return workerNumber, isOK
+func (c *ControllerConfigMap) GetControllerConfig(controllerType string) (ControllerConfig, bool) {
+	controllerConfig, isOK := c.typemap[controllerType]
+	return controllerConfig, isOK
 }

--- a/cmd/workload-controller-manager/config/controllerconfig.json
+++ b/cmd/workload-controller-manager/config/controllerconfig.json
@@ -3,17 +3,17 @@
         {
             "type":    "node",
             "workers": 5,
-            "reportHealthIntervalInSecond":  10
+            "reportHealthIntervalInSecond":  20
         },
         {
             "type":    "replicaset",
             "workers": 10,
-            "reportHealthIntervalInSecond":  10
+            "reportHealthIntervalInSecond":  20
         },
         {
             "type":     "deployment",
             "workers":  5,
-            "reportHealthIntervalInSecond":  10
+            "reportHealthIntervalInSecond":  20
         }
     ]
 }

--- a/cmd/workload-controller-manager/config/controllerconfig.json
+++ b/cmd/workload-controller-manager/config/controllerconfig.json
@@ -2,15 +2,18 @@
     "controllers": [
         {
             "type":    "node",
-            "workers": 5
+            "workers": 5,
+            "reportHealthIntervalInSecond":  10
         },
         {
             "type":    "replicaset",
-            "workers": 10
+            "workers": 10,
+            "reportHealthIntervalInSecond":  10
         },
         {
             "type":     "deployment",
-            "workers":  5
+            "workers":  5,
+            "reportHealthIntervalInSecond":  10
         }
     ]
 }

--- a/cmd/workload-controller-manager/main.go
+++ b/cmd/workload-controller-manager/main.go
@@ -69,7 +69,7 @@ func main() {
 }
 
 func getConfig() (*controllerManagerConfig.Config, error) {
-	controllerconfig, err := controllerManagerConfig.NewControllerConfig(controllerconfigfilepath)
+	controllerConfigMap, err := controllerManagerConfig.NewControllerConfigMap(controllerconfigfilepath)
 
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func getConfig() (*controllerManagerConfig.Config, error) {
 	c := &controllerManagerConfig.Config{
 		Client:                  client,
 		ControllerManagerConfig: agConfig,
-		ControllerTypeConfig:    controllerconfig,
+		ControllerConfigMap:     controllerConfigMap,
 		//EventRecorder:        eventRecorder,
 	}
 

--- a/pkg/cloudfabric-controller/deployment/deployment_controller.go
+++ b/pkg/cloudfabric-controller/deployment/deployment_controller.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"github.com/grafov/bcast"
 	"k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/kubernetes/cmd/workload-controller-manager/app/config"
 	"k8s.io/kubernetes/pkg/cloudfabric-controller/controllerframework"
 	"reflect"
@@ -173,7 +174,7 @@ func (dc *DeploymentController) Run(controllerConfig config.ControllerConfig, st
 
 	go dc.WatchInstanceUpdate(stopCh)
 
-	go wait.Until(dc.ReportHealth, time.Second*time.Duration(controllerConfig.ReportHealthIntervalInSecond), stopCh)
+	go wait.Until(dc.ReportHealth, time.Second*time.Duration(controllerConfig.ReportHealthIntervalInSecond+rand.Intn(3)), stopCh)
 
 	klog.Infof("All work started for controller %s instance %s", dc.GetControllerType(), dc.GetControllerName())
 

--- a/pkg/cloudfabric-controller/deployment/deployment_controller.go
+++ b/pkg/cloudfabric-controller/deployment/deployment_controller.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"github.com/grafov/bcast"
 	"k8s.io/apimachinery/pkg/apis/meta/fuzzer"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/kubernetes/cmd/workload-controller-manager/app/config"
 	"k8s.io/kubernetes/pkg/cloudfabric-controller/controllerframework"
 	"reflect"
@@ -174,7 +173,7 @@ func (dc *DeploymentController) Run(controllerConfig config.ControllerConfig, st
 
 	go dc.WatchInstanceUpdate(stopCh)
 
-	go wait.Until(dc.ReportHealth, time.Second*time.Duration(controllerConfig.ReportHealthIntervalInSecond+rand.Intn(3)), stopCh)
+	go wait.Until(dc.ReportHealth, time.Second*time.Duration(controllerConfig.ReportHealthIntervalInSecond), stopCh)
 
 	klog.Infof("All work started for controller %s instance %s", dc.GetControllerType(), dc.GetControllerName())
 

--- a/pkg/cloudfabric-controller/replicaset/replica_set.go
+++ b/pkg/cloudfabric-controller/replicaset/replica_set.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/grafov/bcast"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	apps "k8s.io/api/apps/v1"
@@ -206,7 +207,7 @@ func (rsc *ReplicaSetController) Run(controllerConfig config.ControllerConfig, s
 
 	go rsc.ControllerBase.WatchInstanceUpdate(stopCh)
 
-	go wait.Until(rsc.ControllerBase.ReportHealth, time.Second*time.Duration(controllerConfig.ReportHealthIntervalInSecond), stopCh)
+	go wait.Until(rsc.ControllerBase.ReportHealth, time.Second*time.Duration(controllerConfig.ReportHealthIntervalInSecond+rand.Intn(3)), stopCh)
 
 	klog.Infof("All work started for controller %s instance %s", rsc.GetControllerType(), rsc.GetControllerName())
 

--- a/pkg/cloudfabric-controller/replicaset/replica_set.go
+++ b/pkg/cloudfabric-controller/replicaset/replica_set.go
@@ -37,7 +37,6 @@ import (
 	"time"
 
 	"github.com/grafov/bcast"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	apps "k8s.io/api/apps/v1"
@@ -207,7 +206,7 @@ func (rsc *ReplicaSetController) Run(controllerConfig config.ControllerConfig, s
 
 	go rsc.ControllerBase.WatchInstanceUpdate(stopCh)
 
-	go wait.Until(rsc.ControllerBase.ReportHealth, time.Second*time.Duration(controllerConfig.ReportHealthIntervalInSecond+rand.Intn(3)), stopCh)
+	go wait.Until(rsc.ControllerBase.ReportHealth, time.Second*time.Duration(controllerConfig.ReportHealthIntervalInSecond), stopCh)
 
 	klog.Infof("All work started for controller %s instance %s", rsc.GetControllerType(), rsc.GetControllerName())
 

--- a/pkg/registry/core/controllerinstance/storage/storage.go
+++ b/pkg/registry/core/controllerinstance/storage/storage.go
@@ -33,7 +33,7 @@ type REST struct {
 	*genericregistry.Store
 }
 
-const TTL = 300 // time-to-live in seconds
+const TTL = 60 // time-to-live in seconds
 
 // NewREST returns a RESTStorage object that will work with ControllerInstance objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, controller instance record in registry will be automatically deleted after 5 minutes when it could not renew its lease. This is designed for a very stable environment. However, initial testing often has stability problem and caused workload controller manager restart. Further investigation also found api server does lease renewal every 10 seconds. This change will allow problematic controller instances to be discovered much faster.

**Which issue(s) this PR fixes**:
Workload controller manager needs to die sooner #174

**Special notes for your reviewer**:
Please suggest configured values.
I introduced type ControllerConfig, so renamed original ControllerConfig to ControllerConfigMap.

**Does this PR introduce a user-facing change?**:
No