### PR TITLE
revert the empty tenat issue workaround

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo.go
@@ -18,6 +18,7 @@ package filters
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,11 +39,8 @@ func WithTenantInfo(handler http.Handler) http.Handler {
 
 		tenantInRequestor := requestor.GetTenant()
 		if tenantInRequestor == metav1.TenantNone {
-			// temporary workaround
-			// tracking issue: https://github.com/futurewei-cloud/arktos/issues/102
-			tenantInRequestor = metav1.TenantSystem
-			//responsewriters.InternalError(w, req, errors.New(fmt.Sprintf("The tenant in the user info of %s is empty. ", requestor.GetName())))
-			//return
+			responsewriters.InternalError(w, req, errors.New(fmt.Sprintf("The tenant in the user info of %s is empty. ", requestor.GetName())))
+			return
 		}
 
 		requestInfo, exists := request.RequestInfoFrom(ctx)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo_test.go
@@ -71,15 +71,13 @@ func TestTenantInfoRequest(t *testing.T) {
 			ExepctedRespCode: 500,
 			ExpectedTenant:   "",
 		},
-		// temporarily disabled test case
-		// tracking issue: https://github.com/futurewei-cloud/arktos/issues/102
-		/*{
+		{
 			Name:             "empty tenant in user info triggers Internal error",
 			Url:              "/api/v1/namespaces/default/pods",
 			UserInfo:         getTenantedUserInfo(metav1.TenantNone),
 			ExepctedRespCode: 500,
 			ExpectedTenant:   "",
-		},*/
+		},
 		{
 			Name:             "system tenant user does not change tenant in request info",
 			Url:              "/api/v1/tenants/aaa/namespaces/default/pods",


### PR DESCRIPTION
This PR reverts the workaround in (https://github.com/futurewei-cloud/arktos/commit/0cc299aaa0045b26c18adcc22d756deb3595d224#diff-3786e4ac530b6b336e17ff7e8219f765) as the necessary fixes are checked in.