### PR TITLE
Migrated etcd 3.3.10 to etcd 3.4.4 cluster server image changes

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -1,0 +1,6 @@
+dependencies:
+  - name: "etcd"
+    version: 3.4.4
+    refPaths:
+    - path: cluster/gce/manifests/etcd.manifest
+      match: etcd_docker_tag|etcd_version

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -1,4 +1,5 @@
 # Copyright 2018 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,11 +36,11 @@ _CRI_TARBALL_ARCH_SHA256 = {
     "s390x": "8b7b5749cba88ef337997ae90aa04380e3cab2c040b44b505b2fcd691c4935e4",
 }
 
-ETCD_VERSION = "3.3.10"
+ETCD_VERSION = "3.4.4"
 _ETCD_TARBALL_ARCH_SHA256 = {
-    "amd64": "1620a59150ec0a0124a65540e23891243feb2d9a628092fb1edcc23974724a45",
-    "arm64": "5ec97b0b872adce275b8130d19db314f7f2b803aeb24c4aae17a19e2d66853c4",
-    "ppc64le": "148fe96f0ec1813c5db9916199e96a913174304546bc8447a2d2f9fee4b8f6c2",
+    "amd64": "35abe668022073dfe6239aa42fd15ded9810f7ccee281af0b9d0646dd270de47",
+    "arm64": "52444314c01f7dad7d319a7b87ea7a5a7e48af96584c48639922a4b2f32329a4",
+    "ppc64le": "b7e43e08e123d0b30c7fddc8b903c0d7c8de49e28db8c87cf5cc4a24b68a715d",
 }
 
 # Dependencies needed for a Kubernetes "release", e.g. building docker images,

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -188,7 +188,7 @@ ENABLE_METADATA_AGENT="${KUBE_ENABLE_METADATA_AGENT:-none}"
 # Useful for scheduling heapster in large clusters with nodes of small size.
 HEAPSTER_MACHINE_TYPE="${HEAPSTER_MACHINE_TYPE:-}"
 
-# Set etcd image (e.g. k8s.gcr.io/etcd) and version (e.g. 3.3.10-1) if you need
+# Set etcd image (e.g. k8s.gcr.io/etcd) and version (e.g. 3.4.4-0) if you need
 # non-default version.
 ETCD_IMAGE="${TEST_ETCD_IMAGE:-}"
 ETCD_DOCKER_REPOSITORY="${TEST_ETCD_DOCKER_REPOSITORY:-}"

--- a/cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
+++ b/cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
@@ -14,4 +14,4 @@ spec:
   dnsPolicy: Default
   containers:
   - name: etcd-empty-dir-cleanup
-    image: k8s.gcr.io/etcd-empty-dir-cleanup:3.3.10.1
+    image: k8s.gcr.io/etcd-empty-dir-cleanup:3.4.4.0

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -14,7 +14,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.3.10-1') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.4.4-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -30,7 +30,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.3.10') }}"
+        "value": "{{ pillar.get('etcd_version', '3.4.4) }}"
       },
       { "name": "DATA_DIRECTORY",
         "value": "/var/etcd/data{{ suffix }}"

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright 2018 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -170,8 +171,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.3.10-1
-export ETCD_VERSION=3.3.10
+export ETCD_IMAGE=3.4.4-0
+export ETCD_VERSION=3.4.4
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -1,4 +1,5 @@
 # Copyright 2016 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +15,13 @@
 
 .PHONY:	build push
 
-ETCD_VERSION = 3.3.10
+ETCD_VERSION = 3.4.4
 # Image should be pulled from k8s.gcr.io, which will auto-detect
 # region (us, eu, asia, ...) and pull from the closest.
 REGISTRY = k8s.gcr.io
 # Images should be pushed to staging-k8s.gcr.io.
 PUSH_REGISTRY = staging-k8s.gcr.io
-TAG = 3.3.10.0
+TAG = 3.4.4.0
 
 clean:
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -1,4 +1,5 @@
 # Copyright 2016 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +16,7 @@
 # Build the etcd image
 #
 # Usage:
-# 	[BUNDLED_ETCD_VERSIONS=2.2.1 2.3.7 3.0.17 3.1.12 3.2.24 3.3.10] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
+# 	[BUNDLED_ETCD_VERSIONS=3.4.4] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 #
 # The image contains different etcd versions to simplify
 # upgrades. Thus be careful when removing any versions from here.
@@ -26,10 +27,10 @@
 # Except from etcd-$(version) and etcdctl-$(version) binaries, we also
 # need etcd and etcdctl binaries for backward compatibility reasons.
 # That binary will be set to the last version from $(BUNDLED_ETCD_VERSIONS).
-BUNDLED_ETCD_VERSIONS?=2.2.1 2.3.7 3.0.17 3.1.12 3.2.24 3.3.10
+BUNDLED_ETCD_VERSIONS?=3.4.4
 
 # LATEST_ETCD_VERSION identifies the most recent etcd version available.
-LATEST_ETCD_VERSION?=3.3.10
+LATEST_ETCD_VERSION?=3.4.4
 
 # REVISION provides a version number fo this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
@@ -52,7 +53,7 @@ MANIFEST_IMAGE := $(PUSH_REGISTRY)/etcd
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 # golang version should match the golang version from https://github.com/coreos/etcd/releases for the current ETCD_VERSION.
-GOLANG_VERSION?=1.10.4
+GOLANG_VERSION?=1.12.9
 GOARM=7
 TEMP_DIR:=$(shell mktemp -d)
 
@@ -97,13 +98,23 @@ else
 
 	# Download etcd in a golang container and cross-compile it statically
 	# For each release create a tmp dir 'etcd_release_tmp_dir' and unpack the release tar there.
+        arch_prefix=""
+        ifeq ($(ARCH),arm)
+		arch_prefix="GOARM=$(GOARM)"
+        endif
+
+        # use '/go/src/go.etcd.io/etcd' to build etcd 3.4 and later.
 	for version in $(BUNDLED_ETCD_VERSIONS); do \
-		etcd_release_tmp_dir=$(shell mktemp -d); \
-		docker run --interactive -v $${etcd_release_tmp_dir}:/etcdbin golang:$(GOLANG_VERSION) /bin/bash -c \
-			"git clone https://github.com/coreos/etcd /go/src/github.com/coreos/etcd \
-			&& cd /go/src/github.com/coreos/etcd \
+	        etcd_release_tmp_dir=$(shell mktemp -d); \
+		etcd_build_dir="/go/src/github.com/coreos/etcd"; \
+		if [ $$(echo $$version | cut -d. -f2) -gt 3 ]; then \
+			etcd_build_dir="/go/src/go.etcd.io/etcd"; \
+		fi; \
+		docker run --interactive -v $${etcd_release_tmp_dir}:/etcdbin golang:$(GOLANG_VERSION)$(DOCKER_VOL_OPTS) /bin/bash -c \
+			"git clone https://github.com/coreos/etcd $$etcd_build_dir \
+			&& cd $$etcd_build_dir \
 			&& git checkout v$${version} \
-			&& GOARM=$(GOARM) GOARCH=$(ARCH) ./build \
+			&& $(arch_prefix) GOARCH=$(ARCH) ./build \
 			&& cp -f bin/$(ARCH)/etcd* bin/etcd* /etcdbin; echo 'done'"; \
 		cp $$etcd_release_tmp_dir/etcd $$etcd_release_tmp_dir/etcdctl $(TEMP_DIR)/; \
 		cp $(TEMP_DIR)/etcd $(TEMP_DIR)/etcd-$$version; \

--- a/cluster/images/etcd/README.md
+++ b/cluster/images/etcd/README.md
@@ -26,7 +26,7 @@ server.
 
 `migrate` writes a `version.txt` file to track the "current" version
 of etcd that was used to persist data to disk. A "target" version may also be provided
-by the `TARGET_STORAGE` (e.g. "etcd3") and `TARGET_VERSION` (e.g. "3.3.10" )
+by the `TARGET_STORAGE` (e.g. "etcd3") and `TARGET_VERSION` (e.g. "3.4.4" )
 environment variables. If the persisted version differs from the target version,
 `migrate-if-needed.sh` will migrate the data from the current to the target
 version.

--- a/cluster/images/etcd/migrate-if-needed.sh
+++ b/cluster/images/etcd/migrate-if-needed.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # Copyright 2016 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,20 +18,17 @@
 # NOTES
 # This script performs etcd upgrade based on the following environmental
 # variables:
-# TARGET_STORAGE - API of etcd to be used (supported: 'etcd2', 'etcd3')
-# TARGET_VERSION - etcd release to be used (supported: '2.2.1', '2.3.7', '3.0.17', '3.1.12', '3.2.24', "3.3.10")
+# TARGET_STORAGE - API of etcd to be used (supported: 'etcd3')
+# TARGET_VERSION - etcd release to be used (supported: '3.4.4')
 # DATA_DIRECTORY - directory with etcd data
 #
 # The current etcd version and storage format is detected based on the
 # contents of "${DATA_DIRECTORY}/version.txt" file (if the file doesn't
-# exist, we default it to "2.2.1/etcd2".
+# exist, we default it to "3.4.4/etcd3".
 #
-# The update workflow support the following upgrade steps:
-# - 2.2.1/etcd2 -> 2.3.7/etcd2
-# - 2.3.7/etcd2 -> 3.0.17/etcd2
-# - 3.0.17/etcd3 -> 3.1.12/etcd3
-# - 3.1.12/etcd3 -> 3.2.24/etcd3
-# - 3.2.24/etcd3 -> 3.3.10/etcd3
+# There is no upgrade process now.
+# If later we have etcd versions to upgrade, the The workflow will support the following upgrade steps:
+# - 3.4.4/etcd3 -> 3.4.x/etcd3
 #
 # NOTE: The releases supported in this script has to match release binaries
 # present in the etcd image (to make this script work correctly).
@@ -43,7 +41,7 @@ set -o nounset
 
 # NOTE: BUNDLED_VERSION has to match release binaries present in the
 # etcd image (to make this script work correctly).
-BUNDLED_VERSIONS="2.2.1, 2.3.7, 3.0.17, 3.1.12, 3.2.24, 3.3.10"
+BUNDLED_VERSIONS="3.4.4"
 
 ETCD_NAME="${ETCD_NAME:-etcd-$(hostname)}"
 if [ -z "${DATA_DIRECTORY:-}" ]; then

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -87,6 +87,8 @@ const (
 
 	// EtcdListenClientPort defines the port etcd listen on for client traffic
 	EtcdListenClientPort = 2379
+	// EtcdMetricsPort is the port at which to obtain etcd metrics and health status
+	EtcdMetricsPort = 2381
 
 	// EtcdPeerCertAndKeyBaseName defines etcd's peer certificate and key base name
 	EtcdPeerCertAndKeyBaseName = "etcd/peer"
@@ -259,7 +261,7 @@ const (
 	MinExternalEtcdVersion = "3.2.18"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.3.10"
+	DefaultEtcdVersion = "3.4.4-0"
 
 	// PauseVersion indicates the default pause image version for kubeadm
 	PauseVersion = "3.1"
@@ -371,6 +373,10 @@ const (
 	// May be overridden by a flag at startup.
 	// Deprecated: use the secure KubeControllerManagerPort instead.
 	InsecureKubeControllerManagerPort = 10252
+
+	// EtcdAdvertiseClientUrlsAnnotationKey is the annotation key on every etcd pod, describing the
+	// advertise client URLs
+	EtcdAdvertiseClientUrlsAnnotationKey = "kubeadm.kubernetes.io/etcd.advertise-client-urls"
 )
 
 var (
@@ -405,12 +411,11 @@ var (
 	CurrentKubernetesVersion = version.MustParseSemantic("v1.14.0")
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
+	// Since the current arktos version is 14, therefore, we change the etcd version to 3.4.4
 	SupportedEtcdVersion = map[uint8]string{
 		12: "3.2.24",
 		13: "3.2.24",
-		14: "3.3.10",
-		15: "3.3.10",
-		16: "3.3.10",
+		14: "3.4.4-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -155,9 +156,24 @@ func TestEtcdSupportedVersion(t *testing.T) {
 		expectedError     error
 	}{
 		{
-			kubernetesVersion: "1.99.0",
+			kubernetesVersion: "1.x.0",
 			expectedVersion:   nil,
-			expectedError:     errors.New("Unsupported or unknown Kubernetes version(1.99.0)"),
+			expectedError:     errors.New("illegal version string \"1.x.0\""),
+		},
+		{
+			kubernetesVersion: "1.14.0",
+			expectedVersion:   version.MustParseSemantic("3.4.4-0"),
+			expectedError:     nil,
+		},
+		{
+			kubernetesVersion: "1.14.1",
+			expectedVersion:   version.MustParseSemantic("3.4.4-0"),
+			expectedError:     nil,
+		},
+		{
+			kubernetesVersion: "1.16.0",
+			expectedVersion:   nil,
+			expectedError:     errors.New("Unsupported or unknown Kubernetes version(1.16.0)"),
 		},
 		{
 			kubernetesVersion: MinimumControlPlaneVersion.WithPatch(1).String(),

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -85,11 +85,9 @@ kube::etcd::start() {
   ETCD_PID=$!
 
   echo "Waiting for etcd to come up."
-  kube::util::wait_for_url "${KUBE_INTEGRATION_ETCD_URL}/version" "etcd: " 0.25 80
-  curl -fs -L ${KUBE_INTEGRATION_ETCD_URL}/v3/kv/put -X POST -d '{"key": "Zm9v", "value": "YmFy"}'
-  curl -fs -L ${KUBE_INTEGRATION_ETCD_URL}/v3/kv/range -X POST -d '{"key": "Zm9v"}'
-  curl -fs -L ${KUBE_INTEGRATION_ETCD_URL}/v3/kv/range -X POST -d '{"key": "Zm9v", "range_end": "Zm9w"}'
-  curl -fs -L ${KUBE_INTEGRATION_ETCD_URL}/v3/kv/deleterange -X POST -d '{"key": "Zm9v"}'
+  # Check etcd health
+  kube::util::wait_for_url "${KUBE_INTEGRATION_ETCD_URL}/health" "etcd: " 0.25 80
+  curl -fs -X POST "${KUBE_INTEGRATION_ETCD_URL}/v3/kv/put" -d '{"key": "X3Rlc3Q=", "value": ""}'
 }
 
 kube::etcd::stop() {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -232,7 +233,7 @@ func initImageConfigs() map[int]Config {
 	configs[DebianBase] = Config{googleContainerRegistry, "debian-base", "0.4.1"}
 	configs[EchoServer] = Config{e2eRegistry, "echoserver", "2.2"}
 	configs[EntrypointTester] = Config{e2eRegistry, "entrypoint-tester", "1.0"}
-	configs[Etcd] = Config{gcRegistry, "etcd", "3.3.10"}
+	configs[Etcd] = Config{gcRegistry, "etcd", "3.4.4"}
 	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
 	configs[GBRedisSlave] = Config{sampleRegistry, "gb-redisslave", "v3"}
 	configs[InClusterClient] = Config{e2eRegistry, "inclusterclient", "1.0"}


### PR DESCRIPTION
There will be a change to replace github.com/coreos/etcd by go.etcd.io/etcd  for client shortly. I have to divide the changes into small ones to make it reviewable.