### PR TITLE
Workload controller manager needs to die sooner #174

### DIFF
--- a/cmd/workload-controller-manager/app/config/controllerconfig.go
+++ b/cmd/workload-controller-manager/app/config/controllerconfig.go
@@ -22,8 +22,9 @@ import (
 	"os"
 )
 
-type controllerTypes struct {
-	Types []controllerType `json:"controllers"`
+type controllerManagerConfig struct {
+	ReportHealthIntervalInSecond int              `json:"reportHealthIntervalInSecond"`
+	Types                        []controllerType `json:"controllers"`
 }
 
 type controllerType struct {
@@ -33,7 +34,8 @@ type controllerType struct {
 
 // ControllerConfig is the config to load controller configurations
 type ControllerConfig struct {
-	typemap map[string]int
+	typemap                      map[string]int
+	reportHealthIntervalInSecond int
 }
 
 // NewControllerConfig to load configuration from a local file
@@ -49,7 +51,7 @@ func NewControllerConfig(filePath string) (ControllerConfig, error) {
 		return ControllerConfig{}, err
 	}
 
-	var types controllerTypes
+	var types controllerManagerConfig
 
 	json.Unmarshal([]byte(byteValue), &types)
 
@@ -58,10 +60,14 @@ func NewControllerConfig(filePath string) (ControllerConfig, error) {
 	for _, controllerType := range types.Types {
 		controllerMap[controllerType.Type] = controllerType.Workers
 	}
-	return ControllerConfig{typemap: controllerMap}, nil
+	return ControllerConfig{typemap: controllerMap, reportHealthIntervalInSecond: types.ReportHealthIntervalInSecond}, nil
 }
 
 func (c *ControllerConfig) GetWorkerNumber(controllerType string) (int, bool) {
 	workerNumber, isOK := c.typemap[controllerType]
 	return workerNumber, isOK
+}
+
+func (c *ControllerConfig) GetReportHealthIntervalInSecond() int {
+	return c.reportHealthIntervalInSecond
 }

--- a/cmd/workload-controller-manager/config/controllerconfig.json
+++ b/cmd/workload-controller-manager/config/controllerconfig.json
@@ -1,4 +1,5 @@
 {
+    "reportHealthIntervalInSecond": 10,
     "controllers": [
         {
             "type":    "node",

--- a/pkg/cloudfabric-controller/deployment/deployment_controller.go
+++ b/pkg/cloudfabric-controller/deployment/deployment_controller.go
@@ -172,8 +172,6 @@ func (dc *DeploymentController) Run(workers int, stopCh <-chan struct{}) {
 
 	go dc.WatchInstanceUpdate(stopCh)
 
-	go wait.Until(dc.ReportHealth, time.Minute, stopCh)
-
 	klog.Infof("All work started for controller %s instance %s", dc.GetControllerType(), dc.GetControllerName())
 
 	<-stopCh

--- a/pkg/cloudfabric-controller/replicaset/replica_set.go
+++ b/pkg/cloudfabric-controller/replicaset/replica_set.go
@@ -30,11 +30,12 @@ package replicaset
 
 import (
 	"fmt"
-	controller "k8s.io/kubernetes/pkg/cloudfabric-controller"
 	"reflect"
 	"sort"
 	"sync"
 	"time"
+
+	controller "k8s.io/kubernetes/pkg/cloudfabric-controller"
 
 	"github.com/grafov/bcast"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -204,8 +205,6 @@ func (rsc *ReplicaSetController) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	go rsc.ControllerBase.WatchInstanceUpdate(stopCh)
-
-	go wait.Until(rsc.ControllerBase.ReportHealth, time.Minute, stopCh)
 
 	klog.Infof("All work started for controller %s instance %s", rsc.GetControllerType(), rsc.GetControllerName())
 

--- a/pkg/registry/core/controllerinstance/storage/storage.go
+++ b/pkg/registry/core/controllerinstance/storage/storage.go
@@ -33,7 +33,7 @@ type REST struct {
 	*genericregistry.Store
 }
 
-const TTL = 300 // time-to-live in seconds
+const TTL = 30 // time-to-live in seconds
 
 // NewREST returns a RESTStorage object that will work with ControllerInstance objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Currently, controller instance record in registry will be automatically deleted after 5 minutes when it could not renew its lease. This is designed for a very stable environment. However, initial testing often has stability problem and caused workload controller manager restart. Further investigation also found api server does lease renewal every 10 seconds. This change will allow problematic controller instances to be discovered much faster.

Which issue(s) this PR fixes:
Workload controller manager needs to die sooner #174

Special notes for your reviewer:
Please suggest configured values.
I introduced type ControllerConfig, so renamed original ControllerConfig to ControllerConfigMap.

Does this PR introduce a user-facing change?:
No