### PR TITLE
Change crd scope

### DIFF
--- a/pkg/registry/rbac/clusterrole/registry.go
+++ b/pkg/registry/rbac/clusterrole/registry.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/registry/rbac/escalation_check.go
+++ b/pkg/registry/rbac/escalation_check.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/registry/rbac/validation/rule.go
+++ b/pkg/registry/rbac/validation/rule.go
@@ -411,7 +411,7 @@ func (r *StaticRoles) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
 
 func (r *StaticRoles) GetClusterRoleWithMultiTenancy(tenant, name string) (*rbacv1.ClusterRole, error) {
 	for _, clusterRole := range r.clusterRoles {
-		if clusterRole.Name == name && clusterRole.Tenant == tenant{
+		if clusterRole.Name == name && clusterRole.Tenant == tenant {
 			return clusterRole, nil
 		}
 	}

--- a/plugin/pkg/auth/authorizer/rbac/rbac_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac_test.go
@@ -45,8 +45,8 @@ func newRule(verbs, apiGroups, resources, nonResourceURLs string) rbacv1.PolicyR
 func newRole(tenant, name, namespace string, rules ...rbacv1.PolicyRule) *rbacv1.Role {
 	return &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{
 		Namespace: namespace,
-		Name: name,
-		Tenant: tenant,
+		Name:      name,
+		Tenant:    tenant,
 	}, Rules: rules}
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
@@ -335,7 +335,6 @@ const CustomResourceCleanupFinalizer = "customresourcecleanup.apiextensions.k8s.
 
 // +genclient
 // +genclient:nonNamespaced
-// +genclient:nonTenanted
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -349,7 +349,6 @@ type CustomResourceDefinitionStatus struct {
 const CustomResourceCleanupFinalizer = "customresourcecleanup.apiextensions.k8s.io"
 
 // +genclient
-// +genclient:nonTenanted
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -59,7 +59,7 @@ func ValidateCustomResourceDefinition(obj *apiextensions.CustomResourceDefinitio
 		return ret
 	}
 
-	allErrs := genericvalidation.ValidateObjectMeta(&obj.ObjectMeta, false, false, nameValidationFn, field.NewPath("metadata"))
+	allErrs := genericvalidation.ValidateObjectMeta(&obj.ObjectMeta, true, false, nameValidationFn, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateCustomResourceDefinitionSpec(&obj.Spec, field.NewPath("spec"))...)
 	allErrs = append(allErrs, ValidateCustomResourceDefinitionStatus(&obj.Status, field.NewPath("status"))...)
 	allErrs = append(allErrs, ValidateCustomResourceDefinitionStoredVersions(obj.Status.StoredVersions, obj.Spec.Versions, field.NewPath("status").Child("storedVersions"))...)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -85,7 +85,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: invalid port 0",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -135,7 +135,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: invalid port 65536",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -185,7 +185,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: both service and URL provided",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -235,7 +235,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: blank URL",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -282,7 +282,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig_should_not_be_set",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -323,7 +323,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "ConversionReviewVersions_should_not_be_set",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -362,7 +362,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: invalid ConversionReviewVersion",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -409,7 +409,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: invalid ConversionReviewVersion version string",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -457,7 +457,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: at least one valid ConversionReviewVersion",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -502,7 +502,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: duplicate ConversionReviewVersion",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -549,7 +549,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "missing_webhookconfig",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -592,7 +592,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "invalid_conversion_strategy",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -635,7 +635,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "none conversion without preserveUnknownFields=false",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -671,7 +671,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhook conversion without preserveUnknownFields=false",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -713,7 +713,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhook conversion with preserveUnknownFields=false",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -758,7 +758,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "no_storage_version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -796,7 +796,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "multiple_storage_version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -835,7 +835,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "missing_storage_version_in_stored_versions",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -873,7 +873,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "empty_stored_version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -906,7 +906,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "mismatched name",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.not.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.not.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Names: apiextensions.CustomResourceDefinitionNames{
@@ -928,7 +928,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "missing values",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 			},
 			errors: []validationMatch{
 				invalid("status", "storedVersions"),
@@ -945,7 +945,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "bad names 01",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group",
 					Version: "ve()*rsion",
@@ -989,7 +989,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "bad names 02",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.c(*&om",
 					Version:  "version",
@@ -1026,7 +1026,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "additionalProperties and properties forbidden",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1062,7 +1062,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "additionalProperties without properties allowed (map[string]string)",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1098,7 +1098,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "per-version fields may not all be set to identical values (top-level field should be used instead)",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1148,7 +1148,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-preserve-unknown-field: false",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1184,7 +1184,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "preserveUnknownFields with unstructural global schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1225,7 +1225,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "preserveUnknownFields with unstructural schema in one version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1269,7 +1269,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "preserveUnknownFields with no schema in one version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1311,7 +1311,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "preserveUnknownFields with no schema at all",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1352,7 +1352,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "labelSelectorPath outside of .spec and .status",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version0",
@@ -1429,7 +1429,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults with disabled feature gate",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1465,7 +1465,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-int-or-string without structural",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1499,7 +1499,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-preserve-unknown-fields without structural",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1533,7 +1533,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-embedded-resource without structural",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1571,7 +1571,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-embedded-resource inside resource meta",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1636,7 +1636,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults with enabled feature gate, unstructural schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1670,7 +1670,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults with enabled feature gate, structural schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1705,7 +1705,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults in value validation with enabled feature gate, structural schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1762,7 +1762,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "invalid defaults with enabled feature gate, structural schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1938,7 +1938,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults with enabled feature gate, structural schema, without pruning",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1975,7 +1975,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "additionalProperties at resource root",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -2025,7 +2025,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "metadata defaults",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "v1",
@@ -2232,7 +2232,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "contradicting meta field types",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -2381,7 +2381,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "tenant-scoped CRD",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Tenant"),

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -43,6 +43,8 @@ type validationMatch struct {
 	errorType field.ErrorType
 }
 
+var testTenant = "test-te"
+
 func required(path ...string) validationMatch {
 	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeRequired}
 }
@@ -85,7 +87,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: invalid port 0",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -135,7 +137,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: invalid port 65536",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -185,7 +187,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: both service and URL provided",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -235,7 +237,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: blank URL",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -282,7 +284,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig_should_not_be_set",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -323,7 +325,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "ConversionReviewVersions_should_not_be_set",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -362,7 +364,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: invalid ConversionReviewVersion",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -409,7 +411,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: invalid ConversionReviewVersion version string",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -457,7 +459,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: at least one valid ConversionReviewVersion",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -502,7 +504,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhookconfig: duplicate ConversionReviewVersion",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -549,7 +551,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "missing_webhookconfig",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -592,7 +594,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "invalid_conversion_strategy",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -635,7 +637,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "none conversion without preserveUnknownFields=false",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -671,7 +673,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhook conversion without preserveUnknownFields=false",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -713,7 +715,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "webhook conversion with preserveUnknownFields=false",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -758,7 +760,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "no_storage_version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -796,7 +798,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "multiple_storage_version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -835,7 +837,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "missing_storage_version_in_stored_versions",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -873,7 +875,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "empty_stored_version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Cluster"),
@@ -906,7 +908,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "mismatched name",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.not.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.not.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Names: apiextensions.CustomResourceDefinitionNames{
@@ -928,7 +930,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "missing values",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 			},
 			errors: []validationMatch{
 				invalid("status", "storedVersions"),
@@ -945,7 +947,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "bad names 01",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group",
 					Version: "ve()*rsion",
@@ -989,7 +991,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "bad names 02",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.c(*&om",
 					Version:  "version",
@@ -1026,7 +1028,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "additionalProperties and properties forbidden",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1062,7 +1064,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "additionalProperties without properties allowed (map[string]string)",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1098,7 +1100,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "per-version fields may not all be set to identical values (top-level field should be used instead)",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1148,7 +1150,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-preserve-unknown-field: false",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1184,7 +1186,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "preserveUnknownFields with unstructural global schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1225,7 +1227,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "preserveUnknownFields with unstructural schema in one version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1269,7 +1271,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "preserveUnknownFields with no schema in one version",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1311,7 +1313,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "preserveUnknownFields with no schema at all",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version",
@@ -1352,7 +1354,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "labelSelectorPath outside of .spec and .status",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "version0",
@@ -1429,7 +1431,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults with disabled feature gate",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1465,7 +1467,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-int-or-string without structural",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1499,7 +1501,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-preserve-unknown-fields without structural",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1533,7 +1535,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-embedded-resource without structural",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1571,7 +1573,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "x-kubernetes-embedded-resource inside resource meta",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1636,7 +1638,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults with enabled feature gate, unstructural schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1670,7 +1672,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults with enabled feature gate, structural schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1705,7 +1707,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults in value validation with enabled feature gate, structural schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1762,7 +1764,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "invalid defaults with enabled feature gate, structural schema",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1938,7 +1940,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "defaults with enabled feature gate, structural schema, without pruning",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -1975,7 +1977,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "additionalProperties at resource root",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -2025,7 +2027,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "metadata defaults",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:   "group.com",
 					Version: "v1",
@@ -2232,7 +2234,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "contradicting meta field types",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group:    "group.com",
 					Version:  "version",
@@ -2381,7 +2383,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 		{
 			name: "tenant-scoped CRD",
 			resource: &apiextensions.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: "test-te"},
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com", Tenant: testTenant},
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Group: "group.com",
 					Scope: apiextensions.ResourceScope("Tenant"),

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -43,7 +43,11 @@ type ApiextensionsV1beta1Client struct {
 }
 
 func (c *ApiextensionsV1beta1Client) CustomResourceDefinitions() CustomResourceDefinitionInterface {
-	return newCustomResourceDefinitions(c)
+	return newCustomResourceDefinitionsWithMultiTenancy(c, "default")
+}
+
+func (c *ApiextensionsV1beta1Client) CustomResourceDefinitionsWithMultiTenancy(tenant string) CustomResourceDefinitionInterface {
+	return newCustomResourceDefinitionsWithMultiTenancy(c, tenant)
 }
 
 // NewForConfig creates a new ApiextensionsV1beta1Client for the given config.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_apiextensions_client.go
@@ -30,8 +30,11 @@ type FakeApiextensionsV1beta1 struct {
 }
 
 func (c *FakeApiextensionsV1beta1) CustomResourceDefinitions() v1beta1.CustomResourceDefinitionInterface {
+	return &FakeCustomResourceDefinitions{c, "default"}
+}
 
-	return &FakeCustomResourceDefinitions{c}
+func (c *FakeApiextensionsV1beta1) CustomResourceDefinitionsWithMultiTenancy(tenant string) v1beta1.CustomResourceDefinitionInterface {
+	return &FakeCustomResourceDefinitions{c, tenant}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_customresourcedefinition.go
@@ -32,6 +32,7 @@ import (
 // FakeCustomResourceDefinitions implements CustomResourceDefinitionInterface
 type FakeCustomResourceDefinitions struct {
 	Fake *FakeApiextensionsV1beta1
+	te   string
 }
 
 var customresourcedefinitionsResource = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}
@@ -41,7 +42,8 @@ var customresourcedefinitionsKind = schema.GroupVersionKind{Group: "apiextension
 // Get takes name of the customResourceDefinition, and returns the corresponding customResourceDefinition object, and an error if there is any.
 func (c *FakeCustomResourceDefinitions) Get(name string, options v1.GetOptions) (result *v1beta1.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(customresourcedefinitionsResource, name), &v1beta1.CustomResourceDefinition{})
+		Invokes(testing.NewTenantGetAction(customresourcedefinitionsResource, name, c.te), &v1beta1.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -52,7 +54,8 @@ func (c *FakeCustomResourceDefinitions) Get(name string, options v1.GetOptions) 
 // List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
 func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *v1beta1.CustomResourceDefinitionList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(customresourcedefinitionsResource, customresourcedefinitionsKind, opts), &v1beta1.CustomResourceDefinitionList{})
+		Invokes(testing.NewTenantListAction(customresourcedefinitionsResource, customresourcedefinitionsKind, opts, c.te), &v1beta1.CustomResourceDefinitionList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -74,7 +77,8 @@ func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *v1bet
 func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	aggWatch := watch.NewAggregatedWatcher()
 	watcher, err := c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(customresourcedefinitionsResource, opts))
+		InvokesWatch(testing.NewTenantWatchAction(customresourcedefinitionsResource, opts, c.te))
+
 	aggWatch.AddWatchInterface(watcher, err)
 	return aggWatch
 }
@@ -82,7 +86,8 @@ func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) watch.Aggrega
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *FakeCustomResourceDefinitions) Create(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(customresourcedefinitionsResource, customResourceDefinition), &v1beta1.CustomResourceDefinition{})
+		Invokes(testing.NewTenantCreateAction(customresourcedefinitionsResource, customResourceDefinition, c.te), &v1beta1.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -93,7 +98,8 @@ func (c *FakeCustomResourceDefinitions) Create(customResourceDefinition *v1beta1
 // Update takes the representation of a customResourceDefinition and updates it. Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *FakeCustomResourceDefinitions) Update(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(customresourcedefinitionsResource, customResourceDefinition), &v1beta1.CustomResourceDefinition{})
+		Invokes(testing.NewTenantUpdateAction(customresourcedefinitionsResource, customResourceDefinition, c.te), &v1beta1.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -105,7 +111,8 @@ func (c *FakeCustomResourceDefinitions) Update(customResourceDefinition *v1beta1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCustomResourceDefinitions) UpdateStatus(customResourceDefinition *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(customresourcedefinitionsResource, "status", customResourceDefinition), &v1beta1.CustomResourceDefinition{})
+		Invokes(testing.NewTenantUpdateSubresourceAction(customresourcedefinitionsResource, "status", customResourceDefinition, c.te), &v1beta1.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +122,16 @@ func (c *FakeCustomResourceDefinitions) UpdateStatus(customResourceDefinition *v
 // Delete takes name of the customResourceDefinition and deletes it. Returns an error if one occurs.
 func (c *FakeCustomResourceDefinitions) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(customresourcedefinitionsResource, name), &v1beta1.CustomResourceDefinition{})
+		Invokes(testing.NewTenantDeleteAction(customresourcedefinitionsResource, name, c.te), &v1beta1.CustomResourceDefinition{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCustomResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 
-	action := testing.NewRootDeleteCollectionAction(customresourcedefinitionsResource, listOptions)
+	action := testing.NewTenantDeleteCollectionAction(customresourcedefinitionsResource, listOptions, c.te)
+
 	_, err := c.Fake.Invokes(action, &v1beta1.CustomResourceDefinitionList{})
 	return err
 }
@@ -130,7 +139,8 @@ func (c *FakeCustomResourceDefinitions) DeleteCollection(options *v1.DeleteOptio
 // Patch applies the patch and returns the patched customResourceDefinition.
 func (c *FakeCustomResourceDefinitions) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(customresourcedefinitionsResource, name, pt, data, subresources...), &v1beta1.CustomResourceDefinition{})
+		Invokes(testing.NewTenantPatchSubresourceAction(customresourcedefinitionsResource, c.te, name, pt, data, subresources...), &v1beta1.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/apiextensions_client.go
@@ -42,7 +42,11 @@ type ApiextensionsClient struct {
 }
 
 func (c *ApiextensionsClient) CustomResourceDefinitions() CustomResourceDefinitionInterface {
-	return newCustomResourceDefinitions(c)
+	return newCustomResourceDefinitionsWithMultiTenancy(c, "default")
+}
+
+func (c *ApiextensionsClient) CustomResourceDefinitionsWithMultiTenancy(tenant string) CustomResourceDefinitionInterface {
+	return newCustomResourceDefinitionsWithMultiTenancy(c, tenant)
 }
 
 // NewForConfig creates a new ApiextensionsClient for the given config.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
@@ -34,6 +34,7 @@ import (
 // A group's client should implement this interface.
 type CustomResourceDefinitionsGetter interface {
 	CustomResourceDefinitions() CustomResourceDefinitionInterface
+	CustomResourceDefinitionsWithMultiTenancy(tenant string) CustomResourceDefinitionInterface
 }
 
 // CustomResourceDefinitionInterface has methods to work with CustomResourceDefinition resources.
@@ -54,13 +55,19 @@ type CustomResourceDefinitionInterface interface {
 type customResourceDefinitions struct {
 	client  rest.Interface
 	clients []rest.Interface
+	te      string
 }
 
 // newCustomResourceDefinitions returns a CustomResourceDefinitions
 func newCustomResourceDefinitions(c *ApiextensionsClient) *customResourceDefinitions {
+	return newCustomResourceDefinitionsWithMultiTenancy(c, "default")
+}
+
+func newCustomResourceDefinitionsWithMultiTenancy(c *ApiextensionsClient, tenant string) *customResourceDefinitions {
 	return &customResourceDefinitions{
 		client:  c.RESTClient(),
 		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }
 
@@ -68,6 +75,7 @@ func newCustomResourceDefinitions(c *ApiextensionsClient) *customResourceDefinit
 func (c *customResourceDefinitions) Get(name string, options v1.GetOptions) (result *apiextensions.CustomResourceDefinition, err error) {
 	result = &apiextensions.CustomResourceDefinition{}
 	err = c.client.Get().
+		Tenant(c.te).
 		Resource("customresourcedefinitions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,6 +93,7 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextens
 	}
 	result = &apiextensions.CustomResourceDefinitionList{}
 	err = c.client.Get().
+		Tenant(c.te).
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -104,6 +113,7 @@ func (c *customResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedW
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
 		watcher, err := client.Get().
+			Tenant(c.te).
 			Resource("customresourcedefinitions").
 			VersionedParams(&opts, scheme.ParameterCodec).
 			Timeout(timeout).
@@ -118,6 +128,7 @@ func (c *customResourceDefinitions) Create(customResourceDefinition *apiextensio
 	result = &apiextensions.CustomResourceDefinition{}
 
 	err = c.client.Post().
+		Tenant(c.te).
 		Resource("customresourcedefinitions").
 		Body(customResourceDefinition).
 		Do().
@@ -131,6 +142,7 @@ func (c *customResourceDefinitions) Update(customResourceDefinition *apiextensio
 	result = &apiextensions.CustomResourceDefinition{}
 
 	err = c.client.Put().
+		Tenant(c.te).
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
 		Body(customResourceDefinition).
@@ -147,6 +159,7 @@ func (c *customResourceDefinitions) UpdateStatus(customResourceDefinition *apiex
 	result = &apiextensions.CustomResourceDefinition{}
 
 	err = c.client.Put().
+		Tenant(c.te).
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
 		SubResource("status").
@@ -160,6 +173,7 @@ func (c *customResourceDefinitions) UpdateStatus(customResourceDefinition *apiex
 // Delete takes name of the customResourceDefinition and deletes it. Returns an error if one occurs.
 func (c *customResourceDefinitions) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
+		Tenant(c.te).
 		Resource("customresourcedefinitions").
 		Name(name).
 		Body(options).
@@ -174,6 +188,7 @@ func (c *customResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, 
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		Tenant(c.te).
 		Resource("customresourcedefinitions").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -186,6 +201,7 @@ func (c *customResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, 
 func (c *customResourceDefinitions) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *apiextensions.CustomResourceDefinition, err error) {
 	result = &apiextensions.CustomResourceDefinition{}
 	err = c.client.Patch(pt).
+		Tenant(c.te).
 		Resource("customresourcedefinitions").
 		SubResource(subresources...).
 		Name(name).

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/fake/fake_apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/fake/fake_apiextensions_client.go
@@ -30,8 +30,11 @@ type FakeApiextensions struct {
 }
 
 func (c *FakeApiextensions) CustomResourceDefinitions() internalversion.CustomResourceDefinitionInterface {
+	return &FakeCustomResourceDefinitions{c, "default"}
+}
 
-	return &FakeCustomResourceDefinitions{c}
+func (c *FakeApiextensions) CustomResourceDefinitionsWithMultiTenancy(tenant string) internalversion.CustomResourceDefinitionInterface {
+	return &FakeCustomResourceDefinitions{c, tenant}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/fake/fake_customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/fake/fake_customresourcedefinition.go
@@ -32,6 +32,7 @@ import (
 // FakeCustomResourceDefinitions implements CustomResourceDefinitionInterface
 type FakeCustomResourceDefinitions struct {
 	Fake *FakeApiextensions
+	te   string
 }
 
 var customresourcedefinitionsResource = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "", Resource: "customresourcedefinitions"}
@@ -41,7 +42,8 @@ var customresourcedefinitionsKind = schema.GroupVersionKind{Group: "apiextension
 // Get takes name of the customResourceDefinition, and returns the corresponding customResourceDefinition object, and an error if there is any.
 func (c *FakeCustomResourceDefinitions) Get(name string, options v1.GetOptions) (result *apiextensions.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(customresourcedefinitionsResource, name), &apiextensions.CustomResourceDefinition{})
+		Invokes(testing.NewTenantGetAction(customresourcedefinitionsResource, name, c.te), &apiextensions.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -52,7 +54,8 @@ func (c *FakeCustomResourceDefinitions) Get(name string, options v1.GetOptions) 
 // List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
 func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *apiextensions.CustomResourceDefinitionList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(customresourcedefinitionsResource, customresourcedefinitionsKind, opts), &apiextensions.CustomResourceDefinitionList{})
+		Invokes(testing.NewTenantListAction(customresourcedefinitionsResource, customresourcedefinitionsKind, opts, c.te), &apiextensions.CustomResourceDefinitionList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -74,7 +77,8 @@ func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *apiex
 func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	aggWatch := watch.NewAggregatedWatcher()
 	watcher, err := c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(customresourcedefinitionsResource, opts))
+		InvokesWatch(testing.NewTenantWatchAction(customresourcedefinitionsResource, opts, c.te))
+
 	aggWatch.AddWatchInterface(watcher, err)
 	return aggWatch
 }
@@ -82,7 +86,8 @@ func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) watch.Aggrega
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *FakeCustomResourceDefinitions) Create(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(customresourcedefinitionsResource, customResourceDefinition), &apiextensions.CustomResourceDefinition{})
+		Invokes(testing.NewTenantCreateAction(customresourcedefinitionsResource, customResourceDefinition, c.te), &apiextensions.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -93,7 +98,8 @@ func (c *FakeCustomResourceDefinitions) Create(customResourceDefinition *apiexte
 // Update takes the representation of a customResourceDefinition and updates it. Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *FakeCustomResourceDefinitions) Update(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(customresourcedefinitionsResource, customResourceDefinition), &apiextensions.CustomResourceDefinition{})
+		Invokes(testing.NewTenantUpdateAction(customresourcedefinitionsResource, customResourceDefinition, c.te), &apiextensions.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -105,7 +111,8 @@ func (c *FakeCustomResourceDefinitions) Update(customResourceDefinition *apiexte
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCustomResourceDefinitions) UpdateStatus(customResourceDefinition *apiextensions.CustomResourceDefinition) (*apiextensions.CustomResourceDefinition, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(customresourcedefinitionsResource, "status", customResourceDefinition), &apiextensions.CustomResourceDefinition{})
+		Invokes(testing.NewTenantUpdateSubresourceAction(customresourcedefinitionsResource, "status", customResourceDefinition, c.te), &apiextensions.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -115,14 +122,16 @@ func (c *FakeCustomResourceDefinitions) UpdateStatus(customResourceDefinition *a
 // Delete takes name of the customResourceDefinition and deletes it. Returns an error if one occurs.
 func (c *FakeCustomResourceDefinitions) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(customresourcedefinitionsResource, name), &apiextensions.CustomResourceDefinition{})
+		Invokes(testing.NewTenantDeleteAction(customresourcedefinitionsResource, name, c.te), &apiextensions.CustomResourceDefinition{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCustomResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 
-	action := testing.NewRootDeleteCollectionAction(customresourcedefinitionsResource, listOptions)
+	action := testing.NewTenantDeleteCollectionAction(customresourcedefinitionsResource, listOptions, c.te)
+
 	_, err := c.Fake.Invokes(action, &apiextensions.CustomResourceDefinitionList{})
 	return err
 }
@@ -130,7 +139,8 @@ func (c *FakeCustomResourceDefinitions) DeleteCollection(options *v1.DeleteOptio
 // Patch applies the patch and returns the patched customResourceDefinition.
 func (c *FakeCustomResourceDefinitions) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *apiextensions.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(customresourcedefinitionsResource, name, pt, data, subresources...), &apiextensions.CustomResourceDefinition{})
+		Invokes(testing.NewTenantPatchSubresourceAction(customresourcedefinitionsResource, c.te, name, pt, data, subresources...), &apiextensions.CustomResourceDefinition{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
@@ -42,6 +42,7 @@ type CustomResourceDefinitionInformer interface {
 type customResourceDefinitionInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	tenant           string
 }
 
 // NewCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
@@ -51,23 +52,31 @@ func NewCustomResourceDefinitionInformer(client clientset.Interface, resyncPerio
 	return NewFilteredCustomResourceDefinitionInformer(client, resyncPeriod, indexers, nil)
 }
 
+func NewCustomResourceDefinitionInformerWithMultiTenancy(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tenant string) cache.SharedIndexInformer {
+	return NewFilteredCustomResourceDefinitionInformerWithMultiTenancy(client, resyncPeriod, indexers, nil, tenant)
+}
+
 // NewFilteredCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+	return NewFilteredCustomResourceDefinitionInformerWithMultiTenancy(client, resyncPeriod, indexers, tweakListOptions, "default")
+}
+
+func NewFilteredCustomResourceDefinitionInformerWithMultiTenancy(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc, tenant string) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiextensionsV1beta1().CustomResourceDefinitions().List(options)
+				return client.ApiextensionsV1beta1().CustomResourceDefinitionsWithMultiTenancy(tenant).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiextensionsV1beta1().CustomResourceDefinitions().Watch(options)
+				return client.ApiextensionsV1beta1().CustomResourceDefinitionsWithMultiTenancy(tenant).Watch(options)
 			},
 		},
 		&apiextensionsv1beta1.CustomResourceDefinition{},
@@ -77,7 +86,7 @@ func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, res
 }
 
 func (f *customResourceDefinitionInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCustomResourceDefinitionInformer(client, resyncPeriod, cache.Indexers{}, f.tweakListOptions)
+	return NewFilteredCustomResourceDefinitionInformerWithMultiTenancy(client, resyncPeriod, cache.Indexers{cache.TenantIndex: cache.MetaTenantIndexFunc}, f.tweakListOptions, f.tenant)
 }
 
 func (f *customResourceDefinitionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/interface.go
@@ -48,5 +48,5 @@ func NewWithMultiTenancy(f internalinterfaces.SharedInformerFactory, namespace s
 
 // CustomResourceDefinitions returns a CustomResourceDefinitionInformer.
 func (v *version) CustomResourceDefinitions() CustomResourceDefinitionInformer {
-	return &customResourceDefinitionInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &customResourceDefinitionInformer{factory: v.factory, tenant: v.tenant, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion/customresourcedefinition.go
@@ -42,6 +42,7 @@ type CustomResourceDefinitionInformer interface {
 type customResourceDefinitionInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	tenant           string
 }
 
 // NewCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
@@ -51,23 +52,31 @@ func NewCustomResourceDefinitionInformer(client internalclientset.Interface, res
 	return NewFilteredCustomResourceDefinitionInformer(client, resyncPeriod, indexers, nil)
 }
 
+func NewCustomResourceDefinitionInformerWithMultiTenancy(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tenant string) cache.SharedIndexInformer {
+	return NewFilteredCustomResourceDefinitionInformerWithMultiTenancy(client, resyncPeriod, indexers, nil, tenant)
+}
+
 // NewFilteredCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCustomResourceDefinitionInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+	return NewFilteredCustomResourceDefinitionInformerWithMultiTenancy(client, resyncPeriod, indexers, tweakListOptions, "default")
+}
+
+func NewFilteredCustomResourceDefinitionInformerWithMultiTenancy(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc, tenant string) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.Apiextensions().CustomResourceDefinitions().List(options)
+				return client.Apiextensions().CustomResourceDefinitionsWithMultiTenancy(tenant).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.Apiextensions().CustomResourceDefinitions().Watch(options)
+				return client.Apiextensions().CustomResourceDefinitionsWithMultiTenancy(tenant).Watch(options)
 			},
 		},
 		&apiextensions.CustomResourceDefinition{},
@@ -77,7 +86,7 @@ func NewFilteredCustomResourceDefinitionInformer(client internalclientset.Interf
 }
 
 func (f *customResourceDefinitionInformer) defaultInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCustomResourceDefinitionInformer(client, resyncPeriod, cache.Indexers{}, f.tweakListOptions)
+	return NewFilteredCustomResourceDefinitionInformerWithMultiTenancy(client, resyncPeriod, cache.Indexers{cache.TenantIndex: cache.MetaTenantIndexFunc}, f.tweakListOptions, f.tenant)
 }
 
 func (f *customResourceDefinitionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion/interface.go
@@ -48,5 +48,5 @@ func NewWithMultiTenancy(f internalinterfaces.SharedInformerFactory, namespace s
 
 // CustomResourceDefinitions returns a CustomResourceDefinitionInformer.
 func (v *version) CustomResourceDefinitions() CustomResourceDefinitionInformer {
-	return &customResourceDefinitionInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &customResourceDefinitionInformer{factory: v.factory, tenant: v.tenant, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
@@ -1,5 +1,6 @@
 /*
 Copyright The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
@@ -29,6 +29,9 @@ import (
 type CustomResourceDefinitionLister interface {
 	// List lists all CustomResourceDefinitions in the indexer.
 	List(selector labels.Selector) (ret []*apiextensions.CustomResourceDefinition, err error)
+	// CustomResourceDefinitions returns an object that can list and get CustomResourceDefinitions.
+	CustomResourceDefinitions() CustomResourceDefinitionTenantLister
+	CustomResourceDefinitionsWithMultiTenancy(tenant string) CustomResourceDefinitionTenantLister
 	// Get retrieves the CustomResourceDefinition from the index for a given name.
 	Get(name string) (*apiextensions.CustomResourceDefinition, error)
 	CustomResourceDefinitionListerExpansion
@@ -55,6 +58,55 @@ func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*apiextensions.CustomResourceDefinition, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(apiextensions.Resource("customresourcedefinition"), name)
+	}
+	return obj.(*apiextensions.CustomResourceDefinition), nil
+}
+
+// CustomResourceDefinitions returns an object that can list and get CustomResourceDefinitions.
+func (s *customResourceDefinitionLister) CustomResourceDefinitions() CustomResourceDefinitionTenantLister {
+	return customResourceDefinitionTenantLister{indexer: s.indexer, tenant: "default"}
+}
+
+func (s *customResourceDefinitionLister) CustomResourceDefinitionsWithMultiTenancy(tenant string) CustomResourceDefinitionTenantLister {
+	return customResourceDefinitionTenantLister{indexer: s.indexer, tenant: tenant}
+}
+
+// CustomResourceDefinitionTenantLister helps list and get CustomResourceDefinitions.
+type CustomResourceDefinitionTenantLister interface {
+	// List lists all CustomResourceDefinitions in the indexer for a given tenant/tenant.
+	List(selector labels.Selector) (ret []*apiextensions.CustomResourceDefinition, err error)
+	// Get retrieves the CustomResourceDefinition from the indexer for a given tenant/tenant and name.
+	Get(name string) (*apiextensions.CustomResourceDefinition, error)
+	CustomResourceDefinitionTenantListerExpansion
+}
+
+// customResourceDefinitionTenantLister implements the CustomResourceDefinitionTenantLister
+// interface.
+type customResourceDefinitionTenantLister struct {
+	indexer cache.Indexer
+	tenant  string
+}
+
+// List lists all CustomResourceDefinitions in the indexer for a given tenant.
+func (s customResourceDefinitionTenantLister) List(selector labels.Selector) (ret []*apiextensions.CustomResourceDefinition, err error) {
+	err = cache.ListAllByTenant(s.indexer, s.tenant, selector, func(m interface{}) {
+		ret = append(ret, m.(*apiextensions.CustomResourceDefinition))
+	})
+	return ret, err
+}
+
+// Get retrieves the CustomResourceDefinition from the indexer for a given tenant and name.
+func (s customResourceDefinitionTenantLister) Get(name string) (*apiextensions.CustomResourceDefinition, error) {
+	key := s.tenant + "/" + name
+	if s.tenant == "default" {
+		key = name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/expansion_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/expansion_generated.go
@@ -1,5 +1,6 @@
 /*
 Copyright The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/expansion_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/expansion_generated.go
@@ -21,3 +21,7 @@ package internalversion
 // CustomResourceDefinitionListerExpansion allows custom methods to be added to
 // CustomResourceDefinitionLister.
 type CustomResourceDefinitionListerExpansion interface{}
+
+// CustomResourceDefinitionTenantListerExpansion allows custom methods to be added to
+// CustomResourceDefinitionTenantLister.
+type CustomResourceDefinitionTenantListerExpansion interface{}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
@@ -1,5 +1,6 @@
 /*
 Copyright The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
@@ -29,6 +29,9 @@ import (
 type CustomResourceDefinitionLister interface {
 	// List lists all CustomResourceDefinitions in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error)
+	// CustomResourceDefinitions returns an object that can list and get CustomResourceDefinitions.
+	CustomResourceDefinitions() CustomResourceDefinitionTenantLister
+	CustomResourceDefinitionsWithMultiTenancy(tenant string) CustomResourceDefinitionTenantLister
 	// Get retrieves the CustomResourceDefinition from the index for a given name.
 	Get(name string) (*v1beta1.CustomResourceDefinition, error)
 	CustomResourceDefinitionListerExpansion
@@ -55,6 +58,55 @@ func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*v1beta1.CustomResourceDefinition, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(v1beta1.Resource("customresourcedefinition"), name)
+	}
+	return obj.(*v1beta1.CustomResourceDefinition), nil
+}
+
+// CustomResourceDefinitions returns an object that can list and get CustomResourceDefinitions.
+func (s *customResourceDefinitionLister) CustomResourceDefinitions() CustomResourceDefinitionTenantLister {
+	return customResourceDefinitionTenantLister{indexer: s.indexer, tenant: "default"}
+}
+
+func (s *customResourceDefinitionLister) CustomResourceDefinitionsWithMultiTenancy(tenant string) CustomResourceDefinitionTenantLister {
+	return customResourceDefinitionTenantLister{indexer: s.indexer, tenant: tenant}
+}
+
+// CustomResourceDefinitionTenantLister helps list and get CustomResourceDefinitions.
+type CustomResourceDefinitionTenantLister interface {
+	// List lists all CustomResourceDefinitions in the indexer for a given tenant/tenant.
+	List(selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error)
+	// Get retrieves the CustomResourceDefinition from the indexer for a given tenant/tenant and name.
+	Get(name string) (*v1beta1.CustomResourceDefinition, error)
+	CustomResourceDefinitionTenantListerExpansion
+}
+
+// customResourceDefinitionTenantLister implements the CustomResourceDefinitionTenantLister
+// interface.
+type customResourceDefinitionTenantLister struct {
+	indexer cache.Indexer
+	tenant  string
+}
+
+// List lists all CustomResourceDefinitions in the indexer for a given tenant.
+func (s customResourceDefinitionTenantLister) List(selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error) {
+	err = cache.ListAllByTenant(s.indexer, s.tenant, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.CustomResourceDefinition))
+	})
+	return ret, err
+}
+
+// Get retrieves the CustomResourceDefinition from the indexer for a given tenant and name.
+func (s customResourceDefinitionTenantLister) Get(name string) (*v1beta1.CustomResourceDefinition, error) {
+	key := s.tenant + "/" + name
+	if s.tenant == "default" {
+		key = name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/expansion_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/expansion_generated.go
@@ -1,5 +1,6 @@
 /*
 Copyright The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/expansion_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/expansion_generated.go
@@ -21,3 +21,7 @@ package v1beta1
 // CustomResourceDefinitionListerExpansion allows custom methods to be added to
 // CustomResourceDefinitionLister.
 type CustomResourceDefinitionListerExpansion interface{}
+
+// CustomResourceDefinitionTenantListerExpansion allows custom methods to be added to
+// CustomResourceDefinitionTenantLister.
+type CustomResourceDefinitionTenantListerExpansion interface{}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -50,7 +50,7 @@ func (strategy) NamespaceScoped() bool {
 }
 
 func (strategy) TenantScoped() bool {
-	return false
+	return true
 }
 
 // PrepareForCreate clears the status of a CustomResourceDefinition before creation.
@@ -140,7 +140,7 @@ func (statusStrategy) NamespaceScoped() bool {
 }
 
 func (statusStrategy) TenantScoped() bool {
-	return false
+	return true
 }
 
 func (statusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/test/integration/etcd/multi_tenancy_data.go
+++ b/test/integration/etcd/multi_tenancy_data.go
@@ -484,12 +484,12 @@ func GetEtcdStorageDataForNamespaceWithMultiTenancy(tenant, namespace string) ma
 		// k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 		gvr("apiextensions.k8s.io", "v1beta1", "customresourcedefinitions"): {
 			Stub:             `{"metadata": {"name": "openshiftwebconsoleconfigs.webconsole.operator.openshift.io"},"spec": {"scope": "Cluster","group": "webconsole.operator.openshift.io","version": "v1alpha1","names": {"kind": "OpenShiftWebConsoleConfig","plural": "openshiftwebconsoleconfigs","singular": "openshiftwebconsoleconfig"}}}`,
-			ExpectedEtcdPath: "/registry/apiextensions.k8s.io/customresourcedefinitions/" + "openshiftwebconsoleconfigs.webconsole.operator.openshift.io",
+			ExpectedEtcdPath: "/registry/apiextensions.k8s.io/customresourcedefinitions/" + tenant + "/openshiftwebconsoleconfigs.webconsole.operator.openshift.io",
 		},
 		//tenant-scope CRD
 		gvr("apiextensions.k8s.io", "v1beta1", "customresourcedefinitions"): {
 			Stub:             `{"metadata": {"name": "gryffindors.hogwarts.io"},"spec": {"scope": "Tenant","group": "hogwarts.io","version": "v1alpha1","names": {"kind": "gryffindor","plural": "gryffindors","singular": "gryffindor"}}}`,
-			ExpectedEtcdPath: "/registry/apiextensions.k8s.io/customresourcedefinitions/gryffindors.hogwarts.io",
+			ExpectedEtcdPath: "/registry/apiextensions.k8s.io/customresourcedefinitions/" + tenant + "/gryffindors.hogwarts.io",
 		},
 		gvr("cr.bar.com", "v1", "foos"): {
 			Stub:             `{"kind": "Foo", "apiVersion": "cr.bar.com/v1", "metadata": {"name": "cr1foo"}, "color": "blue"}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper


### PR DESCRIPTION
This PR changed scope of CRD from cluster-scope to tenant-scope, so each tenant can have their own CRDs.

For the convenience of reviewers, the PR is split into three commits:
1. the code change to change the scope
2. the update in test files.
3. the auto updated files due to the scope change. This commit includes a big number of line changes, but the reviewer can just skip it.