### PR TITLE
multi tenancy CRD

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
@@ -65,6 +65,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/discovery:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/filters:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -67,7 +67,6 @@ import (
 	apifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/handlers"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
-	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
@@ -199,14 +198,19 @@ func NewCustomResourceDefinitionHandler(
 var longRunningFilter = genericfilters.BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString())
 
 func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	req, err := apifilters.NormalizeTenant(req)
-	if err != nil {
-		responsewriters.InternalError(w, req, err)
-		return
+	ctx := req.Context()
+	req, _ = apifilters.SetShortPathRequestTenant(req)
+	requestInfo, _ := apirequest.RequestInfoFrom(ctx)
+
+	crdTenant := requestInfo.Tenant
+	// SetShortPathRequestTenant does not update the tenant in a short-path request if it is a system-user request,
+	// as it may be an operation across all tenants. Also in some integration tests, the tenant in the requestInfo is not set.
+	// However, if code hits here, we know it is NOT a request across multiple tenants,
+	// so we can set the tenant here.
+	if crdTenant == metav1.TenantNone {
+		crdTenant = metav1.TenantDefault
 	}
 
-	ctx := req.Context()
-	requestInfo, _ := apirequest.RequestInfoFrom(ctx)
 	if !requestInfo.IsResourceRequest {
 		pathParts := splitPath(requestInfo.Path)
 		// only match /apis/<group>/<version>
@@ -225,11 +229,6 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	crdTenant := requestInfo.Tenant
-	// backward compatibility with behavior with no multi-tenancy
-	if crdTenant == metav1.TenantNone {
-		crdTenant = metav1.TenantDefault
-	}
 	crdName := requestInfo.Resource + "." + requestInfo.APIGroup
 	crd, err := r.crdLister.CustomResourceDefinitionsWithMultiTenancy(crdTenant).Get(crdName)
 	if apierrors.IsNotFound(err) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -93,7 +94,8 @@ func NewCRDFinalizer(
 }
 
 func (c *CRDFinalizer) sync(key string) error {
-	cachedCRD, err := c.crdLister.Get(key)
+	tenant, name, err := cache.SplitMetaTenantKey(key)
+	cachedCRD, err := c.crdLister.CustomResourceDefinitionsWithMultiTenancy(tenant).Get(name)
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -115,7 +117,7 @@ func (c *CRDFinalizer) sync(key string) error {
 		Reason:  "InstanceDeletionInProgress",
 		Message: "CustomResource deletion is in progress",
 	})
-	crd, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	crd, err = c.crdClient.CustomResourceDefinitionsWithMultiTenancy(tenant).UpdateStatus(crd)
 	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
 		// deleted or changed in the meantime, we'll get called again
 		return nil
@@ -130,7 +132,7 @@ func (c *CRDFinalizer) sync(key string) error {
 		cond, deleteErr := c.deleteInstances(crd)
 		apiextensions.SetCRDCondition(crd, cond)
 		if deleteErr != nil {
-			crd, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+			crd, err = c.crdClient.CustomResourceDefinitionsWithMultiTenancy(tenant).UpdateStatus(crd)
 			if err != nil {
 				utilruntime.HandleError(err)
 			}
@@ -146,7 +148,7 @@ func (c *CRDFinalizer) sync(key string) error {
 	}
 
 	apiextensions.CRDRemoveFinalizer(crd, apiextensions.CustomResourceCleanupFinalizer)
-	crd, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	crd, err = c.crdClient.CustomResourceDefinitionsWithMultiTenancy(tenant).UpdateStatus(crd)
 	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
 		// deleted or changed in the meantime, we'll get called again
 		return nil
@@ -157,7 +159,7 @@ func (c *CRDFinalizer) sync(key string) error {
 
 	// and now issue another delete, which should clean it all up if no finalizers remain or no-op if they do
 	// TODO(liggitt): just return in 1.16, once n-1 apiservers automatically delete when finalizers are all removed
-	err = c.crdClient.CustomResourceDefinitions().Delete(crd.Name, nil)
+	err = c.crdClient.CustomResourceDefinitionsWithMultiTenancy(tenant).Delete(crd.Name, nil)
 	if apierrors.IsNotFound(err) {
 		return nil
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -95,6 +95,10 @@ func NewCRDFinalizer(
 
 func (c *CRDFinalizer) sync(key string) error {
 	tenant, name, err := cache.SplitMetaTenantKey(key)
+	if err != nil {
+		return err
+	}
+
 	cachedCRD, err := c.crdLister.CustomResourceDefinitionsWithMultiTenancy(tenant).Get(name)
 	if apierrors.IsNotFound(err) {
 		return nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
@@ -131,6 +131,10 @@ func calculateCondition(in *apiextensions.CustomResourceDefinition) *apiextensio
 
 func (c *ConditionController) sync(key string) error {
 	tenant, name, err := cache.SplitMetaTenantKey(key)
+	if err != nil {
+		return err
+	}
+
 	inCustomResourceDefinition, err := c.crdLister.CustomResourceDefinitionsWithMultiTenancy(tenant).Get(name)
 	if apierrors.IsNotFound(err) {
 		return nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -129,7 +130,8 @@ func calculateCondition(in *apiextensions.CustomResourceDefinition) *apiextensio
 }
 
 func (c *ConditionController) sync(key string) error {
-	inCustomResourceDefinition, err := c.crdLister.Get(key)
+	tenant, name, err := cache.SplitMetaTenantKey(key)
+	inCustomResourceDefinition, err := c.crdLister.CustomResourceDefinitionsWithMultiTenancy(tenant).Get(name)
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -165,7 +167,7 @@ func (c *ConditionController) sync(key string) error {
 		apiextensions.SetCRDCondition(crd, *cond)
 	}
 
-	_, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	_, err = c.crdClient.CustomResourceDefinitionsWithMultiTenancy(tenant).UpdateStatus(crd)
 	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
 		// deleted or changed in the meantime, we'll get called again
 		return nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -368,6 +368,9 @@ func (c *NamingConditionController) deleteCustomResourceDefinition(obj interface
 
 func (c *NamingConditionController) requeueAllOtherGroupCRDs(key string) error {
 	tenant, name, err := cache.SplitMetaTenantKey(key)
+	if err != nil {
+		return err
+	}
 
 	pluralGroup := strings.SplitN(name, ".", 2)
 	list, err := c.crdLister.CustomResourceDefinitionsWithMultiTenancy(tenant).List(labels.Everything())

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -83,11 +84,11 @@ func NewNamingConditionController(
 	return c
 }
 
-func (c *NamingConditionController) getAcceptedNamesForGroup(group string) (allResources sets.String, allKinds sets.String) {
+func (c *NamingConditionController) getAcceptedNamesForGroup(group, tenant string) (allResources sets.String, allKinds sets.String) {
 	allResources = sets.String{}
 	allKinds = sets.String{}
 
-	list, err := c.crdLister.List(labels.Everything())
+	list, err := c.crdLister.CustomResourceDefinitionsWithMultiTenancy(tenant).List(labels.Everything())
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +102,7 @@ func (c *NamingConditionController) getAcceptedNamesForGroup(group string) (allR
 		// this makes sure that if we tight loop on update and run, our mutation cache will show
 		// us the version of the objects we just updated to.
 		item := curr
-		obj, exists, err := c.crdMutationCache.GetByKey(curr.Name)
+		obj, exists, err := c.crdMutationCache.GetByKey(tenant + "/" + curr.Name)
 		if exists && err == nil {
 			item = obj.(*apiextensions.CustomResourceDefinition)
 		}
@@ -119,7 +120,7 @@ func (c *NamingConditionController) getAcceptedNamesForGroup(group string) (allR
 
 func (c *NamingConditionController) calculateNamesAndConditions(in *apiextensions.CustomResourceDefinition) (apiextensions.CustomResourceDefinitionNames, apiextensions.CustomResourceDefinitionCondition, apiextensions.CustomResourceDefinitionCondition) {
 	// Get the names that have already been claimed
-	allResources, allKinds := c.getAcceptedNamesForGroup(in.Spec.Group)
+	allResources, allKinds := c.getAcceptedNamesForGroup(in.Spec.Group, in.Tenant)
 
 	namesAcceptedCondition := apiextensions.CustomResourceDefinitionCondition{
 		Type:   apiextensions.NamesAccepted,
@@ -229,7 +230,9 @@ func equalToAcceptedOrFresh(requestedName, acceptedName string, usedNames sets.S
 }
 
 func (c *NamingConditionController) sync(key string) error {
-	inCustomResourceDefinition, err := c.crdLister.Get(key)
+	tenant, name, err := cache.SplitMetaTenantKey(key)
+	inCustomResourceDefinition, err := c.crdLister.CustomResourceDefinitionsWithMultiTenancy(tenant).Get(name)
+
 	if apierrors.IsNotFound(err) {
 		// CRD was deleted and has freed its names.
 		// Reconsider all other CRDs in the same group.
@@ -260,7 +263,7 @@ func (c *NamingConditionController) sync(key string) error {
 	apiextensions.SetCRDCondition(crd, namingCondition)
 	apiextensions.SetCRDCondition(crd, establishedCondition)
 
-	updatedObj, err := c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	updatedObj, err := c.crdClient.CustomResourceDefinitionsWithMultiTenancy(tenant).UpdateStatus(crd)
 	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
 		// deleted or changed in the meantime, we'll get called again
 		return nil
@@ -363,15 +366,17 @@ func (c *NamingConditionController) deleteCustomResourceDefinition(obj interface
 	c.enqueue(castObj)
 }
 
-func (c *NamingConditionController) requeueAllOtherGroupCRDs(name string) error {
+func (c *NamingConditionController) requeueAllOtherGroupCRDs(key string) error {
+	tenant, name, err := cache.SplitMetaTenantKey(key)
+
 	pluralGroup := strings.SplitN(name, ".", 2)
-	list, err := c.crdLister.List(labels.Everything())
+	list, err := c.crdLister.CustomResourceDefinitionsWithMultiTenancy(tenant).List(labels.Everything())
 	if err != nil {
 		return err
 	}
 	for _, curr := range list {
 		if curr.Spec.Group == pluralGroup[1] && curr.Name != name {
-			c.queue.Add(curr.Name)
+			c.queue.Add(tenant + "/" + curr.Name)
 		}
 	}
 	return nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,11 +33,13 @@ type crdBuilder struct {
 	curr apiextensions.CustomResourceDefinition
 }
 
+var testTenant = "test-te"
+
 func newCRD(name string) *crdBuilder {
 	tokens := strings.SplitN(name, ".", 2)
 	return &crdBuilder{
 		curr: apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Tenant: testTenant},
 			Spec: apiextensions.CustomResourceDefinitionSpec{
 				Group: tokens[1],
 				Names: apiextensions.CustomResourceDefinitionNames{

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -356,7 +356,7 @@ func isWatchCachePrimed(crd *apiextensionsv1beta1.CustomResourceDefinition, dyna
 
 // DeleteCustomResourceDefinition deletes a CRD and waits until it disappears from discovery.
 func DeleteCustomResourceDefinition(crd *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) error {
-	if err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crd.Name, nil); err != nil {
+	if err := apiExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitionsWithMultiTenancy(crd.Tenant).Delete(crd.Name, nil); err != nil {
 		return err
 	}
 	for _, version := range servedVersions(crd) {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/main_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo.go
@@ -28,44 +28,48 @@ import (
 // WithTenantInfo set the tenant in the requestInfo for short-path requests based on the user info from the authentication result.
 func WithTenantInfo(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		ctx := req.Context()
 
-		requestor, exists := request.UserFrom(ctx)
-		if !exists {
-			responsewriters.InternalError(w, req, errors.New("The user info is missing."))
+		newReq, err := NormalizeTenant(req)
+		if err != nil {
+			responsewriters.InternalError(w, req, err)
 			return
 		}
 
-		tenantInRequestor := requestor.GetTenant()
-		if tenantInRequestor == metav1.TenantNone {
-			// temporary workaround
-			// tracking issue: https://github.com/futurewei-cloud/arktos/issues/102
-			tenantInRequestor = metav1.TenantSystem
-			//responsewriters.InternalError(w, req, errors.New(fmt.Sprintf("The tenant in the user info of %s is empty. ", requestor.GetName())))
-			//return
-		}
-
-		requestInfo, exists := request.RequestInfoFrom(ctx)
-		if !exists {
-			responsewriters.InternalError(w, req, errors.New("The request info is missing."))
-			return
-		}
-
-		requestInfo.Tenant = normalizeTenant(tenantInRequestor, requestInfo.Tenant)
-		req = req.WithContext(request.WithRequestInfo(ctx, requestInfo))
-
-		handler.ServeHTTP(w, req)
+		handler.ServeHTTP(w, newReq)
 	})
 }
 
-// normalizeObjectTenant decides what the object tenant should be based on what the user tenant is.
-func normalizeTenant(userTenant, objectTenant string) string {
-	// for a reqeust from a regular user, if the tenant in the object is empty, use the tenant from user info
-	// this is what we call "shor-path", which allows users to use traditional Kubernets API in the multi-tenancy Arktos
-	if objectTenant == metav1.TenantNone && userTenant != metav1.TenantSystem {
-		return userTenant
+// NormalizeObjectTenant sets the tenant in request info based on the user tenant.
+func NormalizeTenant(req *http.Request) (*http.Request, error) {
+
+	ctx := req.Context()
+
+	requestor, exists := request.UserFrom(ctx)
+	if !exists {
+		return nil, errors.New("The user info is missing.")
 	}
 
-	// in the other cases, we continue to use the tenant in the request info
-	return objectTenant
+	tenantInRequestor := requestor.GetTenant()
+	if tenantInRequestor == metav1.TenantNone {
+		// temporary workaround
+		// tracking issue: https://github.com/futurewei-cloud/arktos/issues/102
+		tenantInRequestor = metav1.TenantSystem
+		//responsewriters.InternalError(w, req, errors.New(fmt.Sprintf("The tenant in the user info of %s is empty. ", requestor.GetName())))
+		//return
+	}
+
+	requestInfo, exists := request.RequestInfoFrom(ctx)
+	if !exists {
+		return nil, errors.New("The request info is missing.")
+	}
+
+	// for a reqeust from a regular user, if the tenant in the object is empty, use the tenant from user info
+	// this is what we call "shor-path", which allows users to use traditional Kubernets API in the multi-tenancy Arktos
+	if requestInfo.Tenant == metav1.TenantNone && tenantInRequestor != metav1.TenantSystem {
+		requestInfo.Tenant = tenantInRequestor
+	}
+
+	req = req.WithContext(request.WithRequestInfo(ctx, requestInfo))
+
+	return req, nil
 }

--- a/test/integration/etcd/BUILD
+++ b/test/integration/etcd/BUILD
@@ -60,6 +60,7 @@ go_library(
         "//cmd/kube-apiserver/app/options:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/master:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",

--- a/test/integration/etcd/etcd_cross_group_test.go
+++ b/test/integration/etcd/etcd_cross_group_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,7 +175,10 @@ func TestEtcdStoragePath(t *testing.T) {
 		}
 	}
 
-	for path, gvrs := range pathSeen {
+	//Temporarilu turn this check off as we now allow CRDs of the same G/V/K under different tenants.
+	// TODO: rewrite the following check after the following issue is closed:
+	// https://github.com/futurewei-cloud/arktos/issues/227
+	/*for path, gvrs := range pathSeen {
 		if len(gvrs) != 1 {
 			gvrStrings := []string{}
 			for _, key := range gvrs {
@@ -183,7 +186,7 @@ func TestEtcdStoragePath(t *testing.T) {
 			}
 			t.Errorf("invalid test data, please ensure all expectedEtcdPath are unique, path %s has duplicate GVRs:\n%s", path, gvrStrings)
 		}
-	}
+	}*/
 }
 
 func dumpEtcdKVOnFailure(t *testing.T, kvClient clientv3.KV) {

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -175,7 +175,7 @@ func TestEtcdStoragePath(t *testing.T) {
 		}
 	}
 
-	//Temporarilu turn this check off as we now allow CRDs of the same G/V/K under different tenants.
+	//Temporarily turn this check off as we now allow CRDs of the same G/V/K under different tenants.
 	// TODO: rewrite the following check after the following issue is closed:
 	// https://github.com/futurewei-cloud/arktos/issues/227
 	/*for path, gvrs := range pathSeen {

--- a/test/integration/etcd/multi_tenancy_etcd_cross_group_test.go
+++ b/test/integration/etcd/multi_tenancy_etcd_cross_group_test.go
@@ -49,7 +49,6 @@ func TestCrossGroupStorageWithMultiTenancy(t *testing.T) {
 
 	crossGroupResources := map[schema.GroupVersionKind][]Resource{}
 
-	master.Client.CoreV1().Tenants().Create(&v1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: testTenant}})
 	master.Client.CoreV1().NamespacesWithMultiTenancy(testTenant).Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace, Tenant: testTenant}})
 
 	// Group by persisted GVK

--- a/test/integration/etcd/multi_tenancy_etcd_storage_path_test.go
+++ b/test/integration/etcd/multi_tenancy_etcd_storage_path_test.go
@@ -161,7 +161,7 @@ func TestEtcdStoragePathWithMultiTenancy(t *testing.T) {
 		}
 	}
 
-	//Temporarilu turn this check off as we now allow CRDs of the same G/V/K under different tenants.
+	//Temporarily turn this check off as we now allow CRDs of the same G/V/K under different tenants.
 	// TODO: rewrite the following check after the following issue is closed:
 	// https://github.com/futurewei-cloud/arktos/issues/227
 	/*for path, gvrs := range pathSeen {

--- a/test/integration/etcd/multi_tenancy_etcd_storage_path_test.go
+++ b/test/integration/etcd/multi_tenancy_etcd_storage_path_test.go
@@ -48,9 +48,6 @@ func TestEtcdStoragePathWithMultiTenancy(t *testing.T) {
 
 	client := &allClient{dynamicClient: master.Dynamic}
 
-	if _, err := master.Client.CoreV1().Tenants().Create(&v1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: testTenant}}); err != nil {
-		t.Fatal(err)
-	}
 	if _, err := master.Client.CoreV1().NamespacesWithMultiTenancy(testTenant).Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace, Tenant: testTenant}}); err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +161,10 @@ func TestEtcdStoragePathWithMultiTenancy(t *testing.T) {
 		}
 	}
 
-	for path, gvrs := range pathSeen {
+	//Temporarilu turn this check off as we now allow CRDs of the same G/V/K under different tenants.
+	// TODO: rewrite the following check after the following issue is closed:
+	// https://github.com/futurewei-cloud/arktos/issues/227
+	/*for path, gvrs := range pathSeen {
 		if len(gvrs) != 1 {
 			gvrStrings := []string{}
 			for _, key := range gvrs {
@@ -172,7 +172,7 @@ func TestEtcdStoragePathWithMultiTenancy(t *testing.T) {
 			}
 			t.Errorf("invalid test data, please ensure all expectedEtcdPath are unique, path %s has duplicate GVRs:\n%s", path, gvrStrings)
 		}
-	}
+	}*/
 }
 
 func (c *allClient) createWithMultiTenancy(stub, te string, ns string, mapping *meta.RESTMapping, all *[]cleanupData) error {

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -360,7 +360,7 @@ func createTestCRD(t *testing.T, client apiextensionsclientset.Interface, skipCr
 		}
 		return
 	}
-	if err := wait.PollImmediate(500*time.Millisecond, time.Second*2, func() (bool, error) {
+	if err := wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
 		return CrdExistsInDiscovery(client, crd), nil
 	}); err != nil {
 		t.Fatalf("Failed to see %s under tenant %s in discovery: %v", crd.Name, crd.Tenant, err)
@@ -368,7 +368,7 @@ func createTestCRD(t *testing.T, client apiextensionsclientset.Interface, skipCr
 }
 
 func waitForEstablishedCRD(client apiextensionsclientset.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition) error {
-	return wait.PollImmediate(500*time.Millisecond, time.Second*2, func() (bool, error) {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
 		crd, err := client.ApiextensionsV1beta1().CustomResourceDefinitionsWithMultiTenancy(crd.Tenant).Get(crd.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This PR enable CRD isolation among different tenants. Different tenant can have the CRD of the same G/V/K. The existing crd definition yaml file can continue in each tenant's world. 

To show this, two tenants, qian & peng, are created. And two corresponding contexts, qian-context and peng-context, are created. The following is the test I did in my dev box. 



##############################
create a CRD of foos.samplecontroller.k8s.io in qian's world, using the existing crd.yaml file from the repo, without any change. 
And then an object of the new resource type is created.
The CRD and CRD object are created under the specific tenant
##############################
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=qian-context apply -f ./staging/src/k8s.io/sample-controller/artifacts/examples/crd.yaml
customresourcedefinition.apiextensions.k8s.io/foos.samplecontroller.k8s.io created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get crds --all-tenants
TENANT   NAME                           CREATED AT
qian     foos.samplecontroller.k8s.io   2020-04-27T05:41:58Z

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=qian-context create -f ./staging/src/k8s.io/sample-controller/artifacts/examples/example-foo.yaml
foo.samplecontroller.k8s.io/example-foo created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=qian-context get foos --all-namespaces
NAMESPACE   NAME          AGE
testns      example-foo   0s
```
##############################
create the same CRD, using the same CRD yaml file, in another tenant's world. 
The same G/V/K coexists, as they are under different tenants.
That is what we called multi-tenany CRD.
##############################
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=peng-context apply -f ./staging/src/k8s.io/sample-controller/artifacts/examples/crd.yaml
customresourcedefinition.apiextensions.k8s.io/foos.samplecontroller.k8s.io created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get crds --all-tenants
TENANT   NAME                           CREATED AT
peng     foos.samplecontroller.k8s.io   2020-04-27T05:41:59Z
qian     foos.samplecontroller.k8s.io   2020-04-27T05:41:58Z
```