### PR TITLE
Remove sudo in aws cluster setup

### DIFF
--- a/aws_kube_params.inc
+++ b/aws_kube_params.inc
@@ -5,7 +5,7 @@ export KUBE_AWS_INSTANCE_PREFIX=arktos
 export KUBE_AWS_ZONE=us-east-2b
 export VPC_ID=vpc-0bb8ff51fd37c59b1
 export SUBNET_ID=subnet-00550372a5041fc32
-export NUM_NODES=5
+export NUM_NODES=2
 export KUBEMARK_NUM_NODES=100
 
 export KUBEMARK_MASTER_SIZE=t2.xlarge

--- a/docs/setup-guide/aws-dev-cluster.md
+++ b/docs/setup-guide/aws-dev-cluster.md
@@ -12,8 +12,8 @@ Use cases for a Arktos multi-node dev cluster on AWS are to test features in clo
 
 1. Build the Arktos release binaries from a bash terminal from your Arktos source root directory.
 ```bash
-sudo -E make clean
-source $PWD/aws_build_version && sudo -E make quick-release
+make clean
+source $PWD/aws_build_version && make quick-release
 ```
 
 2. Create a VPC and subnet in AWS. Note down the aws zone, vpd-id, subnet-id to use.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
It's not necessary to use sodu when setup aws cluster. So I update doc to remove it.
Also changed default config of node count from 5 to 2 to save cost.

**Does this PR introduce a user-facing change?**:
No