### PR TITLE
update title/version in swagger doc

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -24,7 +24,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apiserver/pkg/storage/datapartition"
 	"net"
 	"net/http"
 	"net/url"
@@ -32,6 +31,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/apiserver/pkg/storage/datapartition"
 
 	"github.com/go-openapi/spec"
 	"github.com/spf13/cobra"
@@ -414,7 +415,7 @@ func buildGenericConfig(
 	}
 
 	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(legacyscheme.Scheme, extensionsapiserver.Scheme, aggregatorscheme.Scheme))
-	genericConfig.OpenAPIConfig.Info.Title = "Kubernetes"
+	genericConfig.OpenAPIConfig.Info.Title = "Arktos"
 	genericConfig.LongRunningFunc = filters.BasicLongRunningRequestCheck(
 		sets.NewString("watch", "proxy"),
 		sets.NewString("attach", "exec", "proxy", "log", "portforward"),

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute/models.go
@@ -19,11 +19,12 @@ package compute
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
-	"net/http"
 )
 
 // AccessLevel enumerates the values for access level.


### PR DESCRIPTION
Update the title/version in swagger.json to reflect the fact that we are now at Arktos v.0.2, instead of Kubernetes v1.15.0.

This change will get us out of the pain to manually update the swagger.json every time after running "make update".