### PR TITLE
cluster-wide crd

### DIFF
--- a/test/yaml/multi_tenancy_examples/crd/beef-burger.yaml
+++ b/test/yaml/multi_tenancy_examples/crd/beef-burger.yaml
@@ -1,0 +1,4 @@
+apiVersion: futurewei.k8s.io/v1alpha1
+kind: Burger
+metadata:
+  name: beef-burger

--- a/test/yaml/multi_tenancy_examples/crd/forced_crd.yaml
+++ b/test/yaml/multi_tenancy_examples/crd/forced_crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: burgers.futurewei.k8s.io
+  annotations:
+    futurewei.k8s.io/crd-sharing-policy: forced
+spec:
+  group: futurewei.k8s.io
+  version: v1alpha1
+  names:
+    kind: Burger
+    plural: burgers
+  scope: Namespaced

--- a/test/yaml/multi_tenancy_examples/crd/turkey-burger.yaml
+++ b/test/yaml/multi_tenancy_examples/crd/turkey-burger.yaml
@@ -1,0 +1,4 @@
+apiVersion: futurewei.k8s.io/v1alpha1
+kind: Burger
+metadata:
+  name: turkey-burger


### PR DESCRIPTION
This PR is to help unblock the multi-tenancy networking work by allowing a cluster-wide CRD. A CRD, when defined under the system-tenant with the annotation "futurewei.k8s.io/crd-sharing-policy: forced", will be usable for all the tenants across the cluster.

Here is the test result in my dev box.

1. Create two tenants, qian and peng. configure the corresponding contexts.

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl config view
apiVersion: v1
clusters:
- cluster:
    certificate-authority: /var/run/kubernetes/server-ca.crt
    server: https://qianchen-virtualbox:6443
  name: local
contexts:
- context:
    cluster: local
    namespace: testns
    tenant: peng
    user: peng
  name: peng-context
- context:
    cluster: local
    namespace: testns
    tenant: qian
    user: qian
  name: qian-context
current-context: ""
kind: Config
preferences: {}
users:
- name: peng
  user:
    client-certificate: /var/run/kubernetes/client-peng.crt
    client-key: /var/run/kubernetes/client-peng.key
- name: qian
  user:
    client-certificate: /var/run/kubernetes/client-qian.crt
    client-key: /var/run/kubernetes/client-qian.key
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant qian
tenant/qian created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant peng
tenant/peng created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create ns testns --tenant qian
namespace/testns created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create ns testns --tenant peng
namespace/testns created
```

2. Create a 'forced' CRD under the system tenant
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl apply -f test/yaml/multi_tenancy_examples/crd/forced_crd.yaml
customresourcedefinition.apiextensions.k8s.io/burgers.futurewei.k8s.io created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get crds --all-tenants
TENANT    NAME                       CREATED AT
default   burgers.futurewei.k8s.io   2020-05-05T16:47:32Z
```

3. non-system tenants can create the object of the 'forced' CRD
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl apply -f test/yaml/multi_tenancy_examples/crd/beef-burger.yaml --context=qian-context
burger.futurewei.k8s.io/beef-burger created 

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl apply -f test/yaml/multi_tenancy_examples/crd/turkey-burger.yaml --context=peng-context
burger.futurewei.k8s.io/turkey-burger created
```

4. system-user can check the objects that are created across all the tenants, and each non-system  can see the objects in his own context. 
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get burgers --all-tenants --all-namespaces
TENANT   NAMESPACE   NAME            AGE
peng     testns      turkey-burger   7s
qian     testns      beef-burger     7s
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get burger --all-namespaces --context=qian-context
NAMESPACE   NAME          AGE
testns      beef-burger   13m
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get burger --all-namespaces --context=peng-context
NAMESPACE   NAME            AGE
testns      turkey-burger   13m
```