### PR TITLE
add multi-tenancy to statefulset

### DIFF
--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -270,6 +271,7 @@ func GetPodConditionFromList(conditions []v1.PodCondition, conditionType v1.PodC
 	if conditions == nil {
 		return -1, nil
 	}
+
 	for i := range conditions {
 		if conditions[i].Type == conditionType {
 			return i, &conditions[i]

--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -75,6 +75,7 @@ func NewControllerRevision(parent metav1.Object,
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:          labelMap,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(parent, parentKind)},
+			Tenant:          parent.GetTenant(),
 		},
 		Data:     data,
 		Revision: revision,
@@ -219,7 +220,7 @@ type realHistory struct {
 
 func (rh *realHistory) ListControllerRevisions(parent metav1.Object, selector labels.Selector) ([]*apps.ControllerRevision, error) {
 	// List all revisions in the namespace that match the selector
-	history, err := rh.lister.ControllerRevisions(parent.GetNamespace()).List(selector)
+	history, err := rh.lister.ControllerRevisionsWithMultiTenancy(parent.GetNamespace(), parent.GetTenant()).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -248,9 +249,10 @@ func (rh *realHistory) CreateControllerRevision(parent metav1.Object, revision *
 		// Update the revisions name
 		clone.Name = ControllerRevisionName(parent.GetName(), hash)
 		ns := parent.GetNamespace()
-		created, err := rh.client.AppsV1().ControllerRevisions(ns).Create(clone)
+		tenant := parent.GetTenant()
+		created, err := rh.client.AppsV1().ControllerRevisionsWithMultiTenancy(ns, tenant).Create(clone)
 		if errors.IsAlreadyExists(err) {
-			exists, err := rh.client.AppsV1().ControllerRevisions(ns).Get(clone.Name, metav1.GetOptions{})
+			exists, err := rh.client.AppsV1().ControllerRevisionsWithMultiTenancy(ns, tenant).Get(clone.Name, metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -271,14 +273,14 @@ func (rh *realHistory) UpdateControllerRevision(revision *apps.ControllerRevisio
 			return nil
 		}
 		clone.Revision = newRevision
-		updated, updateErr := rh.client.AppsV1().ControllerRevisions(clone.Namespace).Update(clone)
+		updated, updateErr := rh.client.AppsV1().ControllerRevisionsWithMultiTenancy(clone.Namespace, clone.Tenant).Update(clone)
 		if updateErr == nil {
 			return nil
 		}
 		if updated != nil {
 			clone = updated
 		}
-		if updated, err := rh.lister.ControllerRevisions(clone.Namespace).Get(clone.Name); err == nil {
+		if updated, err := rh.lister.ControllerRevisionsWithMultiTenancy(clone.Namespace, clone.Tenant).Get(clone.Name); err == nil {
 			// make a copy so we don't mutate the shared cache
 			clone = updated.DeepCopy()
 		}
@@ -288,7 +290,7 @@ func (rh *realHistory) UpdateControllerRevision(revision *apps.ControllerRevisio
 }
 
 func (rh *realHistory) DeleteControllerRevision(revision *apps.ControllerRevision) error {
-	return rh.client.AppsV1().ControllerRevisions(revision.Namespace).Delete(revision.Name, nil)
+	return rh.client.AppsV1().ControllerRevisionsWithMultiTenancy(revision.Namespace, revision.Tenant).Delete(revision.Name, nil)
 }
 
 func (rh *realHistory) AdoptControllerRevision(parent metav1.Object, parentKind schema.GroupVersionKind, revision *apps.ControllerRevision) (*apps.ControllerRevision, error) {
@@ -297,7 +299,7 @@ func (rh *realHistory) AdoptControllerRevision(parent metav1.Object, parentKind 
 		return nil, fmt.Errorf("attempt to adopt revision owned by %v", owner)
 	}
 	// Use strategic merge patch to add an owner reference indicating a controller ref
-	return rh.client.AppsV1().ControllerRevisions(parent.GetNamespace()).Patch(revision.GetName(),
+	return rh.client.AppsV1().ControllerRevisionsWithMultiTenancy(parent.GetNamespace(), parent.GetTenant()).Patch(revision.GetName(),
 		types.StrategicMergePatchType, []byte(fmt.Sprintf(
 			`{"metadata":{"ownerReferences":[{"apiVersion":"%s","kind":"%s","name":"%s","uid":"%s","controller":true,"blockOwnerDeletion":true}],"uid":"%s"}}`,
 			parentKind.GroupVersion().String(), parentKind.Kind,
@@ -306,7 +308,7 @@ func (rh *realHistory) AdoptControllerRevision(parent metav1.Object, parentKind 
 
 func (rh *realHistory) ReleaseControllerRevision(parent metav1.Object, revision *apps.ControllerRevision) (*apps.ControllerRevision, error) {
 	// Use strategic merge patch to add an owner reference indicating a controller ref
-	released, err := rh.client.AppsV1().ControllerRevisions(revision.GetNamespace()).Patch(revision.GetName(),
+	released, err := rh.client.AppsV1().ControllerRevisionsWithMultiTenancy(revision.GetNamespace(), revision.GetTenant()).Patch(revision.GetName(),
 		types.StrategicMergePatchType,
 		[]byte(fmt.Sprintf(`{"metadata":{"ownerReferences":[{"$patch":"delete","uid":"%s"}],"uid":"%s"}}`, parent.GetUID(), revision.UID)))
 
@@ -330,7 +332,7 @@ type fakeHistory struct {
 }
 
 func (fh *fakeHistory) ListControllerRevisions(parent metav1.Object, selector labels.Selector) ([]*apps.ControllerRevision, error) {
-	history, err := fh.lister.ControllerRevisions(parent.GetNamespace()).List(selector)
+	history, err := fh.lister.ControllerRevisionsWithMultiTenancy(parent.GetNamespace(), parent.GetTenant()).List(selector)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -257,6 +258,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 	updateRevision *apps.ControllerRevision,
 	collisionCount int32,
 	pods []*v1.Pod) (*apps.StatefulSetStatus, error) {
+
 	// get the current and update revisions of the set.
 	currentSet, err := ApplyRevision(set, currentRevision)
 	if err != nil {

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -121,7 +122,7 @@ func CreatesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) 
 		t.Errorf("Failed to turn up StatefulSet : %s", err)
 	}
 	var err error
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -149,7 +150,7 @@ func ScalesUp(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) {
 		t.Errorf("Failed to scale StatefulSet : %s", err)
 	}
 	var err error
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -196,7 +197,7 @@ func ReplacesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc)
 		t.Errorf("Failed to turn up StatefulSet : %s", err)
 	}
 	var err error
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -207,7 +208,7 @@ func ReplacesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc)
 	if err != nil {
 		t.Error(err)
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -216,14 +217,14 @@ func ReplacesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc)
 	spc.podsIndexer.Delete(pods[2])
 	spc.podsIndexer.Delete(pods[4])
 	for i := 0; i < 5; i += 2 {
-		pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			t.Error(err)
 		}
 		if err = ssc.UpdateStatefulSet(set, pods); err != nil {
 			t.Errorf("Failed to update StatefulSet : %s", err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("Error getting updated StatefulSet: %v", err)
 		}
@@ -233,7 +234,7 @@ func ReplacesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc)
 		if err = ssc.UpdateStatefulSet(set, pods); err != nil {
 			t.Errorf("Failed to update StatefulSet : %s", err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("Error getting updated StatefulSet: %v", err)
 		}
@@ -241,14 +242,14 @@ func ReplacesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc)
 			t.Error(err)
 		}
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
 	if err := ssc.UpdateStatefulSet(set, pods); err != nil {
 		t.Errorf("Failed to update StatefulSet : %s", err)
 	}
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -265,7 +266,7 @@ func RecreatesFailedPod(t *testing.T, set *apps.StatefulSet, invariants invarian
 	if err != nil {
 		t.Error(err)
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -275,7 +276,7 @@ func RecreatesFailedPod(t *testing.T, set *apps.StatefulSet, invariants invarian
 	if err := invariants(set, spc); err != nil {
 		t.Error(err)
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -287,7 +288,7 @@ func RecreatesFailedPod(t *testing.T, set *apps.StatefulSet, invariants invarian
 	if err := invariants(set, spc); err != nil {
 		t.Error(err)
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -309,7 +310,7 @@ func CreatePodFailure(t *testing.T, set *apps.StatefulSet, invariants invariantF
 		t.Errorf("Failed to turn up StatefulSet : %s", err)
 	}
 	var err error
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -335,7 +336,7 @@ func UpdatePodFailure(t *testing.T, set *apps.StatefulSet, invariants invariantF
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	var err error
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -350,7 +351,7 @@ func UpdatePodFailure(t *testing.T, set *apps.StatefulSet, invariants invariantF
 	}
 
 	// now mutate a pod's identity
-	pods, err := spc.podsLister.List(labels.Everything())
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(labels.Everything())
 	if err != nil {
 		t.Fatalf("Error listing pods: %v", err)
 	}
@@ -380,7 +381,7 @@ func UpdateSetStatusFailure(t *testing.T, set *apps.StatefulSet, invariants inva
 		t.Errorf("Failed to turn up StatefulSet : %s", err)
 	}
 	var err error
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -404,7 +405,7 @@ func PodRecreateDeleteFailure(t *testing.T, set *apps.StatefulSet, invariants in
 	if err != nil {
 		t.Error(err)
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -414,7 +415,7 @@ func PodRecreateDeleteFailure(t *testing.T, set *apps.StatefulSet, invariants in
 	if err := invariants(set, spc); err != nil {
 		t.Error(err)
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -433,7 +434,7 @@ func PodRecreateDeleteFailure(t *testing.T, set *apps.StatefulSet, invariants in
 	if err := invariants(set, spc); err != nil {
 		t.Error(err)
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -453,7 +454,7 @@ func TestStatefulSetControlScaleDownDeleteError(t *testing.T) {
 		t.Errorf("Failed to turn up StatefulSet : %s", err)
 	}
 	var err error
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -465,7 +466,7 @@ func TestStatefulSetControlScaleDownDeleteError(t *testing.T) {
 	if err := scaleDownStatefulSetControl(set, ssc, spc, invariants); err != nil {
 		t.Errorf("Failed to turn down StatefulSet %s", err)
 	}
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
@@ -623,7 +624,7 @@ func TestStatefulSetControlRollingUpdate(t *testing.T) {
 		if err := scaleUpStatefulSetControl(set, ssc, spc, test.invariants); err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err := spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err := spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -635,11 +636,11 @@ func TestStatefulSetControlRollingUpdate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -800,7 +801,7 @@ func TestStatefulSetControlOnDeleteUpdate(t *testing.T) {
 		if err := scaleUpStatefulSetControl(set, ssc, spc, test.invariants); err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err := spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err := spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -813,11 +814,11 @@ func TestStatefulSetControlOnDeleteUpdate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -833,7 +834,7 @@ func TestStatefulSetControlOnDeleteUpdate(t *testing.T) {
 		if err := scaleDownStatefulSetControl(set, ssc, spc, test.invariants); err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -841,11 +842,11 @@ func TestStatefulSetControlOnDeleteUpdate(t *testing.T) {
 		if err := scaleUpStatefulSetControl(set, ssc, spc, test.invariants); err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -1069,7 +1070,7 @@ func TestStatefulSetControlRollingUpdateWithPartition(t *testing.T) {
 		if err := scaleUpStatefulSetControl(set, ssc, spc, test.invariants); err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err := spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err := spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -1081,11 +1082,11 @@ func TestStatefulSetControlRollingUpdateWithPartition(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -1216,7 +1217,7 @@ func TestStatefulSetControlLimitsHistory(t *testing.T) {
 		if err := scaleUpStatefulSetControl(set, ssc, spc, test.invariants); err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err := spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err := spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -1229,11 +1230,11 @@ func TestStatefulSetControlLimitsHistory(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: %s", test.name, err)
 			}
-			pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+			pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 			if err != nil {
 				t.Fatalf("%s: %s", test.name, err)
 			}
-			set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+			set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 			if err != nil {
 				t.Fatalf("%s: %s", test.name, err)
 			}
@@ -1292,7 +1293,7 @@ func TestStatefulSetControlRollback(t *testing.T) {
 		if err := scaleUpStatefulSetControl(set, ssc, spc, test.invariants); err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err := spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err := spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -1304,11 +1305,11 @@ func TestStatefulSetControlRollback(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -1330,11 +1331,11 @@ func TestStatefulSetControlRollback(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
@@ -1593,7 +1594,7 @@ func (spc *fakeStatefulPodControl) setPodPending(set *apps.StatefulSet, ordinal 
 	if err != nil {
 		return nil, err
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -1605,7 +1606,7 @@ func (spc *fakeStatefulPodControl) setPodPending(set *apps.StatefulSet, ordinal 
 	pod.Status.Phase = v1.PodPending
 	fakeResourceVersion(pod)
 	spc.podsIndexer.Update(pod)
-	return spc.podsLister.Pods(set.Namespace).List(selector)
+	return spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 }
 
 func (spc *fakeStatefulPodControl) setPodRunning(set *apps.StatefulSet, ordinal int) ([]*v1.Pod, error) {
@@ -1613,7 +1614,7 @@ func (spc *fakeStatefulPodControl) setPodRunning(set *apps.StatefulSet, ordinal 
 	if err != nil {
 		return nil, err
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -1625,7 +1626,7 @@ func (spc *fakeStatefulPodControl) setPodRunning(set *apps.StatefulSet, ordinal 
 	pod.Status.Phase = v1.PodRunning
 	fakeResourceVersion(pod)
 	spc.podsIndexer.Update(pod)
-	return spc.podsLister.Pods(set.Namespace).List(selector)
+	return spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 }
 
 func (spc *fakeStatefulPodControl) setPodReady(set *apps.StatefulSet, ordinal int) ([]*v1.Pod, error) {
@@ -1633,7 +1634,7 @@ func (spc *fakeStatefulPodControl) setPodReady(set *apps.StatefulSet, ordinal in
 	if err != nil {
 		return nil, err
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -1646,7 +1647,7 @@ func (spc *fakeStatefulPodControl) setPodReady(set *apps.StatefulSet, ordinal in
 	podutil.UpdatePodCondition(&pod.Status, &condition)
 	fakeResourceVersion(pod)
 	spc.podsIndexer.Update(pod)
-	return spc.podsLister.Pods(set.Namespace).List(selector)
+	return spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 }
 
 func (spc *fakeStatefulPodControl) addTerminatingPod(set *apps.StatefulSet, ordinal int) ([]*v1.Pod, error) {
@@ -1662,7 +1663,7 @@ func (spc *fakeStatefulPodControl) addTerminatingPod(set *apps.StatefulSet, ordi
 	if err != nil {
 		return nil, err
 	}
-	return spc.podsLister.Pods(set.Namespace).List(selector)
+	return spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 }
 
 func (spc *fakeStatefulPodControl) setPodTerminated(set *apps.StatefulSet, ordinal int) ([]*v1.Pod, error) {
@@ -1675,7 +1676,7 @@ func (spc *fakeStatefulPodControl) setPodTerminated(set *apps.StatefulSet, ordin
 	if err != nil {
 		return nil, err
 	}
-	return spc.podsLister.Pods(set.Namespace).List(selector)
+	return spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 }
 
 func (spc *fakeStatefulPodControl) CreateStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
@@ -1767,7 +1768,7 @@ func assertMonotonicInvariants(set *apps.StatefulSet, spc *fakeStatefulPodContro
 	if err != nil {
 		return err
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return err
 	}
@@ -1786,7 +1787,7 @@ func assertMonotonicInvariants(set *apps.StatefulSet, spc *fakeStatefulPodContro
 		}
 
 		for _, claim := range getPersistentVolumeClaims(set, pods[ord]) {
-			claim, err := spc.claimsLister.PersistentVolumeClaims(set.Namespace).Get(claim.Name)
+			claim, err := spc.claimsLister.PersistentVolumeClaimsWithMultiTenancy(set.Namespace, set.Tenant).Get(claim.Name)
 			if err != nil {
 				return err
 			}
@@ -1807,7 +1808,7 @@ func assertBurstInvariants(set *apps.StatefulSet, spc *fakeStatefulPodControl) e
 	if err != nil {
 		return err
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return err
 	}
@@ -1818,7 +1819,7 @@ func assertBurstInvariants(set *apps.StatefulSet, spc *fakeStatefulPodControl) e
 		}
 
 		for _, claim := range getPersistentVolumeClaims(set, pods[ord]) {
-			claim, err := spc.claimsLister.PersistentVolumeClaims(set.Namespace).Get(claim.Name)
+			claim, err := spc.claimsLister.PersistentVolumeClaimsWithMultiTenancy(set.Namespace, set.Tenant).Get(claim.Name)
 			if err != nil {
 				return err
 			}
@@ -1841,7 +1842,7 @@ func assertUpdateInvariants(set *apps.StatefulSet, spc *fakeStatefulPodControl) 
 	if err != nil {
 		return err
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return err
 	}
@@ -1853,7 +1854,7 @@ func assertUpdateInvariants(set *apps.StatefulSet, spc *fakeStatefulPodControl) 
 		}
 
 		for _, claim := range getPersistentVolumeClaims(set, pods[ord]) {
-			claim, err := spc.claimsLister.PersistentVolumeClaims(set.Namespace).Get(claim.Name)
+			claim, err := spc.claimsLister.PersistentVolumeClaimsWithMultiTenancy(set.Namespace, set.Tenant).Get(claim.Name)
 			if err != nil {
 				return err
 			}
@@ -1905,7 +1906,7 @@ func scaleUpStatefulSetControl(set *apps.StatefulSet,
 		return err
 	}
 	for set.Status.ReadyReplicas < *set.Spec.Replicas {
-		pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			return err
 		}
@@ -1947,7 +1948,7 @@ func scaleUpStatefulSetControl(set *apps.StatefulSet,
 		if err = ssc.UpdateStatefulSet(set, pods); err != nil {
 			return err
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			return err
 		}
@@ -1964,7 +1965,7 @@ func scaleDownStatefulSetControl(set *apps.StatefulSet, ssc StatefulSetControlIn
 		return err
 	}
 	for set.Status.Replicas > *set.Spec.Replicas {
-		pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			return err
 		}
@@ -1973,7 +1974,7 @@ func scaleDownStatefulSetControl(set *apps.StatefulSet, ssc StatefulSetControlIn
 			if err := ssc.UpdateStatefulSet(set, pods); err != nil {
 				return err
 			}
-			set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+			set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 			if err != nil {
 				return err
 			}
@@ -1983,11 +1984,11 @@ func scaleDownStatefulSetControl(set *apps.StatefulSet, ssc StatefulSetControlIn
 			if err = ssc.UpdateStatefulSet(set, pods); err != nil {
 				return err
 			}
-			set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+			set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 			if err != nil {
 				return err
 			}
-			pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+			pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 			if err != nil {
 				return err
 			}
@@ -2000,7 +2001,7 @@ func scaleDownStatefulSetControl(set *apps.StatefulSet, ssc StatefulSetControlIn
 		if err := ssc.UpdateStatefulSet(set, pods); err != nil {
 			return err
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			return err
 		}
@@ -2056,7 +2057,7 @@ func updateStatefulSetControl(set *apps.StatefulSet,
 	if err != nil {
 		return err
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return err
 	}
@@ -2064,16 +2065,16 @@ func updateStatefulSetControl(set *apps.StatefulSet,
 		return err
 	}
 
-	set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+	set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 	if err != nil {
 		return err
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return err
 	}
 	for !updateComplete(set, pods) {
-		pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			return err
 		}
@@ -2111,14 +2112,14 @@ func updateStatefulSetControl(set *apps.StatefulSet,
 		if err = ssc.UpdateStatefulSet(set, pods); err != nil {
 			return err
 		}
-		set, err = spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+		set, err = spc.setsLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name)
 		if err != nil {
 			return err
 		}
 		if err := invariants(set, spc); err != nil {
 			return err
 		}
-		pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/statefulset/stateful_set_status_updater.go
+++ b/pkg/controller/statefulset/stateful_set_status_updater.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,11 +54,11 @@ func (ssu *realStatefulSetStatusUpdater) UpdateStatefulSetStatus(
 	// don't wait due to limited number of clients, but backoff after the default number of steps
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		set.Status = *status
-		_, updateErr := ssu.client.AppsV1().StatefulSets(set.Namespace).UpdateStatus(set)
+		_, updateErr := ssu.client.AppsV1().StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).UpdateStatus(set)
 		if updateErr == nil {
 			return nil
 		}
-		if updated, err := ssu.setLister.StatefulSets(set.Namespace).Get(set.Name); err == nil {
+		if updated, err := ssu.setLister.StatefulSetsWithMultiTenancy(set.Namespace, set.Tenant).Get(set.Name); err == nil {
 			// make a copy so we don't mutate the shared cache
 			set = updated.DeepCopy()
 		} else {

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -106,7 +107,7 @@ func TestStatefulSetControllerRespectsTermination(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -157,7 +158,7 @@ func TestStatefulSetControllerBlocksScaling(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -168,7 +169,7 @@ func TestStatefulSetControllerBlocksScaling(t *testing.T) {
 	spc.DeleteStatefulPod(set, pods[0])
 	ssc.enqueueStatefulSet(set)
 	fakeWorker(ssc)
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err = spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -225,7 +226,7 @@ func TestStatefulSetControllerDeletionTimestampRace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -617,7 +618,7 @@ func scaleUpStatefulSetController(set *apps.StatefulSet, ssc *StatefulSetControl
 		return err
 	}
 	for set.Status.ReadyReplicas < *set.Spec.Replicas {
-		pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+		pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 		if err != nil {
 			return err
 		}
@@ -663,7 +664,7 @@ func scaleDownStatefulSetController(set *apps.StatefulSet, ssc *StatefulSetContr
 	if err != nil {
 		return err
 	}
-	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.PodsWithMultiTenancy(set.Namespace, set.Tenant).List(selector)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -114,6 +114,7 @@ func identityMatches(set *apps.StatefulSet, pod *v1.Pod) bool {
 		set.Name == parent &&
 		pod.Name == getPodName(set, ordinal) &&
 		pod.Namespace == set.Namespace &&
+		pod.Tenant == set.Tenant &&
 		pod.Labels[apps.StatefulSetPodNameLabel] == pod.Name
 }
 

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/kubernetes/pkg/controller/history"
 )
 
+var testTenant = "johndoe"
+
 func TestGetParentNameAndOrdinal(t *testing.T) {
 	set := newStatefulSet(3)
 	pod := newStatefulSetPod(set, 1)
@@ -340,7 +342,7 @@ func newPod() *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo-0",
 			Namespace: v1.NamespaceDefault,
-			Tenant:    v1.TenantDefault,
+			Tenant:    testTenant,
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
@@ -357,7 +359,7 @@ func newPVC(name string) v1.PersistentVolumeClaim {
 	return v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
-			Tenant: v1.TenantDefault,
+			Tenant: testTenant,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			Resources: v1.ResourceRequirements{
@@ -411,7 +413,7 @@ func newStatefulSetWithVolumes(replicas int, name string, petMounts []v1.VolumeM
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: v1.NamespaceDefault,
-			Tenant:    v1.TenantDefault,
+			Tenant:    testTenant,
 			UID:       types.UID("test"),
 		},
 		Spec: apps.StatefulSetSpec{

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/attachdetach/metrics/metrics.go
+++ b/pkg/controller/volume/attachdetach/metrics/metrics.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/attachdetach/metrics/metrics_test.go
+++ b/pkg/controller/volume/attachdetach/metrics/metrics_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/attachdetach/util/util.go
+++ b/pkg/controller/volume/attachdetach/util/util.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/expand/cache/volume_resize_map.go
+++ b/pkg/controller/volume/expand/cache/volume_resize_map.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -244,7 +245,7 @@ func newVolume(name, capacity, boundToClaimUID, boundToClaimName string, phase v
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			ResourceVersion: "1",
-			Tenant: metav1.TenantDefault,
+			Tenant:          metav1.TenantDefault,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			Capacity: v1.ResourceList{
@@ -270,7 +271,7 @@ func newVolume(name, capacity, boundToClaimUID, boundToClaimName string, phase v
 			UID:        types.UID(boundToClaimUID),
 			Namespace:  testNamespace,
 			Name:       boundToClaimName,
-			Tenant: metav1.TenantDefault,
+			Tenant:     metav1.TenantDefault,
 		}
 	}
 
@@ -360,7 +361,7 @@ func newClaim(name, claimUID, capacity, boundToVolume string, phase v1.Persisten
 			Namespace:       testNamespace,
 			UID:             types.UID(claimUID),
 			ResourceVersion: "1",
-			Tenant: metav1.TenantDefault,
+			Tenant:          metav1.TenantDefault,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce, v1.ReadOnlyMany},
@@ -867,7 +868,7 @@ func (plugin *mockVolumePlugin) Provision(selectedNode *v1.Node, allowedTopologi
 		accessModes := plugin.provisionOptions.PVC.Spec.AccessModes
 		pv = &v1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: plugin.provisionOptions.PVName,
+				Name:   plugin.provisionOptions.PVName,
 				Tenant: metav1.TenantDefault,
 			},
 			Spec: v1.PersistentVolumeSpec{

--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/persistentvolume/provision_test.go
+++ b/pkg/controller/volume/persistentvolume/provision_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/persistentvolume/util/util.go
+++ b/pkg/controller/volume/persistentvolume/util/util.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -217,5 +218,3 @@ func pvToVolumeKey(pv *v1.PersistentVolume) string {
 	key, _ := cache.MetaNamespaceKeyFunc(pv)
 	return key
 }
-
-

--- a/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,7 +50,7 @@ type reaction struct {
 func pv() *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: defaultPVName,
+			Name:   defaultPVName,
 			Tenant: metav1.TenantDefault,
 		},
 	}
@@ -58,7 +59,7 @@ func pv() *v1.PersistentVolume {
 func boundPV() *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: defaultPVName,
+			Name:   defaultPVName,
 			Tenant: metav1.TenantDefault,
 		},
 		Status: v1.PersistentVolumeStatus{

--- a/pkg/controller/volume/scheduling/BUILD
+++ b/pkg/controller/volume/scheduling/BUILD
@@ -57,6 +57,7 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache_test.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,7 +31,7 @@ func makePV(name, version, storageClass string) *v1.PersistentVolume {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			ResourceVersion: version,
-			Tenant: metav1.TenantDefault,
+			Tenant:          metav1.TenantDefault,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			StorageClassName: storageClass,
@@ -312,7 +313,7 @@ func makeClaim(name, version, namespace string) *v1.PersistentVolumeClaim {
 			Namespace:       namespace,
 			ResourceVersion: version,
 			Annotations:     map[string]string{},
-			Tenant: metav1.TenantDefault,
+			Tenant:          metav1.TenantDefault,
 		},
 	}
 }

--- a/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -787,7 +788,7 @@ func (b *volumeBinder) revertAssumedPVs(bindings []*bindingInfo) {
 
 func (b *volumeBinder) revertAssumedPVCs(claims []*v1.PersistentVolumeClaim) {
 	for _, claim := range claims {
-		pvcName, _:= cache.MetaNamespaceKeyFunc(claim)
+		pvcName, _ := cache.MetaNamespaceKeyFunc(claim)
 		b.pvcCache.Restore(pvcName)
 	}
 }

--- a/pkg/controller/volume/scheduling/scheduler_binder_test.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scheduler/algorithm/predicates/csi_volume_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/csi_volume_predicate.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scheduler/algorithm/predicates/csi_volume_predicate_test.go
+++ b/pkg/scheduler/algorithm/predicates/csi_volume_predicate_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scheduler/algorithm/predicates/max_attachable_volume_predicate_test.go
+++ b/pkg/scheduler/algorithm/predicates/max_attachable_volume_predicate_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scheduler/algorithm/predicates/testing_helper.go
+++ b/pkg/scheduler/algorithm/predicates/testing_helper.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/scheduler/predicates_test.go
+++ b/test/integration/scheduler/predicates_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -48,7 +49,7 @@ func TestSpecReplicasChange(t *testing.T) {
 
 	// Add a template annotation change to test STS's status does update
 	// without .Spec.Replicas change
-	stsClient := c.AppsV1().StatefulSets(ns.Name)
+	stsClient := c.AppsV1().StatefulSetsWithMultiTenancy(ns.Name, ns.Tenant)
 	var oldGeneration int64
 	newSTS := updateSTS(t, stsClient, sts.Name, func(sts *appsv1.StatefulSet) {
 		oldGeneration = sts.Generation
@@ -85,7 +86,7 @@ func TestDeletingAndFailedPods(t *testing.T) {
 	waitSTSStable(t, c, sts)
 
 	// Verify STS creates 2 pods
-	podClient := c.CoreV1().Pods(ns.Name)
+	podClient := c.CoreV1().PodsWithMultiTenancy(ns.Name, ns.Tenant)
 	pods := getPods(t, podClient, labelMap)
 	if len(pods.Items) != 2 {
 		t.Fatalf("len(pods) = %d, want 2", len(pods.Items))
@@ -97,7 +98,7 @@ func TestDeletingAndFailedPods(t *testing.T) {
 	updatePod(t, podClient, deletingPod.Name, func(pod *v1.Pod) {
 		pod.Finalizers = []string{"fake.example.com/blockDeletion"}
 	})
-	if err := c.CoreV1().Pods(ns.Name).Delete(deletingPod.Name, &metav1.DeleteOptions{}); err != nil {
+	if err := c.CoreV1().PodsWithMultiTenancy(ns.Name, ns.Tenant).Delete(deletingPod.Name, &metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("error deleting pod %s: %v", deletingPod.Name, err)
 	}
 

--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -248,7 +248,7 @@ func TestPersistentVolumeBindRace(t *testing.T) {
 		counter++
 		newPvc := pvc.DeepCopy()
 		newPvc.ObjectMeta = metav1.ObjectMeta{
-			Name: fmt.Sprintf("fake-pvc-race-%d", counter),
+			Name:   fmt.Sprintf("fake-pvc-race-%d", counter),
 			Tenant: metav1.TenantDefault,
 		}
 		claim, err := testClient.CoreV1().PersistentVolumeClaimsWithMultiTenancy(ns.Name, newPvc.Tenant).Create(newPvc)
@@ -286,7 +286,7 @@ func TestPersistentVolumeBindRace(t *testing.T) {
 	if pv.Spec.ClaimRef == nil {
 		t.Fatalf("Unexpected nil claimRef")
 	}
-	if pv.Spec.ClaimRef.Tenant!= claimRef.Tenant || pv.Spec.ClaimRef.Namespace != claimRef.Namespace || pv.Spec.ClaimRef.Name != claimRef.Name {
+	if pv.Spec.ClaimRef.Tenant != claimRef.Tenant || pv.Spec.ClaimRef.Namespace != claimRef.Namespace || pv.Spec.ClaimRef.Name != claimRef.Name {
 		t.Fatalf("Bind mismatch! Expected %s/%s/%s but got %s/%s/%s", claimRef.Tenant, claimRef.Namespace, claimRef.Name, pv.Spec.ClaimRef.Tenant, pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name)
 	}
 }
@@ -366,7 +366,7 @@ func TestPersistentVolumeClaimLabelSelector(t *testing.T) {
 	if pv.Spec.ClaimRef == nil {
 		t.Fatalf("True PV should be bound")
 	}
-	if pv.Spec.ClaimRef.Tenant!= pvc.Tenant || pv.Spec.ClaimRef.Namespace != pvc.Namespace || pv.Spec.ClaimRef.Name != pvc.Name {
+	if pv.Spec.ClaimRef.Tenant != pvc.Tenant || pv.Spec.ClaimRef.Namespace != pvc.Namespace || pv.Spec.ClaimRef.Name != pvc.Name {
 		t.Fatalf("Bind mismatch! Expected %s/%s/%s but got %s/%s/%s", pvc.Tenant, pvc.Namespace, pvc.Name, pv.Spec.ClaimRef.Tenant, pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name)
 	}
 }
@@ -466,7 +466,7 @@ func TestPersistentVolumeClaimLabelSelectorMatchExpressions(t *testing.T) {
 	if pv.Spec.ClaimRef == nil {
 		t.Fatalf("True PV should be bound")
 	}
-	if pv.Spec.ClaimRef.Tenant!= pvc.Tenant || pv.Spec.ClaimRef.Namespace != pvc.Namespace || pv.Spec.ClaimRef.Name != pvc.Name {
+	if pv.Spec.ClaimRef.Tenant != pvc.Tenant || pv.Spec.ClaimRef.Namespace != pvc.Namespace || pv.Spec.ClaimRef.Name != pvc.Name {
 		t.Fatalf("Bind mismatch! Expected %s/%s/%s but got %s/%s/%s", pvc.Tenant, pvc.Namespace, pvc.Name, pv.Spec.ClaimRef.Tenant, pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name)
 	}
 }
@@ -1165,7 +1165,7 @@ func createClients(ns *v1.Namespace, t *testing.T, s *httptest.Server, syncPerio
 func createPV(name, path, cap string, mode []v1.PersistentVolumeAccessMode, reclaim v1.PersistentVolumeReclaimPolicy) *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
 			Tenant: metav1.TenantDefault,
 		},
 		Spec: v1.PersistentVolumeSpec{
@@ -1182,7 +1182,7 @@ func createPVC(name, namespace, cap string, mode []v1.PersistentVolumeAccessMode
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Tenant: metav1.TenantDefault,
+			Tenant:    metav1.TenantDefault,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			Resources:        v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceName(v1.ResourceStorage): resource.MustParse(cap)}},


### PR DESCRIPTION
Part of https://github.com/futurewei-cloud/arktos/issues/186

**Notes for reviewers**
- Commit 1  and 3 are the actual change. commit 2 is "make update" autogenerated files for changes in the pv and pvc PR and therefore deserves little time in reviewing.
- All unit tests for statefulset are now using a non-system & non-default test tenant. Before this, and in other unit tests too, we've been using system tenant for backward compatible test. They make changing tests very labor intensive and is actually violating how unit test should work. In this PR I'm arguing that the backward case with system tenant shouldn't be in the unit test for other part of the code. We should either make sure the unit test cases with system tenant (specificially with the lister functions) are sufficient, and/or add integration/e2e tests to verify it. 


### local e2e test:

#### create pv
```bash
TENANT            NAME                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE
futureweitenant   persistentvolume/my-pv-0   1Gi        RWO            Retain           Available           manual                  7s
futureweitenant   persistentvolume/my-pv-1   1Gi        RWO            Retain           Available           manual                  7s
```

#### create statefulset with 2 pods consuming pv
```bash
TENANT            NAMESPACE             NAME                            HASHKEY               READY   STATUS    RESTARTS   AGE
futureweitenant   futurewei-namespace   pod/goose-ss-0                  1118939078841033003   1/1     Running   0          9s
futureweitenant   futurewei-namespace   pod/goose-ss-1                  1176681893112659923   1/1     Running   0          6s
```

#### PVCs were created automatically:
```bash
TENANT            NAMESPACE             NAME                                   STATUS   VOLUME    CAPACITY   ACCESS MODES   STORAGECLASS   AGE
futureweitenant   futurewei-namespace   persistentvolumeclaim/www-goose-ss-0   Bound    my-pv-1   1Gi        RWO            manual         28s
futureweitenant   futurewei-namespace   persistentvolumeclaim/www-goose-ss-1   Bound    my-pv-0   1Gi        RWO            manual         25s
```

#### Deletion was tested by deleting the statefulset and related service first, then manually delete pvc and pv, following the process detailed by [this](https://kubernetes.io/docs/tasks/run-application/delete-stateful-set/)