### PR TITLE
tenant controller bootstraps cluster role and binding

### DIFF
--- a/pkg/controller/tenant/BUILD
+++ b/pkg/controller/tenant/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/util/metrics:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
@@ -54,6 +55,7 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/arktos-ext/pkg/apis/arktosextensions/v1:go_default_library",

--- a/pkg/controller/tenant/tenant_controller.go
+++ b/pkg/controller/tenant/tenant_controller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -44,7 +45,13 @@ import (
 	"k8s.io/klog"
 )
 
-var tenant_default_namespaces = [...]string{core.NamespaceDefault, core.NamespaceSystem, core.NamespacePublic}
+var tenantDefaultNamespaces = [...]string{core.NamespaceDefault, core.NamespaceSystem, core.NamespacePublic}
+
+const (
+	initialClusterRoleUser        = "admin"
+	initialClusterRoleName        = "admin-role"
+	initialClusterRoleBindingName = "admin-role-binding"
+)
 
 // tenantController is responsible for performing actions dependent upon a tenant phase
 type tenantController struct {
@@ -197,21 +204,25 @@ func (tc *tenantController) syncTenant(tenantName string) (err error) {
 		klog.V(4).Infof("Finished initializing tenant %q (%v)", tenantName, time.Since(startTime))
 	}()
 
-	createFailures := []error{}
-
-	// Create Default namespaces
-	for _, nsName := range tenant_default_namespaces {
-
-		ns := v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Tenant: tenantName, Name: nsName},
-		}
-		if _, err := tc.kubeClient.CoreV1().NamespacesWithMultiTenancy(tenantName).Create(&ns); err != nil && !errors.IsAlreadyExists(err) {
-			createFailures = append(createFailures, err)
-		}
+	if err, done := tc.createNamespaces(tenantName); !done {
+		return err
 	}
 
+	if err, done := tc.createInitialRoleAndBinding(tenantName); !done {
+		return err
+	}
+
+	if err, done := tc.createDefaultNetworkObject(tenantName); !done {
+		return err
+	}
+	return nil
+}
+
+func (tc *tenantController) createDefaultNetworkObject(tenantName string) (error, bool) {
+	failures := []error{}
+
 	// create default network object, if applicable
-	tenant, _ := tc.lister.Get(tenantName)	// no error as its caller, processQueue, has checked.
+	tenant, _ := tc.lister.Get(tenantName) // no error as its caller, processQueue, has checked.
 	if tenant.Status.Phase == v1.TenantTerminating {
 		klog.Infof("Tenant %q is terminating; skipped the creation of default network", tenantName)
 	} else if len(tc.defaultNetworkTemplatePath) == 0 {
@@ -219,24 +230,84 @@ func (tc *tenantController) syncTenant(tenantName string) (err error) {
 	} else {
 		klog.Infof("creating the default network in tenant %q", tenantName)
 		defaultNetwork := arktosv1.Network{}
-		if err = tc.getDefaultNetwork(tenantName, &defaultNetwork); err != nil {
-			createFailures = append(createFailures, err)
+		if err := tc.getDefaultNetwork(tenantName, &defaultNetwork); err != nil {
+			failures = append(failures, err)
 		} else {
 			if _, err = tc.networkClient.ArktosV1().NetworksWithMultiTenancy(tenantName).Create(&defaultNetwork); err != nil && !errors.IsAlreadyExists(err) {
-				createFailures = append(createFailures, err)
+				failures = append(failures, err)
 			}
 		}
 	}
 
-	if len(createFailures) != 0 {
-		ret := utilerrors.Flatten(utilerrors.NewAggregate(createFailures))
+	if len(failures) != 0 {
+		ret := utilerrors.Flatten(utilerrors.NewAggregate(failures))
 		klog.Errorf("Errors happened in tenant initialization of %v: %v", tenantName, ret)
-		return ret
+		return ret, false
 	}
-
-	return nil
+	return nil, true
 }
 
+func (tc *tenantController) createNamespaces(tenantName string) (error, bool) {
+	failures := []error{}
+	for _, nsName := range tenantDefaultNamespaces {
+		ns := v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Tenant: tenantName, Name: nsName},
+		}
+		if _, err := tc.kubeClient.CoreV1().NamespacesWithMultiTenancy(tenantName).Create(&ns); err != nil && !errors.IsAlreadyExists(err) {
+			failures = append(failures, err)
+		}
+	}
+	if len(failures) != 0 {
+		ret := utilerrors.Flatten(utilerrors.NewAggregate(failures))
+		klog.Errorf("Errors happened in tenant initialization of %v: %v", tenantName, ret)
+		return ret, false
+	}
+	return nil, true
+}
+
+func (tc *tenantController) createInitialRoleAndBinding(tenant string) (error, bool) {
+	// tenant admin act as cluster admin for tha tenant
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   initialClusterRoleName,
+			Tenant: tenant,
+		},
+		Rules: []rbacv1.PolicyRule{initialClusterRoleRules()},
+	}
+
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   initialClusterRoleBindingName,
+			Tenant: tenant,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.UserKind, Name: initialClusterRoleUser},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: initialClusterRoleName},
+	}
+
+	var failures []error
+	if _, err := tc.kubeClient.RbacV1().ClusterRolesWithMultiTenancy(tenant).Create(role); err != nil && !errors.IsAlreadyExists(err) {
+		failures = append(failures, err)
+	}
+	if _, err := tc.kubeClient.RbacV1().ClusterRoleBindingsWithMultiTenancy(tenant).Create(binding); err != nil && !errors.IsAlreadyExists(err) {
+		failures = append(failures, err)
+	}
+	if len(failures) != 0 {
+		ret := utilerrors.Flatten(utilerrors.NewAggregate(failures))
+		klog.Errorf("Errors happened when creating initial cluster role and binding for tenant %s: %v", tenant, ret)
+		return ret, false
+	}
+	return nil, true
+}
+
+func initialClusterRoleRules() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		Verbs:     []string{"*"},
+		APIGroups: []string{"*"},
+		Resources: []string{"*"},
+	}
+}
 func (tc *tenantController) getDefaultNetwork(tenant string, net *arktosv1.Network) error {
 	// todo: validate content of template file
 	tmpl, err := tc.templateGetter(tc.defaultNetworkTemplatePath)

--- a/pkg/controller/tenant/tenant_controller_test.go
+++ b/pkg/controller/tenant/tenant_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	arktosv1 "k8s.io/arktos-ext/pkg/apis/arktosextensions/v1"
@@ -33,14 +34,21 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 )
 
+const (
+	roleActionCountPerBootstrap = 2
+)
+
 func TestTenantCreation(t *testing.T) {
 
 	testcases := map[string]struct {
-		Tenant                  *v1.Tenant
-		ExpectCreatedNamespaces []string
-		NetworkTemplate         string
-		NetworkTemplatePath 	string
-		ExpectedNetwork         *arktosv1.Network
+		Tenant                   *v1.Tenant
+		ExpectCreatedNamespaces  []string
+		NetworkTemplate          string
+		NetworkTemplatePath      string
+		ExpectedNetwork          *arktosv1.Network
+		ExpectInitialRole        *rbacv1.ClusterRole
+		ExpectInitialRoleBinding *rbacv1.ClusterRoleBinding
+		ExpectActionCount        int
 	}{
 		"new-tenants": {
 			Tenant: &v1.Tenant{
@@ -48,9 +56,9 @@ func TestTenantCreation(t *testing.T) {
 					Name: "test-tenant-1",
 				},
 			},
-			ExpectCreatedNamespaces: tenant_default_namespaces[:],
-			NetworkTemplate: `{"metadata":{"name":"default", "tenant":"should-be-overridden"},"spec":{"type":"test-type","vpcID":"{{.}}-12345"}}`,
-			NetworkTemplatePath: "test.tmpl",
+			ExpectCreatedNamespaces: tenantDefaultNamespaces[:],
+			NetworkTemplate:         `{"metadata":{"name":"default", "tenant":"should-be-overridden"},"spec":{"type":"test-type","vpcID":"{{.}}-12345"}}`,
+			NetworkTemplatePath:     "test.tmpl",
 			ExpectedNetwork: &arktosv1.Network{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "default",
@@ -61,6 +69,9 @@ func TestTenantCreation(t *testing.T) {
 					VPCID: "test-tenant-1-12345",
 				},
 			},
+			ExpectInitialRole:        initialClusterRole("test-tenant-1"),
+			ExpectInitialRoleBinding: initialClusterRoleBinding("test-tenant-1"),
+			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap,
 		},
 		"new-tenants-with-empty-default-network-tmpl-path": {
 			Tenant: &v1.Tenant{
@@ -68,24 +79,30 @@ func TestTenantCreation(t *testing.T) {
 					Name: "test-tenant-2",
 				},
 			},
-			ExpectCreatedNamespaces: tenant_default_namespaces[:],
-			NetworkTemplate: `{"metadata":{"name":"default"},"spec":{"type":"test-type","vpcID":"{{.}}-12345"}}`,
-			NetworkTemplatePath: "",
-			ExpectedNetwork: nil,
+			ExpectCreatedNamespaces:  tenantDefaultNamespaces[:],
+			NetworkTemplate:          `{"metadata":{"name":"default"},"spec":{"type":"test-type","vpcID":"{{.}}-12345"}}`,
+			NetworkTemplatePath:      "",
+			ExpectedNetwork:          nil,
+			ExpectInitialRole:        initialClusterRole("test-tenant-2"),
+			ExpectInitialRoleBinding: initialClusterRoleBinding("test-tenant-2"),
+			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap,
 		},
 		"terminating-tenant-not-create-default-network": {
 			Tenant: &v1.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-tenant-3",
 				},
-				Status: v1.TenantStatus {
+				Status: v1.TenantStatus{
 					Phase: v1.TenantTerminating,
 				},
 			},
-			ExpectCreatedNamespaces: tenant_default_namespaces[:],
-			NetworkTemplate: `{"metadata":{"name":"default"},"spec":{"type":"test-type","vpcID":"{{.}}-12345"}}`,
-			NetworkTemplatePath: "test.tmpl",
-			ExpectedNetwork: nil,
+			ExpectCreatedNamespaces:  tenantDefaultNamespaces[:],
+			NetworkTemplate:          `{"metadata":{"name":"default"},"spec":{"type":"test-type","vpcID":"{{.}}-12345"}}`,
+			NetworkTemplatePath:      "test.tmpl",
+			ExpectedNetwork:          nil,
+			ExpectInitialRole:        initialClusterRole("test-tenant-3"),
+			ExpectInitialRoleBinding: initialClusterRoleBinding("test-tenant-3"),
+			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap,
 		},
 	}
 
@@ -133,59 +150,111 @@ func TestTenantCreation(t *testing.T) {
 			t.Errorf("%s: took too long", k)
 		}
 
-		// verify ns actions
-		actions := client.Actions()
-		if len(tc.ExpectCreatedNamespaces) != len(actions) {
-			t.Errorf("%s: Expected to create namespaces %#v. Actual actions were: %#v", k, tc.ExpectCreatedNamespaces, actions)
-			continue
+		clientActions := client.Actions()
+		if len(clientActions) != tc.ExpectActionCount {
+			t.Errorf("unmatched action counts, expect: %d, actual %d", tc.ExpectActionCount, len(clientActions))
 		}
 
-		actualCreatedNamespaces := sets.NewString()
-		expectCreatedNamespaces := sets.NewString()
-		for _, s := range tc.ExpectCreatedNamespaces {
-			expectCreatedNamespaces.Insert(s)
-		}
-		for i := 0; i < len(actions); i++ {
-			action := actions[i]
-			if !action.Matches("create", "namespaces") {
-				t.Errorf("%s: Unexpected action %v", k, action)
-				break
+		t.Run("bootstrap namespaces", func(t *testing.T) {
+			actualCreatedNamespaces := sets.NewString()
+			expectCreatedNamespaces := sets.NewString()
+			for _, s := range tc.ExpectCreatedNamespaces {
+				expectCreatedNamespaces.Insert(s)
 			}
+			for _, action := range clientActions {
+				if !action.Matches("create", "namespaces") {
+					continue
+				}
 
-			createdNamespace := action.(core.CreateAction).GetObject().(*v1.Namespace)
-			if createdNamespace.Tenant != tc.Tenant.Name {
-				t.Errorf("%s: Unexpected tenant name in the created namespace: %s", k, createdNamespace.Tenant)
-			}
+				createdNamespace := action.(core.CreateAction).GetObject().(*v1.Namespace)
+				if createdNamespace.Tenant != tc.Tenant.Name {
+					t.Errorf("%s: Unexpected tenant name in the created namespace: %s",
+						k, createdNamespace.Tenant)
+				}
 
-			createdNamespaceName := createdNamespace.Name
-			if !expectCreatedNamespaces.Has(createdNamespaceName) {
-				t.Errorf("%s: Unexpected namespace is created: %s", k, createdNamespaceName)
-			}
-			if actualCreatedNamespaces.Has(createdNamespaceName) {
-				t.Errorf("%s: namespace is created multiple times: %s", k, createdNamespaceName)
-			}
+				createdNamespaceName := createdNamespace.Name
+				if !expectCreatedNamespaces.Has(createdNamespaceName) {
+					t.Errorf("%s: Unexpected namespace is created: %s", k, createdNamespaceName)
+				}
+				if actualCreatedNamespaces.Has(createdNamespaceName) {
+					t.Errorf("%s: namespace is created multiple times: %s", k, createdNamespaceName)
+				}
 
-			actualCreatedNamespaces.Insert(createdNamespaceName)
-		}
+				actualCreatedNamespaces.Insert(createdNamespaceName)
+			}
+			if len(actualCreatedNamespaces) != len(expectCreatedNamespaces) {
+				t.Errorf("%s: not all namespaces are created: expected: %v, actual: %v", k,
+					expectCreatedNamespaces, actualCreatedNamespaces)
+			}
+		})
 
-		// verify network CR actions
-		netActions := networkClient.Actions()
-		if (tc.ExpectedNetwork == nil) {
-			if 0 != len(netActions) {
-				t.Errorf("%s: Should have no action; got actions: %#v", k, netActions)
+		t.Run("bootstrap cluster role and binding", func(t *testing.T) {
+			for _, action := range clientActions {
+				if action.Matches("create", "clusterroles") {
+					createdClusterRole := action.(core.CreateAction).GetObject().(*rbacv1.ClusterRole)
+					if !reflect.DeepEqual(tc.ExpectInitialRole, createdClusterRole) {
+						t.Errorf("%s: Unexpected cluster role created, expect: %v\nactual: %v",
+							k, tc.ExpectInitialRole, createdClusterRole)
+					}
+					continue
+				}
+				if action.Matches("create", "clusterrolebindings") {
+					createdClusterRoleBinding := action.(core.CreateAction).GetObject().(*rbacv1.ClusterRoleBinding)
+					if !reflect.DeepEqual(tc.ExpectInitialRoleBinding, createdClusterRoleBinding) {
+						t.Errorf("%s: Unexpected cluster role binding created, expect: %v\nactual: %v",
+							k, tc.ExpectInitialRoleBinding, createdClusterRoleBinding)
+					}
+				}
 			}
-		} else {
-			if 1 != len(netActions) {
-				t.Errorf("%s: Expected to create network %#v. Actual actions were: %#v", k, tc.ExpectedNetwork.Name, netActions)
+		})
+
+		t.Run("network CR", func(t *testing.T) {
+			// verify network CR actions
+			netActions := networkClient.Actions()
+			if tc.ExpectedNetwork == nil {
+				if 0 != len(netActions) {
+					t.Errorf("%s: Should have no action; got actions: %#v", k, netActions)
+				}
+			} else {
+				if 1 != len(netActions) {
+					t.Errorf("%s: Expected to create network %#v. Actual actions were: %#v", k, tc.ExpectedNetwork.Name, netActions)
+				}
+				if !netActions[0].Matches("create", "networks") {
+					t.Errorf("%s: Unexpected action %v", k, netActions[0])
+				}
+				netObj := netActions[0].(core.CreateAction).GetObject().(*arktosv1.Network)
+				if !reflect.DeepEqual(netObj, tc.ExpectedNetwork) {
+					t.Errorf("%s: Expected network object %#v; got %#v", k, tc.ExpectedNetwork, netObj)
+				}
 			}
-			if !netActions[0].Matches("create", "networks") {
-				t.Errorf("%s: Unexpected action %v", k, netActions[0])
-			}
-			netObj := netActions[0].(core.CreateAction).GetObject().(*arktosv1.Network)
-			if !reflect.DeepEqual(netObj, tc.ExpectedNetwork) {
-				t.Errorf("%s: Expected network object %#v; got %#v", k, tc.ExpectedNetwork, netObj)
-			}
-		}
+		})
+	}
+}
+
+func initialClusterRoleBinding(tenant string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   initialClusterRoleBindingName,
+			Tenant: tenant,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.UserKind, Name: "admin"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     initialClusterRoleName,
+		},
+	}
+}
+
+func initialClusterRole(tenant string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   initialClusterRoleName,
+			Tenant: tenant,
+		},
+		Rules: []rbacv1.PolicyRule{initialClusterRoleRules()},
 	}
 }
 

--- a/pkg/controller/tenant/tenant_controller_test.go
+++ b/pkg/controller/tenant/tenant_controller_test.go
@@ -208,7 +208,7 @@ func TestTenantCreation(t *testing.T) {
 			}
 		})
 
-		t.Run("network CR", func(t *testing.T) {
+		t.Run("bootstrap network objects", func(t *testing.T) {
 			// verify network CR actions
 			netActions := networkClient.Actions()
 			if tc.ExpectedNetwork == nil {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -388,7 +388,8 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "tenant-controller"},
 		Rules: []rbacv1.PolicyRule{
-			rbacv1helpers.NewRule("create", "get", "list").Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
+			// all * so that tenant controller could create the initial role and binding for tenant admin
+			rbacv1helpers.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
@@ -34,6 +34,7 @@ var rolesWithAllowStar = sets.NewString(
 	saRolePrefix+"horizontal-pod-autoscaler",
 	saRolePrefix+"clusterrole-aggregation-controller",
 	saRolePrefix+"disruption-controller",
+	saRolePrefix+"tenant-controller",
 )
 
 // TestNoStarsForControllers confirms that no controller role has star verbs, groups,

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -1260,13 +1260,11 @@ items:
     name: system:controller:tenant-controller
   rules:
   - apiGroups:
-    - ""
+    - '*'
     resources:
-    - namespaces
+    - '*'
     verbs:
-    - create
-    - get
-    - list
+    - '*'
   - apiGroups:
     - ""
     resources:


### PR DESCRIPTION
tracking issue https://github.com/futurewei-cloud/arktos/issues/176

### Changes:
A cluster role and rolebinding are created by the tenant controller when a new tenant is created. This role acts as the admin role for the tenant. 

### Note to reviewers:
The SA cluster role for tenant-controller has been bumped up to all verb, groups and resource because this role will be assumed to create the default tenant admin role. As a tenant admin role, it would allow "full" access to the tenant's own world. A lower capability role (the tenant-controller role) cannot create a higher capability role (tenant admin role). There are a few such controller role setup in addition to the tenant-controller (full list [here](plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go)).


### Manual e2e test:
Create a tenant **futureweitenant**, and then cluster role and binding are created automatically:
```bash
kubectl get role,rolebinding,clusterrole,clusterrolebinding --tenant=futureweitenant --all-namespaces                                                      ip-172-31-27-32: Wed May 13 00:23:54 2020

NAME                                                               AGE
clusterrole.rbac.authorization.k8s.io/futureweitenant-admin-role   10s
NAME                                                                              AGE
clusterrolebinding.rbac.authorization.k8s.io/futureweitenant-admin-role-binding   10s
```

The user name for this role is "admin". And this user immediately has access:
```bash
kubectl --context=futurewei-admin-context get pods
No resources found.
```
This show access is permitted. 

Try to access as another user with the correct cert, and it failed authorization:
```bash
kubectl --context=futurewei-johndoe-context get pods
Error from server (Forbidden): pods is forbidden: User "johndoe" cannot list resource "pods" in API group "" in the namespace "futurewei-namespace"
```

Now let tenant admin create role and binding for johndoe, and johndoe now passed authorization:
```bash
root@ip-172-31-27-32:~/arktos_testing# kubectl --context=futurewei-admin-context create -f futureweirole.yaml
role.rbac.authorization.k8s.io/futureweirole created
root@ip-172-31-27-32:~/arktos_testing# kubectl --context=futurewei-admin-context create -f futureweirolebinding.yaml
rolebinding.rbac.authorization.k8s.io/futureweirolebinding created
kubectl --context=futurewei-johndoe-context get pods
No resources found.
```