### PR TITLE
Option for not downloading runtime deployment files in Arktos onebox setup

### DIFF
--- a/hack/lib/common-var-init.sh
+++ b/hack/lib/common-var-init.sh
@@ -28,6 +28,7 @@ VIRTLET_DEPLOYMENT_FILES_DIR=${VIRTLET_DEPLOYMENT_FILES_DIR:-"/tmp"}
 
 # Default to current arktos-vm-runtime release-0.5 branch
 VIRTLET_DEPLOYMENT_FILES_SRC=${VIRTLET_DEPLOYMENT_FILES_SRC:-"https://raw.githubusercontent.com/futurewei-cloud/arktos-vm-runtime/release-0.5/deploy"}
+OVERWRITE_DEPLOYMENT_FILES=${OVERWRITE_DEPLOYMENT_FILES:-"true"}
 
 APPARMOR_ENABLED=${APPARMOR_ENABLED:-""}
 

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -55,14 +55,28 @@ if [[ ! -e "${CONTAINERD_SOCK_PATH}" ]]; then
   exit 1
 fi
 
+# local function to download runtime deployment file
+copyRuntimeDeploymentFile() {
+  if [[ $# != 2 ]]; then
+    echo "Invalid args in copyRuntimeDeploymentFile"
+    exit 1
+  fi
+
+  fileName=$1
+  pathInSrc=$2
+  if [[ (${OVERWRITE_DEPLOYMENT_FILES} == "true") || (! -f ${VIRTLET_DEPLOYMENT_FILES_DIR}/${fileName}) ]]; then 
+    echo "Getting runtime deployment file " ${fileName}
+    wget -O ${VIRTLET_DEPLOYMENT_FILES_DIR}/${fileName}  ${VIRTLET_DEPLOYMENT_FILES_SRC}/${pathInSrc}
+  fi
+}
+
 # Get runtime deployment files
-echo "Getting runtime deployment files"
-wget -O ${VIRTLET_DEPLOYMENT_FILES_DIR}/libvirt-qemu  ${VIRTLET_DEPLOYMENT_FILES_SRC}/apparmor/libvirt-qemu
-wget -O ${VIRTLET_DEPLOYMENT_FILES_DIR}/libvirtd  ${VIRTLET_DEPLOYMENT_FILES_SRC}/apparmor/libvirtd
-wget -O ${VIRTLET_DEPLOYMENT_FILES_DIR}/virtlet  ${VIRTLET_DEPLOYMENT_FILES_SRC}/apparmor/virtlet
-wget -O ${VIRTLET_DEPLOYMENT_FILES_DIR}/vms  ${VIRTLET_DEPLOYMENT_FILES_SRC}/apparmor/vms
-wget -O ${VIRTLET_DEPLOYMENT_FILES_DIR}/vmruntime.yaml  ${VIRTLET_DEPLOYMENT_FILES_SRC}/data/virtlet-ds.yaml
-wget -O ${VIRTLET_DEPLOYMENT_FILES_DIR}/images.yaml  ${VIRTLET_DEPLOYMENT_FILES_SRC}/images.yaml
+copyRuntimeDeploymentFile "libvirt-qemu" "apparmor/libvirt-qemu"
+copyRuntimeDeploymentFile "libvirtd" "apparmor/libvirtd"
+copyRuntimeDeploymentFile "virtlet" "apparmor/virtlet"
+copyRuntimeDeploymentFile "vms" "apparmor/vms"
+copyRuntimeDeploymentFile "vmruntime.yaml" "data/virtlet-ds.yaml"
+copyRuntimeDeploymentFile "images.yaml" "images.yaml"
 
 if [ "${APPARMOR_ENABLED}" == "true" ]; then
   echo "Config test env under apparmor enabled host"


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
Fix issue Arktos issue 166. provides an option for not downloading runtime deployment files from runtime repo if a local copy is prefered to use

**Which issue(s) this PR fixes**:
Fixes 166

Tested locally:

1. Verify normal start of onebox will download runtime deployment files
  ./hack/arktos-up.sh 
2. with files in local directory, verify flag=false won't download them
  OVERWRITE_DEPLOYMENT_FILES=false ./hack/arktos-up.sh 
3. remove the local files and retry to ensure files are downloaded, even flag=false
  rm /tmp/* -f -r
  OVERWRITE_DEPLOYMENT_FILES=false ./hack/arktos-up.sh 

