### PR TITLE
explicit tenant all in url

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -28,6 +28,8 @@ import (
 const (
 	// TenantAll is the default argument to specify on a context when you want to list or filter resources across all tenants
 	TenantAll = ""
+	// Sometimes we need to explicitly indicate the operation targets at all the tenants, not the empty string of the above TenantAll
+	TenantAllExplicit = "all"
 	// TenantNone is the argument for a context when there is no tenant.
 	TenantNone = ""
 	// tenantSystem is the system tenant where we place system components.

--- a/pkg/kubeapiserver/server/insecure_handler.go
+++ b/pkg/kubeapiserver/server/insecure_handler.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubeapiserver/server/insecure_handler.go
+++ b/pkg/kubeapiserver/server/insecure_handler.go
@@ -27,6 +27,7 @@ import (
 // BuildInsecureHandlerChain sets up the server to listen to http. Should be removed.
 func BuildInsecureHandlerChain(apiHandler http.Handler, c *server.Config) http.Handler {
 	handler := apiHandler
+	handler = genericapifilters.WithTenantInfo(handler)
 	handler = genericapifilters.WithAudit(handler, c.AuditBackend, c.AuditPolicyChecker, c.LongRunningFunc)
 	handler = genericapifilters.WithAuthentication(handler, server.InsecureSuperuser{}, nil, nil)
 	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -27,6 +27,8 @@ import (
 const (
 	// TenantAll is the default argument to specify on a context when you want to list or filter resources across all tenants
 	TenantAll string = ""
+	// Sometimes we need to explicitly indicate the operation targets at all the tenants, not the empty string of the above TenantAll
+	TenantAllExplicit = "all"
 	// TenantSystem is the system tenant where we place system components.
 	TenantSystem string = "system"
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/BUILD
@@ -26,6 +26,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/validation",
     importpath = "k8s.io/apimachinery/pkg/api/validation",
     deps = [
+        "//pkg/apis/core:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
@@ -18,10 +18,12 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 const IsNegativeErrorMsg string = `must be greater than or equal to 0`
@@ -58,9 +60,16 @@ func NameIsDNS1035Label(name string, prefix bool) []string {
 }
 
 // ValidateTenantName can be used to check whether the given tenant name is valid.
-// Prefix indicates this name will be used as part of generation, in which case
-// trailing dashes are allowed.
-var ValidateTenantName = NameIsDNSLabel
+func ValidateTenantName(name string, prefix bool) []string {
+	forbiddenTenantNames := []string{api.TenantAllExplicit}
+	for _, forbiddenName := range forbiddenTenantNames {
+		if name == forbiddenName {
+			return []string{fmt.Sprintf("is not an acceptable tenant name")}
+		}
+	}
+
+	return NameIsDNSLabel(name, prefix)
+}
 
 // ValidateControllerTypeName can be used to check whether the given controller type name is valid.
 var ValidateControllerTypeName = NameIsDNSLabel

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -324,12 +324,12 @@ type Initializer struct {
 const (
 	// TenantAll is the default argument to specify on a context when you want to list or filter resources across all tenants
 	TenantAll string = ""
+	// Sometimes we need to explicitly indicate the operation targets at all the tenants, not the empty string of the above TenantAll
+	TenantAllExplicit string = "all"
 	// TenantNone is the argument for a context when there is no tenant.
 	TenantNone string = ""
 	// TenantSystem is the system tenant where we place system components.
 	TenantSystem string = "system"
-	// TenantPublic is the tenant where we place public info
-	TenantPublic string = "public"
 
 	// NamespaceDefault means the object is in the default namespace which is applied when not specified by clients
 	NamespaceDefault string = "default"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo.go
@@ -68,8 +68,12 @@ func SetShortPathRequestTenant(req *http.Request) (*http.Request, error) {
 	// for a reqeust from a regular user, if the tenant in the object is empty, use the tenant from user info
 	// this is what we call "short-path", which allows users to use traditional Kubernets API in the multi-tenancy Arktos
 	resourceTenant := requestInfo.Tenant
-	if resourceTenant == metav1.TenantNone && userTenant != metav1.TenantSystem {
+	if resourceTenant == metav1.TenantNone {
 		requestInfo.Tenant = userTenant
+	}
+
+	if resourceTenant == metav1.TenantAllExplicit {
+		requestInfo.Tenant = metav1.TenantAll
 	}
 
 	req = req.WithContext(request.WithRequestInfo(ctx, requestInfo))

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/tenantinfo_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filters
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -88,11 +89,11 @@ func TestTenantInfoRequest(t *testing.T) {
 			ExpectedTenant:   "aaa",
 		},
 		{
-			Name:             "system tenant user does not change empty tenant in request info",
+			Name:             "system tenant change empty tenant in request info",
 			Url:              "/api/v1/namespaces/default/pods",
 			UserInfo:         getTenantedUserInfo(metav1.TenantSystem),
 			ExepctedRespCode: 200,
-			ExpectedTenant:   "",
+			ExpectedTenant:   metav1.TenantSystem,
 		},
 		{
 			Name:             "short path: for regular tenant user, empty tenant in request info is set to the user tenant",
@@ -114,6 +115,20 @@ func TestTenantInfoRequest(t *testing.T) {
 			UserInfo:         getTenantedUserInfo("regular-user"),
 			ExepctedRespCode: 200,
 			ExpectedTenant:   "another-user",
+		},
+		{
+			Name:             "Regular User: metav1.TenantAllExplicit will be transformed to metav1.TenantAll",
+			Url:              fmt.Sprintf("/api/v1/tenants/%s/namespaces", metav1.TenantAllExplicit),
+			UserInfo:         getTenantedUserInfo("regular-user"),
+			ExepctedRespCode: 200,
+			ExpectedTenant:   metav1.TenantAll,
+		},
+		{
+			Name:             "System User: metav1.TenantAllExplicit will be transformed to metav1.TenantAll",
+			Url:              fmt.Sprintf("/api/v1/tenants/%s/namespaces", metav1.TenantAllExplicit),
+			UserInfo:         getTenantedUserInfo(metav1.TenantSystem),
+			ExepctedRespCode: 200,
+			ExpectedTenant:   metav1.TenantAll,
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -501,7 +501,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, tenantParams, namer, true, true}, allowWatchList)
 		}
 
-		// the folloiwing is for backward-compatible APIs before multi-tenancy, should be removed when we no longer support it
+		// the following is for backward-compatible APIs before multi-tenancy. We call it short-path, for which the tenant info will be extracted from request context.
 		resourcePath = resource
 		itemPath = resourcePath + "/{name}"
 		resourceParams = params
@@ -599,7 +599,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true, true}, allowWatchList)
 		}
 
-		// the folloiwing is for backward-compatible APIs before multi-tenancy, should be removed when we no longer support it
+		// the following is for backward-compatible APIs before multi-tenancy. We call it short-path, for which the tenant info will be extracted from request context.
 		resourcePath = namespaceParamName + "/{namespace}/" + resource
 		itemPath = resourcePath + "/{name}"
 		resourceParams = []*restful.Parameter{namespaceParam}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -499,7 +499,7 @@ func (b *Builder) DefaultTenant() *Builder {
 // across all of the tenant. This overrides the tenant set by TenantParam().
 func (b *Builder) AllTenants(allTenant bool) *Builder {
 	if allTenant {
-		b.tenant = metav1.TenantAll
+		b.tenant = metav1.TenantAllExplicit
 	}
 	b.allTenant = allTenant
 	return b

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -318,6 +318,9 @@ func (config *DirectClientConfig) Tenant() (string, bool, error) {
 		// the tenant override instead of having config.ConfirmUsable() return an error. This allows
 		// things like in-cluster clients to execute `kubectl get pods --tenant=foo` and have the
 		// --tenant flag honored instead of being ignored.
+		if config.overrides.Context.Tenant == metav1.TenantAllExplicit {
+			return "", false, fmt.Errorf("%q is not a valid tenant name", metav1.TenantAllExplicit)
+		}
 		return config.overrides.Context.Tenant, true, nil
 	}
 
@@ -330,8 +333,8 @@ func (config *DirectClientConfig) Tenant() (string, bool, error) {
 		return "", false, err
 	}
 
-	if len(configContext.Tenant) == 0 {
-		return metav1.TenantSystem, false, nil
+	if configContext.Tenant == metav1.TenantAllExplicit {
+		return "", false, fmt.Errorf("%q is not a valid tenant name", metav1.TenantAllExplicit)
 	}
 
 	return configContext.Tenant, false, nil
@@ -550,7 +553,7 @@ func (config *inClusterClientConfig) Tenant() (string, bool, error) {
 		}
 	}
 
-	return metav1.TenantSystem, false, nil
+	return "", false, nil
 }
 
 func (config *inClusterClientConfig) Namespace() (string, bool, error) {


### PR DESCRIPTION
This PR address the issue to explicitly indicate whether a request targets all-tenants. So, with this change, for a request from a system user:
1. GET /api/v1/namespaces: means lists namesapces of system tenants
2.  GET /api/v1/tenants/all/namespaces: means lists namesapces of all the tenants, including the system tenants and regular tenants

TenantAll is "", similar to NamespaceAll in K8s, which is also "" . By making TenantAll as an empty string, the list operation on etcd is quite simple. Therefore, I did not change the definition of TenantAll in Arktos. When Arktos detects the tenant is "all" in the url, the tenant will be set TenantAll. If tenant is empty in the url, the tenant will be set according to short-path logic. 

Tests done in my local dev box:

# "all" is not an acceptable tenant name now.
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant all
The Tenant "all" is invalid: metadata.name: Invalid value: "all": is not an acceptable tenant name

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get pods --tenant all --all-namespaces
error: "all" is not a valid tenant name
```

# verify that "tenants/all" work as expected
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create -f ./test/yaml/multi_tenancy_examples/tenant1.yaml 
tenant/sample-tenant-1 created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create -f ./test/yaml/multi_tenancy_examples/tenant1-ns-a.yaml 
namespace/sample-namespace-a created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create -f ./test/yaml/multi_tenancy_examples/tenant1-ns-a-deployment.yaml 
deployment.apps/sample-nginx-deployment created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get pods --all-tenants --all-namespaces
TENANT            NAMESPACE            NAME                                       HASHKEY               READY   STATUS    RESTARTS   AGE
system            kube-system          kube-dns-5d69f5657d-drlpr                  5427732176834485377   3/3     Running   0          19m
system            kube-system          virtlet-pghwt                              9019363285369125196   3/3     Running   0          18m
sample-tenant-1   sample-namespace-a   sample-nginx-deployment-74cbdd5d99-fj68d   607901798557078899    1/1     Running   0          24s
sample-tenant-1   sample-namespace-a   sample-nginx-deployment-74cbdd5d99-g6rct   1950399659802567693   1/1     Running   0          24s
sample-tenant-1   sample-namespace-a   sample-nginx-deployment-74cbdd5d99-grhk8   6582451568891784181   1/1     Running   0          24s
```

In apiserver.log, I confirmed that the url has been changed to the expected
I0525 23:30:14.824513    8304 wrap.go:47] GET /api/v1/**tenants/all**/pods?limit=500: (3.105091ms) 200 [kubectl/v0.2 (linux/amd64) kubernetes/0f650bf 127.0.0.1:51676]