### PR TITLE
make service controller multi-tenant

### DIFF
--- a/pkg/controller/service/patch.go
+++ b/pkg/controller/service/patch.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,7 +38,7 @@ func patch(c v1core.CoreV1Interface, oldSvc *v1.Service, newSvc *v1.Service) (*v
 		return nil, err
 	}
 
-	return c.Services(oldSvc.Namespace).Patch(oldSvc.Name, types.StrategicMergePatchType, patchBytes, "status")
+	return c.ServicesWithMultiTenancy(oldSvc.Namespace, oldSvc.Tenant).Patch(oldSvc.Name, types.StrategicMergePatchType, patchBytes, "status")
 }
 
 func getPatchBytes(oldSvc *v1.Service, newSvc *v1.Service) ([]byte, error) {

--- a/pkg/controller/service/patch_test.go
+++ b/pkg/controller/service/patch_test.go
@@ -33,7 +33,7 @@ func addAnnotations(svc *v1.Service) {
 func TestPatch(t *testing.T) {
 	svcOrigin := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Tenant:      metav1.TenantSystem,
+			Tenant:      testTenant,
 			Namespace:   "default",
 			Name:        "test-patch",
 			Annotations: map[string]string{},
@@ -47,7 +47,7 @@ func TestPatch(t *testing.T) {
 	// Issue a separate update and verify patch doesn't fail after this.
 	svcToUpdate := svcOrigin.DeepCopy()
 	addAnnotations(svcToUpdate)
-	if _, err := fakeCs.CoreV1().Services(svcOrigin.Namespace).Update(svcToUpdate); err != nil {
+	if _, err := fakeCs.CoreV1().ServicesWithMultiTenancy(svcOrigin.Namespace, svcOrigin.Tenant).Update(svcToUpdate); err != nil {
 		t.Fatalf("Failed to update service: %v", err)
 	}
 
@@ -84,12 +84,14 @@ func TestGetPatchBytes(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-patch-bytes",
 			Finalizers: []string{"foo"},
+			Tenant:     testTenant,
 		},
 	}
 	updated := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-patch-bytes",
 			Finalizers: []string{"foo", "bar"},
+			Tenant:     testTenant,
 		},
 	}
 

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -755,13 +755,13 @@ func (s *ServiceController) syncService(key string) error {
 		klog.V(4).Infof("Finished syncing service %q (%v)", key, time.Since(startTime))
 	}()
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	tenant, namespace, name, err := cache.SplitMetaTenantNamespaceKey(key)
 	if err != nil {
 		return err
 	}
 
 	// service holds the latest service info from apiserver
-	service, err := s.serviceLister.Services(namespace).Get(name)
+	service, err := s.serviceLister.ServicesWithMultiTenancy(namespace, tenant).Get(name)
 	switch {
 	case errors.IsNotFound(err):
 		// service absence in store means watcher caught the deletion, ensure LB info is cleaned

--- a/pkg/kubelet/dockershim/libdocker/fake_client.go
+++ b/pkg/kubelet/dockershim/libdocker/fake_client.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/kuberuntime/helpers_linux_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -2,6 +2,7 @@
 
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Changes: Converted service controller to multi-tenant

### Manual e2e test using steps in [this doc](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/) :
#### Create deployment and expose service using both system tenant and test tenant:
```bash
TENANT            NAMESPACE             NAME                            HASHKEY               READY   STATUS    RESTARTS   AGE
system            default               pod/my-nginx-5dc984b54d-z675b   4657253913366147043   1/1     Running   0          25s
system            default               pod/my-nginx-5dc984b54d-zl7t9   4449315009755198168   1/1     Running   0          25s
futureweitenant   futurewei-namespace   pod/my-nginx-5dc984b54d-pfftg   590654163509119680    1/1     Running   0          21s
futureweitenant   futurewei-namespace   pod/my-nginx-5dc984b54d-szmzj   2206163685672492177   1/1     Running   0          21s

TENANT            NAMESPACE             NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)         AGE
system            default               service/my-nginx     ClusterIP   10.0.0.183   <none>        80/TCP          9s
futureweitenant   futurewei-namespace   service/my-nginx     ClusterIP   10.0.0.2     <none>        80/TCP          14s
```

Here 1 deployment with 2 pods is created for both tenants. And services were created (exposed) for both tenants.

curl to the cluster-ip verified access was correctly. 

#### Deployments were deleted and serviced removed  successfully for both tenants