### PR TITLE
fix kubectl-create-tenant

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5306,7 +5306,7 @@ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.
 
 // ValidateStorageCluster tests if required fields are set.
 func ValidateStorageCluster(storage *core.StorageCluster) field.ErrorList {
-	allErrs := ValidateObjectMeta(&storage.ObjectMeta, false, false, ValidateTenantName, field.NewPath("metadata"))
+	allErrs := ValidateObjectMeta(&storage.ObjectMeta, false, false, ValidateClusterName, field.NewPath("metadata"))
 	allErrs = append(allErrs, validateStorageClusterId(storage.StorageClusterId, field.NewPath("storageClusterId"))...)
 	allErrs = append(allErrs, validateStorageServiceAddress(storage.ServiceAddress, field.NewPath("serviceAddress"))...)
 	return allErrs
@@ -5323,9 +5323,9 @@ func ValidateStorageClusterUpdate(newStorage, oldStorage *core.StorageCluster) f
 
 // ValidateTenant tests if required fields are set.
 func ValidateTenant(tenant *core.Tenant) field.ErrorList {
-	allErrs := ValidateObjectMeta(&tenant.ObjectMeta, false, false, ValidateClusterName, field.NewPath("metadata"))
+	allErrs := ValidateObjectMeta(&tenant.ObjectMeta, false, false, ValidateTenantName, field.NewPath("metadata"))
+	allErrs = append(allErrs, validateStorageClusterId(tenant.Spec.StorageClusterId, field.NewPath("spec", "storageClusterId"))...)
 	for i := range tenant.Spec.Finalizers {
-		allErrs = append(allErrs, validateStorageClusterId(tenant.Spec.StorageClusterId, field.NewPath("spec", "storageClusterId"))...)
 		allErrs = append(allErrs, validateFinalizerName(string(tenant.Spec.Finalizers[i]), field.NewPath("spec", "finalizers"))...)
 	}
 	return allErrs

--- a/pkg/kubectl/cmd/create/create_tenant.go
+++ b/pkg/kubectl/cmd/create/create_tenant.go
@@ -39,7 +39,9 @@ var (
 	  # Create a new tenant named dreamworld with storage cluster set to c1
 	  kubectl create tenant dreamworld --storagecluster=StorageCluserId=c1`))
 
-	defaultStorageClusterId = "1"
+	//TODO: to refer the default value defined in future storage cluster work, instead of hard-coded
+	//tracking issue: https://github.com/futurewei-cloud/arktos/issues/326
+	defaultStorageClusterId = "system"
 )
 
 // TenantOpts is the options for 'create tenant' sub command
@@ -68,7 +70,7 @@ func NewCmdCreateTenant(f cmdutil.Factory, ioStreams genericclioptions.IOStreams
 	}
 
 	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
-	cmd.Flags().StringVar(&options.storageClusterId, "storagecluster", options.storageClusterId, fmt.Sprintf("Storge Cluster Id, default %v", defaultStorageClusterId))
+	cmd.Flags().StringVar(&options.storageClusterId, "storagecluster", options.storageClusterId, fmt.Sprintf("Storge Cluster Id, by default set to %v", defaultStorageClusterId))
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
@@ -86,6 +88,8 @@ func (o *TenantOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 
 	if o.storageClusterId == "" {
 		o.storageClusterId = defaultStorageClusterId
+		// need to let the user know that we are doing something under the hood
+		cmd.Println("setting storage cluster to %v", defaultStorageClusterId)
 	}
 
 	var generator generate.StructuredGenerator

--- a/pkg/kubectl/generate/versioned/tenant.go
+++ b/pkg/kubectl/generate/versioned/tenant.go
@@ -28,6 +28,8 @@ import (
 type TenantGeneratorV1 struct {
 	// Name of Tenant
 	Name string
+
+	StorageClusterId string
 }
 
 // Ensure it supports the generator pattern that uses parameter injection
@@ -50,7 +52,8 @@ func (g TenantGeneratorV1) Generate(genericParams map[string]interface{}) (runti
 		}
 		params[key] = strVal
 	}
-	delegate := &TenantGeneratorV1{Name: params["name"]}
+
+	delegate := &TenantGeneratorV1{Name: params["name"], StorageClusterId: params["storagecluster"]}
 	return delegate.StructuredGenerate()
 }
 
@@ -58,6 +61,7 @@ func (g TenantGeneratorV1) Generate(genericParams map[string]interface{}) (runti
 func (g TenantGeneratorV1) ParamNames() []generate.GeneratorParam {
 	return []generate.GeneratorParam{
 		{Name: "name", Required: true},
+		{Name: "storagecluster", Required: true},
 	}
 }
 
@@ -68,6 +72,7 @@ func (g *TenantGeneratorV1) StructuredGenerate() (runtime.Object, error) {
 	}
 	Tenant := &v1.Tenant{}
 	Tenant.Name = g.Name
+	Tenant.Spec.StorageClusterId = g.StorageClusterId
 	return Tenant, nil
 }
 
@@ -75,6 +80,9 @@ func (g *TenantGeneratorV1) StructuredGenerate() (runtime.Object, error) {
 func (g *TenantGeneratorV1) validate() error {
 	if len(g.Name) == 0 {
 		return fmt.Errorf("name must be specified")
+	}
+	if len(g.StorageClusterId) == 0 {
+		return fmt.Errorf("StorageClusterId must be specified")
 	}
 	return nil
 }

--- a/pkg/kubectl/generate/versioned/tenant.go
+++ b/pkg/kubectl/generate/versioned/tenant.go
@@ -18,6 +18,7 @@ package versioned
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,8 +82,8 @@ func (g *TenantGeneratorV1) validate() error {
 	if len(g.Name) == 0 {
 		return fmt.Errorf("name must be specified")
 	}
-	if len(g.StorageClusterId) == 0 {
-		return fmt.Errorf("StorageClusterId must be specified")
+	if len(strings.TrimSpace(g.StorageClusterId)) == 0 {
+		return fmt.Errorf("StorageClusterId can not be empty")
 	}
 	return nil
 }

--- a/pkg/kubectl/generate/versioned/tenant_test.go
+++ b/pkg/kubectl/generate/versioned/tenant_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func TestTenantGenerate(t *testing.T) {
@@ -34,11 +35,15 @@ func TestTenantGenerate(t *testing.T) {
 		{
 			name: "test1",
 			params: map[string]interface{}{
-				"name": "foo",
+				"name":           "foo",
+				"storagecluster": "1",
 			},
 			expected: &v1.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
+				},
+				Spec: v1.TenantSpec{
+					StorageClusterId: "1",
 				},
 			},
 			expectErr: false,
@@ -51,21 +56,24 @@ func TestTenantGenerate(t *testing.T) {
 		{
 			name: "test3",
 			params: map[string]interface{}{
-				"name": 1,
+				"name":           1,
+				"storagecluster": "1",
 			},
 			expectErr: true,
 		},
 		{
 			name: "test4",
 			params: map[string]interface{}{
-				"name": "",
+				"name":           "",
+				"storagecluster": "1",
 			},
 			expectErr: true,
 		},
 		{
 			name: "test5",
 			params: map[string]interface{}{
-				"name": nil,
+				"name":           nil,
+				"storagecluster": "1",
 			},
 			expectErr: true,
 		},
@@ -73,13 +81,46 @@ func TestTenantGenerate(t *testing.T) {
 			name: "test6",
 			params: map[string]interface{}{
 				"name_wrong_key": "some_value",
+				"storagecluster": "1",
 			},
 			expectErr: true,
 		},
 		{
 			name: "test7",
 			params: map[string]interface{}{
-				"NAME": "some_value",
+				"NAME":           "some_value",
+				"storagecluster": "1",
+			},
+			expectErr: true,
+		},
+		{
+			name: "test8",
+			params: map[string]interface{}{
+				"name": "foo",
+			},
+			expectErr: true,
+		},
+		{
+			name: "test9",
+			params: map[string]interface{}{
+				"name":           "foo",
+				"storagecluster": "",
+			},
+			expectErr: true,
+		},
+		{
+			name: "test10",
+			params: map[string]interface{}{
+				"name":           "foo",
+				"storagecluster": "     ",
+			},
+			expectErr: true,
+		},
+		{
+			name: "test10",
+			params: map[string]interface{}{
+				"name":           "foo",
+				"storagecluster": nil,
 			},
 			expectErr: true,
 		},

--- a/pkg/registry/core/tenant/storage/storage_test.go
+++ b/pkg/registry/core/tenant/storage/storage_test.go
@@ -263,6 +263,9 @@ func TestUpdateDeletingTenantWithCompleteFinalizers(t *testing.T) {
 			DeletionTimestamp: &now,
 			Finalizers:        []string{"example.com/foo"},
 		},
+		Spec: api.TenantSpec{
+			StorageClusterId: "1",
+		},
 		Status: api.TenantStatus{Phase: api.TenantActive},
 	}
 	if err := storage.store.Storage.Create(ctx, key, tenant, nil, 0, false); err != nil {
@@ -301,7 +304,8 @@ func TestFinalizeDeletingTenantWithCompleteFinalizers(t *testing.T) {
 			DeletionTimestamp: &now,
 		},
 		Spec: api.TenantSpec{
-			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+			StorageClusterId: "1",
+			Finalizers:       []api.FinalizerName{api.FinalizerKubernetes},
 		},
 		Status: api.TenantStatus{Phase: api.TenantActive},
 	}
@@ -342,7 +346,8 @@ func TestFinalizeDeletingTenantWithIncompleteMetadataFinalizers(t *testing.T) {
 			Finalizers:        []string{"example.com/foo"},
 		},
 		Spec: api.TenantSpec{
-			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+			StorageClusterId: "1",
+			Finalizers:       []api.FinalizerName{api.FinalizerKubernetes},
 		},
 		Status: api.TenantStatus{Phase: api.TenantActive},
 	}
@@ -377,7 +382,8 @@ func TestDeleteTenantWithCompleteFinalizers(t *testing.T) {
 			DeletionTimestamp: &now,
 		},
 		Spec: api.TenantSpec{
-			Finalizers: []api.FinalizerName{},
+			StorageClusterId: "1",
+			Finalizers:       []api.FinalizerName{},
 		},
 		Status: api.TenantStatus{Phase: api.TenantActive},
 	}
@@ -578,7 +584,8 @@ func TestDeleteWithGCFinalizers(t *testing.T) {
 				Finalizers: test.existingFinalizers,
 			},
 			Spec: api.TenantSpec{
-				Finalizers: []api.FinalizerName{},
+				StorageClusterId: "1",
+				Finalizers:       []api.FinalizerName{},
 			},
 			Status: api.TenantStatus{Phase: api.TenantActive},
 		}

--- a/test/yaml/apiserver_partition/tenant1.yaml
+++ b/test/yaml/apiserver_partition/tenant1.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Tenant
 metadata:
   name: tenant1
+spec: 
+  storageClusterId: "1"

--- a/test/yaml/apiserver_partition/tenant2.yaml
+++ b/test/yaml/apiserver_partition/tenant2.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Tenant
 metadata:
   name: tenant2
+spec: 
+  storageClusterId: "1"

--- a/test/yaml/multi_tenancy_examples/tenant1.yaml
+++ b/test/yaml/multi_tenancy_examples/tenant1.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Tenant
 metadata:
   name: sample-tenant-1
+spec: 
+  storageClusterId: "1"

--- a/test/yaml/multi_tenancy_examples/tenant2.yaml
+++ b/test/yaml/multi_tenancy_examples/tenant2.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Tenant
 metadata:
   name: sample-tenant-2
+spec: 
+  storageClusterId: "1"


### PR DESCRIPTION
This PR fixes the issue "kubectl create tenant" no longer works due to the requirements StorageClusterId must be specified when creating a new tenant, introduced in https://github.com/futurewei-cloud/arktos/commit/e99e24c64791966b57215078b2dab4a32e75f15c.

Before this change, I hit the following error in my dev box:
```
qianchen@qianchen-VirtualBox:~$ kubectl create tenant test-tenant
The Tenant "test-tenant" is invalid: spec.storageClusterId: Required value: must specify storage cluster id
```

WIth this change, user can specify the storageClusterId when creating a new tenant via the the new commandline option --storagecluster. If this option is not used, the storageclusterId will be set to "1" by default.

Tests done in my dev box:
# Create tenant without specifying --storagecluster
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant john
tenant/john created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl describe tenant john
Name:         john
Namespace:    
Tenant:       
Labels:       <none>
Annotations:  <none>
API Version:  v1
Kind:         Tenant
Metadata:
  Creation Timestamp:  2020-05-29T00:29:35Z
  Hash Key:            3685923843883598169
  Resource Version:    496
  Self Link:           /api/v1/tenants/john
  UID:                 9e52abd9-5008-4c2d-adac-9c0709ea9806
Spec:
  Finalizers:
    kubernetes
  Storage Cluster Id:  1
Status:
  Phase:  Active
Events:   <none>
```

# Create another tenant with option of "--storagecluster"
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant mary --storagecluster myowncluster
tenant/mary created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl describe tenant mary
Name:         mary
Namespace:    
Tenant:       
Labels:       <none>
Annotations:  <none>
API Version:  v1
Kind:         Tenant
Metadata:
  Creation Timestamp:  2020-05-29T00:30:05Z
  Hash Key:            3066964301390518027
  Resource Version:    525
  Self Link:           /api/v1/tenants/mary
  UID:                 9cb31aeb-c6f3-4fc0-a2c7-8fc465f10e8b
Spec:
  Finalizers:
    kubernetes
  Storage Cluster Id:  myowncluster
Status:
  Phase:  Active
Events:   <none>
```