### PR TITLE
fix failure in aws kube-up

### DIFF
--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -130,7 +130,7 @@ func getKubeConfigSpecs(cfg *kubeadmapi.InitConfiguration) (map[string]*kubeConf
 		kubeadmconstants.AdminKubeConfigFileName: {
 			CACert:     caCert,
 			APIServer:  controlPlaneEndpoint,
-			ClientName: "kubernetes-admin",
+			ClientName: "system:kubernetes-admin",
 			ClientCertAuth: &clientCertAuth{
 				CAKey:         caKey,
 				Organizations: []string{kubeadmconstants.SystemPrivilegedGroup},

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -117,7 +117,7 @@ func TestGetKubeConfigSpecs(t *testing.T) {
 		}{
 			{
 				kubeConfigFile: kubeadmconstants.AdminKubeConfigFileName,
-				clientName:     "kubernetes-admin",
+				clientName:     "system:kubernetes-admin",
 				organizations:  []string{kubeadmconstants.SystemPrivilegedGroup},
 			},
 			{


### PR DESCRIPTION
/kind: bugfix

Running the following command for scalability tests in AWS failed.
source aws_kube_params.inc && ./cluster/kube-up.sh

Debugging showed the failure was due to the following error:
"the tenant in the use info kubernetes-admin is empty"

It was verified the kube-up.sh succeeded after applying the fix.