### PR TITLE
external network provider integration support: scheduler holds pods not network ready

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/arktos-ext/pkg/apis/arktosextensions/v1:go_default_library",
         "//staging/src/k8s.io/client-go/informers/apps/v1:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/informers/policy/v1beta1:go_default_library",

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -261,5 +262,56 @@ func TestNodeConditionsChanged(t *testing.T) {
 		if changed != c.Changed {
 			t.Errorf("Test case %q failed: should be %t, got %t", c.Name, c.Changed, changed)
 		}
+	}
+}
+
+func TestPodIsNetworkReady(t *testing.T) {
+	tcs := []struct {
+		desc           string
+		pod            *v1.Pod
+		expectedResult bool
+	}{
+		{
+			desc: "pod without annotation is considered as network ready",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-0",
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			desc: "pod with network-readiness annotation other than true is not network ready",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1",
+					Annotations: map[string]string{
+						"arktos.futurewei.com/network-readiness": "false",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "pod with network-readiness annotation true is network ready",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-2",
+					Annotations: map[string]string{
+						"arktos.futurewei.com/network-readiness": "true",
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := podIsNetworkReady(tc.pod)
+			if tc.expectedResult != result {
+				t.Fatalf("expected %t, got %t", tc.expectedResult, result)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/arktos-ext/go.mod
+++ b/staging/src/k8s.io/arktos-ext/go.mod
@@ -9,9 +9,7 @@ replace (
 )
 
 require (
-	github.com/grafov/bcast v0.0.0-20190217190352-1447f067e08d // indirect
 	github.com/kr/pretty v0.2.0 // indirect
-	gopkg.in/fatih/set.v0 v0.2.1 // indirect
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0-00010101000000-000000000000
 	k8s.io/klog v1.0.0

--- a/staging/src/k8s.io/arktos-ext/pkg/apis/arktosextensions/v1/types.go
+++ b/staging/src/k8s.io/arktos-ext/pkg/apis/arktosextensions/v1/types.go
@@ -20,6 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// NetworkReadiness is the key of annotation network-readiness
+const NetworkReadiness = "arktos.futurewei.com/network-readiness"
+
 // +genclient
 // +genclient:nonNamespaced
 // +genclient:onlyVerbs=create,get,list,watch,updateStatus


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
makes scheduler not to schedule pods that are marked as network not ready.

This is part of external network provider integration support. For more information, please refer to [PR- design proposal: pod annotations as hint & cni args](https://github.com/futurewei-cloud/arktos/pull/341)

**Does this PR introduce a user-facing change?**:
(Partially) Yes
It has no impacts on pods to be scheduled except for those explicitly annotated as network-readiness not true
```release-note
pods explicitly having annotation "arktos.futurewei.com/network-readiness" not "true" are put on hold for scheduling by kube-scheduler
```
