### PR TITLE
create system tenant at tenant controller bootstrap

### DIFF
--- a/pkg/controller/tenant/tenant_controller_test.go
+++ b/pkg/controller/tenant/tenant_controller_test.go
@@ -35,7 +35,8 @@ import (
 )
 
 const (
-	roleActionCountPerBootstrap = 2
+	roleActionCountPerBootstrap          = 2
+	systemTenantCreateActionPerBootstrap = 1
 )
 
 func TestTenantCreation(t *testing.T) {
@@ -71,7 +72,7 @@ func TestTenantCreation(t *testing.T) {
 			},
 			ExpectInitialRole:        initialClusterRole("test-tenant-1"),
 			ExpectInitialRoleBinding: initialClusterRoleBinding("test-tenant-1"),
-			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap,
+			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap + systemTenantCreateActionPerBootstrap,
 		},
 		"new-tenants-with-empty-default-network-tmpl-path": {
 			Tenant: &v1.Tenant{
@@ -85,7 +86,7 @@ func TestTenantCreation(t *testing.T) {
 			ExpectedNetwork:          nil,
 			ExpectInitialRole:        initialClusterRole("test-tenant-2"),
 			ExpectInitialRoleBinding: initialClusterRoleBinding("test-tenant-2"),
-			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap,
+			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap + systemTenantCreateActionPerBootstrap,
 		},
 		"terminating-tenant-not-create-default-network": {
 			Tenant: &v1.Tenant{
@@ -102,7 +103,7 @@ func TestTenantCreation(t *testing.T) {
 			ExpectedNetwork:          nil,
 			ExpectInitialRole:        initialClusterRole("test-tenant-3"),
 			ExpectInitialRoleBinding: initialClusterRoleBinding("test-tenant-3"),
-			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap,
+			ExpectActionCount:        len(tenantDefaultNamespaces) + roleActionCountPerBootstrap + systemTenantCreateActionPerBootstrap,
 		},
 	}
 

--- a/test/integration/tenantcontroller/tenantcontroller_test.go
+++ b/test/integration/tenantcontroller/tenantcontroller_test.go
@@ -82,6 +82,23 @@ func cleanup(t *testing.T, client clientset.Interface, name string) {
 	}
 }
 
+func TestSystemTenantCreatedAutomically(t *testing.T) {
+	_, closeFn, controller, _, clientSet, _ := setup(t)
+	defer closeFn()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	go controller.Run(1, stopCh)
+
+	if err := wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+		_, err := clientSet.CoreV1().Tenants().Get(metav1.TenantSystem, metav1.GetOptions{})
+		return err == nil, err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestClusterRoleAndBindingBootstrap(t *testing.T) {
 	_, closeFn, controller, informerSet, clientSet, _ := setup(t)
 	defer closeFn()


### PR DESCRIPTION
Create the system tenant at boostrap.

Verification Done in Dev Box:
Right after the cluster is up by arktos-up.sh, run the following commands:
```
qianchen@qianchen-VirtualBox:~$ ETCDCTL_API=3 etcdctl get "" --prefix=true --keys-only | grep tenants
/registry/tenants/system

qianchen@qianchen-VirtualBox:~$ kubectl create tenant system
setting storage cluster to system
Error from server (AlreadyExists): tenants "system" already exists
```