### PR TITLE
multi-tenancy resource quota controller (per tenant)

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -45,6 +45,8 @@ import (
 	"k8s.io/kubernetes/pkg/quota/v1/install"
 )
 
+const testTenant = "johndoe"
+
 func getResourceList(cpu, memory string) v1.ResourceList {
 	res := v1.ResourceList{}
 	if cpu != "" {
@@ -144,7 +146,7 @@ func setupQuotaController(t *testing.T, kubeClient kubernetes.Interface, lister 
 func newTestPods() []runtime.Object {
 	return []runtime.Object{
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-running", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-running", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodRunning},
 			Spec: v1.PodSpec{
 				Volumes:    []v1.Volume{{Name: "vol"}},
@@ -152,7 +154,7 @@ func newTestPods() []runtime.Object {
 			},
 		},
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-running-2", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-running-2", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodRunning},
 			Spec: v1.PodSpec{
 				Volumes:    []v1.Volume{{Name: "vol"}},
@@ -160,7 +162,7 @@ func newTestPods() []runtime.Object {
 			},
 		},
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-failed", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-failed", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodFailed},
 			Spec: v1.PodSpec{
 				Volumes:    []v1.Volume{{Name: "vol"}},
@@ -173,7 +175,7 @@ func newTestPods() []runtime.Object {
 func newBestEffortTestPods() []runtime.Object {
 	return []runtime.Object{
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-running", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-running", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodRunning},
 			Spec: v1.PodSpec{
 				Volumes:    []v1.Volume{{Name: "vol"}},
@@ -181,7 +183,7 @@ func newBestEffortTestPods() []runtime.Object {
 			},
 		},
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-running-2", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-running-2", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodRunning},
 			Spec: v1.PodSpec{
 				Volumes:    []v1.Volume{{Name: "vol"}},
@@ -189,7 +191,7 @@ func newBestEffortTestPods() []runtime.Object {
 			},
 		},
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-failed", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-failed", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodFailed},
 			Spec: v1.PodSpec{
 				Volumes:    []v1.Volume{{Name: "vol"}},
@@ -202,7 +204,7 @@ func newBestEffortTestPods() []runtime.Object {
 func newTestPodsWithPriorityClasses() []runtime.Object {
 	return []runtime.Object{
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-running", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-running", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodRunning},
 			Spec: v1.PodSpec{
 				Volumes:           []v1.Volume{{Name: "vol"}},
@@ -211,7 +213,7 @@ func newTestPodsWithPriorityClasses() []runtime.Object {
 			},
 		},
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-running-2", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-running-2", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodRunning},
 			Spec: v1.PodSpec{
 				Volumes:           []v1.Volume{{Name: "vol"}},
@@ -220,7 +222,7 @@ func newTestPodsWithPriorityClasses() []runtime.Object {
 			},
 		},
 		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-failed", Namespace: "testing", Tenant: metav1.TenantSystem},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-failed", Namespace: "testing", Tenant: testTenant},
 			Status:     v1.PodStatus{Phase: v1.PodFailed},
 			Spec: v1.PodSpec{
 				Volumes:    []v1.Volume{{Name: "vol"}},
@@ -243,7 +245,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"non-matching-best-effort-scoped-quota": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -273,7 +275,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"matching-best-effort-scoped-quota": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -303,7 +305,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"non-matching-priorityclass-scoped-quota-OpExists": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -339,7 +341,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"matching-priorityclass-scoped-quota-OpExists": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -375,7 +377,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"matching-priorityclass-scoped-quota-OpIn": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -413,7 +415,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"matching-priorityclass-scoped-quota-OpIn-high": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -451,7 +453,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"matching-priorityclass-scoped-quota-OpIn-low": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -489,7 +491,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"matching-priorityclass-scoped-quota-OpNotIn-low": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -527,7 +529,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"non-matching-priorityclass-scoped-quota-OpIn": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -565,7 +567,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"non-matching-priorityclass-scoped-quota-OpNotIn": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -603,7 +605,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"matching-priorityclass-scoped-quota-OpDoesNotExist": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -640,7 +642,7 @@ func TestSyncResourceQuota(t *testing.T) {
 		"pods": {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: metav1.TenantSystem},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing", Tenant: testTenant},
 				Spec: v1.ResourceQuotaSpec{
 					Hard: v1.ResourceList{
 						v1.ResourceCPU:    resource.MustParse("3"),
@@ -670,7 +672,7 @@ func TestSyncResourceQuota(t *testing.T) {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -705,7 +707,7 @@ func TestSyncResourceQuota(t *testing.T) {
 			gvr: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -735,7 +737,7 @@ func TestSyncResourceQuota(t *testing.T) {
 			errorGVR: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -760,7 +762,7 @@ func TestSyncResourceQuota(t *testing.T) {
 			errorGVR: v1.SchemeGroupVersion.WithResource("pods"),
 			quota: v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -870,7 +872,7 @@ func TestAddQuota(t *testing.T) {
 			expectedPriority: true,
 			quota: &v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -886,7 +888,7 @@ func TestAddQuota(t *testing.T) {
 			expectedPriority: true,
 			quota: &v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -907,7 +909,7 @@ func TestAddQuota(t *testing.T) {
 			expectedPriority: true,
 			quota: &v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -928,7 +930,7 @@ func TestAddQuota(t *testing.T) {
 			expectedPriority: true,
 			quota: &v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -952,7 +954,7 @@ func TestAddQuota(t *testing.T) {
 			expectedPriority: false,
 			quota: &v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},
@@ -973,7 +975,7 @@ func TestAddQuota(t *testing.T) {
 			expectedPriority: false,
 			quota: &v1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:    metav1.TenantSystem,
+					Tenant:    testTenant,
 					Namespace: "default",
 					Name:      "rq",
 				},

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -351,7 +352,8 @@ func (qm *QuotaMonitor) processResourceChanges() bool {
 		utilruntime.HandleError(fmt.Errorf("cannot access obj: %v", err))
 		return true
 	}
-	klog.V(4).Infof("QuotaMonitor process object: %s, namespace %s, name %s, uid %s, event type %v", event.gvr.String(), accessor.GetNamespace(), accessor.GetName(), string(accessor.GetUID()), event.eventType)
-	qm.replenishmentFunc(event.gvr.GroupResource(), accessor.GetNamespace())
+	klog.V(4).Infof("QuotaMonitor process object: %s, tenant %s, namespace %s, name %s, uid %s, event type %v",
+		event.gvr.String(), accessor.GetTenant(), accessor.GetNamespace(), accessor.GetName(), string(accessor.GetUID()), event.eventType)
+	qm.replenishmentFunc(event.gvr.GroupResource(), accessor.GetNamespace(), accessor.GetTenant())
 	return true
 }

--- a/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
+++ b/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -66,15 +67,15 @@ func V1ResourceByStorageClass(storageClass string, resourceName corev1.ResourceN
 
 // NewPersistentVolumeClaimEvaluator returns an evaluator that can evaluate persistent volume claims
 func NewPersistentVolumeClaimEvaluator(f quota.ListerForResourceFunc) quota.Evaluator {
-	listFuncByNamespace := generic.ListResourceUsingListerFunc(f, corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"))
-	pvcEvaluator := &pvcEvaluator{listFuncByNamespace: listFuncByNamespace}
+	listFuncByTenantAndNamespace := generic.ListResourceUsingListerFunc(f, corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"))
+	pvcEvaluator := &pvcEvaluator{listFuncByTenantAndNamespace: listFuncByTenantAndNamespace}
 	return pvcEvaluator
 }
 
 // pvcEvaluator knows how to evaluate quota usage for persistent volume claims
 type pvcEvaluator struct {
-	// listFuncByNamespace knows how to list pvc claims
-	listFuncByNamespace generic.ListFuncByNamespace
+	// listFuncByTenantAndNamespace knows how to list pvc claims
+	listFuncByTenantAndNamespace generic.ListFuncByTenantAndNamespace
 }
 
 // Constraints verifies that all required resources are present on the item.
@@ -173,7 +174,7 @@ func (p *pvcEvaluator) Usage(item runtime.Object) (corev1.ResourceList, error) {
 
 // UsageStats calculates aggregate usage for the object.
 func (p *pvcEvaluator) UsageStats(options quota.UsageStatsOptions) (quota.UsageStats, error) {
-	return generic.CalculateUsageStats(options, p.listFuncByNamespace, generic.MatchesNoScopeFunc, p.Usage)
+	return generic.CalculateUsageStats(options, p.listFuncByTenantAndNamespace, generic.MatchesNoScopeFunc, p.Usage)
 }
 
 // ensure we implement required interface

--- a/pkg/quota/v1/evaluator/core/pods.go
+++ b/pkg/quota/v1/evaluator/core/pods.go
@@ -101,15 +101,15 @@ var validationSet = sets.NewString(
 
 // NewPodEvaluator returns an evaluator that can evaluate pods
 func NewPodEvaluator(f quota.ListerForResourceFunc, clock clock.Clock) quota.Evaluator {
-	listFuncByNamespace := generic.ListResourceUsingListerFunc(f, corev1.SchemeGroupVersion.WithResource("pods"))
-	podEvaluator := &podEvaluator{listFuncByNamespace: listFuncByNamespace, clock: clock}
+	listFuncByTenantNamespace := generic.ListResourceUsingListerFunc(f, corev1.SchemeGroupVersion.WithResource("pods"))
+	podEvaluator := &podEvaluator{listFuncByTenantAndNamespace: listFuncByTenantNamespace, clock: clock}
 	return podEvaluator
 }
 
 // podEvaluator knows how to measure usage of pods.
 type podEvaluator struct {
 	// knows how to list pods
-	listFuncByNamespace generic.ListFuncByNamespace
+	listFuncByTenantAndNamespace generic.ListFuncByTenantAndNamespace
 	// used to track time
 	clock clock.Clock
 }
@@ -219,7 +219,7 @@ func (p *podEvaluator) Usage(item runtime.Object) (corev1.ResourceList, error) {
 
 // UsageStats calculates aggregate usage for the object.
 func (p *podEvaluator) UsageStats(options quota.UsageStatsOptions) (quota.UsageStats, error) {
-	return generic.CalculateUsageStats(options, p.listFuncByNamespace, podMatchesScopeFunc, p.Usage)
+	return generic.CalculateUsageStats(options, p.listFuncByTenantAndNamespace, podMatchesScopeFunc, p.Usage)
 }
 
 // verifies we implement the required interface.

--- a/pkg/quota/v1/evaluator/core/services.go
+++ b/pkg/quota/v1/evaluator/core/services.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -43,15 +44,15 @@ var serviceResources = []corev1.ResourceName{
 
 // NewServiceEvaluator returns an evaluator that can evaluate services.
 func NewServiceEvaluator(f quota.ListerForResourceFunc) quota.Evaluator {
-	listFuncByNamespace := generic.ListResourceUsingListerFunc(f, corev1.SchemeGroupVersion.WithResource("services"))
-	serviceEvaluator := &serviceEvaluator{listFuncByNamespace: listFuncByNamespace}
+	listFuncByTenantAndNamespace := generic.ListResourceUsingListerFunc(f, corev1.SchemeGroupVersion.WithResource("services"))
+	serviceEvaluator := &serviceEvaluator{listFuncByTenantAndNamespace: listFuncByTenantAndNamespace}
 	return serviceEvaluator
 }
 
 // serviceEvaluator knows how to measure usage for services.
 type serviceEvaluator struct {
 	// knows how to list items by namespace
-	listFuncByNamespace generic.ListFuncByNamespace
+	listFuncByTenantAndNamespace generic.ListFuncByTenantAndNamespace
 }
 
 // Constraints verifies that all required resources are present on the item
@@ -138,7 +139,7 @@ func (p *serviceEvaluator) Usage(item runtime.Object) (corev1.ResourceList, erro
 
 // UsageStats calculates aggregate usage for the object.
 func (p *serviceEvaluator) UsageStats(options quota.UsageStatsOptions) (quota.UsageStats, error) {
-	return generic.CalculateUsageStats(options, p.listFuncByNamespace, generic.MatchesNoScopeFunc, p.Usage)
+	return generic.CalculateUsageStats(options, p.listFuncByTenantAndNamespace, generic.MatchesNoScopeFunc, p.Usage)
 }
 
 var _ quota.Evaluator = &serviceEvaluator{}

--- a/pkg/quota/v1/interfaces.go
+++ b/pkg/quota/v1/interfaces.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,6 +27,7 @@ import (
 
 // UsageStatsOptions is an options structs that describes how stats should be calculated
 type UsageStatsOptions struct {
+	Tenant string
 	// Namespace where stats should be calculate
 	Namespace string
 	// Scopes that must match counted objects

--- a/pkg/quota/v1/resources.go
+++ b/pkg/quota/v1/resources.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -269,7 +270,7 @@ func ToSet(resourceNames []corev1.ResourceName) sets.String {
 
 // CalculateUsage calculates and returns the requested ResourceList usage.
 // If an error is returned, usage only contains the resources which encountered no calculation errors.
-func CalculateUsage(namespaceName string, scopes []corev1.ResourceQuotaScope, hardLimits corev1.ResourceList, registry Registry, scopeSelector *corev1.ScopeSelector) (corev1.ResourceList, error) {
+func CalculateUsage(tenant string, namespace string, scopes []corev1.ResourceQuotaScope, hardLimits corev1.ResourceList, registry Registry, scopeSelector *corev1.ScopeSelector) (corev1.ResourceList, error) {
 	// find the intersection between the hard resources on the quota
 	// and the resources this controller can track to know what we can
 	// look to measure updated usage stats for
@@ -293,7 +294,13 @@ func CalculateUsage(namespaceName string, scopes []corev1.ResourceQuotaScope, ha
 			continue
 		}
 
-		usageStatsOptions := UsageStatsOptions{Namespace: namespaceName, Scopes: scopes, Resources: intersection, ScopeSelector: scopeSelector}
+		usageStatsOptions := UsageStatsOptions{
+			Tenant:        tenant,
+			Namespace:     namespace,
+			Scopes:        scopes,
+			Resources:     intersection,
+			ScopeSelector: scopeSelector,
+		}
 		stats, err := evaluator.UsageStats(usageStatsOptions)
 		if err != nil {
 			// remember the error

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -51,7 +52,7 @@ func Register(plugins *admission.Plugins) {
 					return nil, errs.ToAggregate()
 				}
 			}
-			return NewResourceQuota(configuration, 5, make(chan struct{}))
+			return NewResourceQuotaAdmission(configuration, 5, make(chan struct{}))
 		})
 }
 
@@ -76,10 +77,10 @@ type liveLookupEntry struct {
 	items  []*corev1.ResourceQuota
 }
 
-// NewResourceQuota configures an admission controller that can enforce quota constraints
+// NewResourceQuotaAdmission configures an admission controller that can enforce quota constraints
 // using the provided registry.  The registry must have the capability to handle group/kinds that
 // are persisted by the server this admission controller is intercepting
-func NewResourceQuota(config *resourcequotaapi.Configuration, numEvaluators int, stopCh <-chan struct{}) (*QuotaAdmission, error) {
+func NewResourceQuotaAdmission(config *resourcequotaapi.Configuration, numEvaluators int, stopCh <-chan struct{}) (*QuotaAdmission, error) {
 	quotaAccessor, err := newQuotaAccessor()
 	if err != nil {
 		return nil, err

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -45,6 +45,11 @@ import (
 	resourcequotaapi "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota"
 )
 
+const (
+	testTenant    = "johndoe"
+	testNamespace = "test"
+)
+
 func getResourceList(cpu, memory string) api.ResourceList {
 	res := api.ResourceList{}
 	if cpu != "" {
@@ -65,8 +70,12 @@ func getResourceRequirements(requests, limits api.ResourceList) api.ResourceRequ
 
 func validPod(name string, numContainers int, resources api.ResourceRequirements) *api.Pod {
 	pod := &api.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test", Tenant: metav1.TenantSystem},
-		Spec:       api.PodSpec{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Tenant:    testTenant,
+		},
+		Spec: api.PodSpec{},
 	}
 	pod.Spec.Containers = make([]api.Container, 0, numContainers)
 	for i := 0; i < numContainers; i++ {
@@ -88,7 +97,7 @@ func validPodWithPriority(name string, numContainers int, resources api.Resource
 
 func validPersistentVolumeClaim(name string, resources api.ResourceRequirements) *api.PersistentVolumeClaim {
 	return &api.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test", Tenant: metav1.TenantSystem},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, Tenant: testTenant},
 		Spec: api.PersistentVolumeClaimSpec{
 			Resources: resources,
 		},
@@ -154,7 +163,7 @@ func TestAdmissionIgnoresDelete(t *testing.T) {
 		evaluator: evaluator,
 	}
 	namespace := "default"
-	tenant := metav1.TenantSystem
+	tenant := testTenant
 	err := handler.Validate(admission.NewAttributesRecord(nil, nil, api.Kind("Pod").WithVersion("version"), tenant, namespace, "name", corev1.Resource("pods").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil), nil)
 	if err != nil {
 		t.Errorf("ResourceQuota should admit all deletes: %v", err)
@@ -167,8 +176,8 @@ func TestAdmissionIgnoresDelete(t *testing.T) {
 func TestAdmissionIgnoresSubresources(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{}
 	resourceQuota.Name = "quota"
-	resourceQuota.Namespace = "test"
-	resourceQuota.Tenant = metav1.TenantSystem
+	resourceQuota.Namespace = testNamespace
+	resourceQuota.Tenant = testTenant
 	resourceQuota.Status = corev1.ResourceQuotaStatus{
 		Hard: corev1.ResourceList{},
 		Used: corev1.ResourceList{},
@@ -206,7 +215,7 @@ func TestAdmissionIgnoresSubresources(t *testing.T) {
 // TestAdmitBelowQuotaLimit verifies that a pod when created has its usage reflected on the quota
 func TestAdmitBelowQuotaLimit(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("3"),
@@ -288,7 +297,7 @@ func TestAdmitBelowQuotaLimit(t *testing.T) {
 // and that dry-run requests can still be rejected if they would exceed the quota
 func TestAdmitDryRun(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("3"),
@@ -341,7 +350,7 @@ func TestAdmitDryRun(t *testing.T) {
 func TestAdmitHandlesOldObjects(t *testing.T) {
 	// in this scenario, the old quota was based on a service type=loadbalancer
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceServices:              resource.MustParse("10"),
@@ -377,11 +386,11 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 
 	// old service was a load balancer, but updated version is a node port.
 	existingService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "1"},
 		Spec:       api.ServiceSpec{Type: api.ServiceTypeLoadBalancer},
 	}
 	newService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant},
 		Spec: api.ServiceSpec{
 			Type:  api.ServiceTypeNodePort,
 			Ports: []api.ServicePort{{Port: 1234}},
@@ -440,7 +449,7 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 
 func TestAdmitHandlesNegativePVCUpdates(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourcePersistentVolumeClaims: resource.MustParse("3"),
@@ -475,14 +484,14 @@ func TestAdmitHandlesNegativePVCUpdates(t *testing.T) {
 	informerFactory.Core().V1().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 
 	oldPVC := &api.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "1"},
 		Spec: api.PersistentVolumeClaimSpec{
 			Resources: getResourceRequirements(api.ResourceList{api.ResourceStorage: resource.MustParse("10Gi")}, api.ResourceList{}),
 		},
 	}
 
 	newPVC := &api.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: "test", Tenant: metav1.TenantSystem},
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: testNamespace, Tenant: testTenant},
 		Spec: api.PersistentVolumeClaimSpec{
 			Resources: getResourceRequirements(api.ResourceList{api.ResourceStorage: resource.MustParse("5Gi")}, api.ResourceList{}),
 		},
@@ -499,7 +508,7 @@ func TestAdmitHandlesNegativePVCUpdates(t *testing.T) {
 
 func TestAdmitHandlesPVCUpdates(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourcePersistentVolumeClaims: resource.MustParse("3"),
@@ -534,14 +543,14 @@ func TestAdmitHandlesPVCUpdates(t *testing.T) {
 	informerFactory.Core().V1().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 
 	oldPVC := &api.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "1"},
 		Spec: api.PersistentVolumeClaimSpec{
 			Resources: getResourceRequirements(api.ResourceList{api.ResourceStorage: resource.MustParse("10Gi")}, api.ResourceList{}),
 		},
 	}
 
 	newPVC := &api.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: "test", Tenant: metav1.TenantSystem},
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: testNamespace, Tenant: testTenant},
 		Spec: api.PersistentVolumeClaimSpec{
 			Resources: getResourceRequirements(api.ResourceList{api.ResourceStorage: resource.MustParse("15Gi")}, api.ResourceList{}),
 		},
@@ -598,7 +607,7 @@ func TestAdmitHandlesPVCUpdates(t *testing.T) {
 func TestAdmitHandlesCreatingUpdates(t *testing.T) {
 	// in this scenario, there is an existing service
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceServices:              resource.MustParse("10"),
@@ -634,11 +643,11 @@ func TestAdmitHandlesCreatingUpdates(t *testing.T) {
 
 	// old service didn't exist, so this update is actually a create
 	oldService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: ""},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: ""},
 		Spec:       api.ServiceSpec{Type: api.ServiceTypeLoadBalancer},
 	}
 	newService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant},
 		Spec: api.ServiceSpec{
 			Type:  api.ServiceTypeNodePort,
 			Ports: []api.ServicePort{{Port: 1234}},
@@ -695,7 +704,7 @@ func TestAdmitHandlesCreatingUpdates(t *testing.T) {
 // TestAdmitExceedQuotaLimit verifies that if a pod exceeded allowed usage that its rejected during admission.
 func TestAdmitExceedQuotaLimit(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("3"),
@@ -738,7 +747,7 @@ func TestAdmitExceedQuotaLimit(t *testing.T) {
 // We ensure that a pod that does not specify a memory limit that it fails in admission.
 func TestAdmitEnforceQuotaConstraints(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceCPU:          resource.MustParse("3"),
@@ -835,7 +844,7 @@ func TestAdmitPodInNamespaceWithoutQuota(t *testing.T) {
 // It ensures that the terminating quota is incremented, and the non-terminating quota is not.
 func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 	resourceQuotaNonTerminating := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota-non-terminating", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-non-terminating", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Spec: corev1.ResourceQuotaSpec{
 			Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeNotTerminating},
 		},
@@ -853,7 +862,7 @@ func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 		},
 	}
 	resourceQuotaTerminating := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota-terminating", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-terminating", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Spec: corev1.ResourceQuotaSpec{
 			Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeTerminating},
 		},
@@ -949,7 +958,7 @@ func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 // It verifies that best effort pods are properly scoped to the best effort quota document.
 func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
 	resourceQuotaBestEffort := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Spec: corev1.ResourceQuotaSpec{
 			Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort},
 		},
@@ -963,7 +972,7 @@ func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
 		},
 	}
 	resourceQuotaNotBestEffort := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota-not-besteffort", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-not-besteffort", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Spec: corev1.ResourceQuotaSpec{
 			Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeNotBestEffort},
 		},
@@ -1056,7 +1065,7 @@ func removeListWatch(in []testcore.Action) []testcore.Action {
 // guaranteed pod.
 func TestAdmitBestEffortQuotaLimitIgnoresBurstable(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Spec: corev1.ResourceQuotaSpec{
 			Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort},
 		},
@@ -1161,8 +1170,8 @@ func TestHasUsageStats(t *testing.T) {
 // TestAdmissionSetsMissingNamespace verifies that if an object lacks a
 // namespace, it will be set.
 func TestAdmissionSetsMissingNamespace(t *testing.T) {
-	namespace := "test"
-	tenant := metav1.TenantSystem
+	namespace := testNamespace
+	tenant := testTenant
 	resourceQuota := &corev1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: namespace, Tenant: tenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
@@ -1209,7 +1218,7 @@ func TestAdmissionSetsMissingNamespace(t *testing.T) {
 // TestAdmitRejectsNegativeUsage verifies that usage for any measured resource cannot be negative.
 func TestAdmitRejectsNegativeUsage(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourcePersistentVolumeClaims: resource.MustParse("3"),
@@ -1256,7 +1265,7 @@ func TestAdmitRejectsNegativeUsage(t *testing.T) {
 // TestAdmitWhenUnrelatedResourceExceedsQuota verifies that if resource X exceeds quota, it does not prohibit resource Y from admission.
 func TestAdmitWhenUnrelatedResourceExceedsQuota(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceServices: resource.MustParse("3"),
@@ -1365,7 +1374,7 @@ func TestAdmitLimitedResourceNoQuotaIgnoresNonMatchingResources(t *testing.T) {
 // TestAdmitLimitedResourceWithQuota verifies if a limited resource is configured with quota, it can be consumed.
 func TestAdmitLimitedResourceWithQuota(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceRequestsCPU: resource.MustParse("10"),
@@ -1413,7 +1422,7 @@ func TestAdmitLimitedResourceWithQuota(t *testing.T) {
 // TestAdmitLimitedResourceWithMultipleQuota verifies if a limited resource is configured with quota, it can be consumed if one matches.
 func TestAdmitLimitedResourceWithMultipleQuota(t *testing.T) {
 	resourceQuota1 := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota1", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota1", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceRequestsCPU: resource.MustParse("10"),
@@ -1424,7 +1433,7 @@ func TestAdmitLimitedResourceWithMultipleQuota(t *testing.T) {
 		},
 	}
 	resourceQuota2 := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota2", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota2", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("10Gi"),
@@ -1473,7 +1482,7 @@ func TestAdmitLimitedResourceWithMultipleQuota(t *testing.T) {
 // TestAdmitLimitedResourceWithQuotaThatDoesNotCover verifies if a limited resource is configured the quota must cover the resource.
 func TestAdmitLimitedResourceWithQuotaThatDoesNotCover(t *testing.T) {
 	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("10Gi"),
@@ -1532,7 +1541,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Covering quota exists for configured limited scope PriorityClassNameExists.",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")), "fake-priority"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -1562,7 +1571,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "configured limited scope PriorityClassNameExists and limited cpu resource. No covering quota for cpu and pod admit fails.",
 			testPod:     validPodWithPriority("not-allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")), "fake-priority"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -1631,7 +1640,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Covering quota exist for configured limited scope resourceQuotaBestEffort",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")), "fake-priority"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort},
 				},
@@ -1779,7 +1788,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Two scopes,BestEffort and PriorityClassIN, in two LimitedResources. Both the scopes matches pod. Quota available only for BestEffort scope. Pod admit fails because covering quota is missing for PriorityClass scope",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")), "cluster-services"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort},
 				},
@@ -1821,7 +1830,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Two scopes,BestEffort and PriorityClassIN, in two LimitedResources. Both the scopes matches pod. Quota available only for PriorityClass scope. Pod admit fails because covering quota is missing for BestEffort scope",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")), "cluster-services"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -1863,7 +1872,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Two scopes,BestEffort and PriorityClassIN, in two LimitedResources. Both the scopes matches pod. Quota available only for both the scopes. Pod admit success. No Error",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")), "cluster-services"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota-besteffort", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					Scopes: []corev1.ResourceQuotaScope{corev1.ResourceQuotaScopeBestEffort},
 				},
@@ -1877,7 +1886,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 				},
 			},
 			anotherQuota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -1926,7 +1935,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "quota fails, though covering quota for configured limited scope PriorityClassNameExists exists.",
 			testPod:     validPodWithPriority("not-allowed-pod", 1, getResourceRequirements(getResourceList("3", "20Gi"), getResourceList("", "")), "fake-priority"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -1964,7 +1973,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Pod has different priorityclass than configured limited. Covering quota exists for configured limited scope PriorityClassIn.",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")), "fake-priority"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -1997,7 +2006,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Pod has limited priorityclass. Covering quota exists for configured limited scope PriorityClassIn.",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")), "cluster-services"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -2030,7 +2039,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Pod has limited priorityclass. Covering quota  does not exist for configured limited scope PriorityClassIn.",
 			testPod:     validPodWithPriority("not-allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")), "cluster-services"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -2063,7 +2072,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "From the above test case, just changing pod priority from cluster-services to another-priorityclass-name. expecting no error",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")), "another-priorityclass-name"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -2116,7 +2125,7 @@ func TestAdmitLimitedScopeWithCoverQuota(t *testing.T) {
 			description: "Pod has limited priorityclass. Covering quota exists for configured limited scope PriorityClassIn through PriorityClassNameExists",
 			testPod:     validPodWithPriority("allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")), "cluster-services"),
 			quota: &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "124"},
+				ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "124"},
 				Spec: corev1.ResourceQuotaSpec{
 					ScopeSelector: &corev1.ScopeSelector{
 						MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
@@ -2217,11 +2226,11 @@ func TestAdmitZeroDeltaUsageWithoutCoveringQuota(t *testing.T) {
 	}
 
 	existingService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "1"},
 		Spec:       api.ServiceSpec{Type: api.ServiceTypeLoadBalancer},
 	}
 	newService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant},
 		Spec:       api.ServiceSpec{Type: api.ServiceTypeLoadBalancer},
 	}
 
@@ -2260,14 +2269,14 @@ func TestAdmitRejectIncreaseUsageWithoutCoveringQuota(t *testing.T) {
 	}
 
 	existingService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "1"},
 		Spec: api.ServiceSpec{
 			Type:  api.ServiceTypeNodePort,
 			Ports: []api.ServicePort{{Port: 1234}},
 		},
 	}
 	newService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant},
 		Spec:       api.ServiceSpec{Type: api.ServiceTypeLoadBalancer},
 	}
 
@@ -2306,11 +2315,11 @@ func TestAdmitAllowDecreaseUsageWithoutCoveringQuota(t *testing.T) {
 	}
 
 	existingService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem, ResourceVersion: "1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant, ResourceVersion: "1"},
 		Spec:       api.ServiceSpec{Type: api.ServiceTypeLoadBalancer},
 	}
 	newService := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "test", Tenant: metav1.TenantSystem},
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: testNamespace, Tenant: testTenant},
 		Spec: api.ServiceSpec{
 			Type:  api.ServiceTypeNodePort,
 			Ports: []api.ServicePort{{Port: 1234}},

--- a/test/integration/quota/BUILD
+++ b/test/integration/quota/BUILD
@@ -12,6 +12,7 @@ go_test(
         "main_test.go",
         "quota_test.go",
     ],
+    args = ["-test.v"],
     tags = ["integration"],
     deps = [
         "//pkg/controller:go_default_library",


### PR DESCRIPTION
This changes convert the resource quota controller to multi-tenant. This resource quota is within a certain tenant.

The unit tests and integration tests are modified. Will bring in more manual tests but review can start now. 