### PR TITLE
using new tenanted user info in integration tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
@@ -46,6 +46,7 @@ func (g *GroupAdder) AuthenticateRequest(req *http.Request) (*authenticator.Resp
 		UID:    r.User.GetUID(),
 		Groups: append(r.User.GetGroups(), g.Groups...),
 		Extra:  r.User.GetExtra(),
+		Tenant: r.User.GetTenant(),
 	}
 	return r, true, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
@@ -29,7 +29,7 @@ func TestGroupAdder(t *testing.T) {
 	adder := authenticator.Request(
 		NewGroupAdder(
 			authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
-				return &authenticator.Response{User: &user.DefaultInfo{Name: "user", Groups: []string{"original"}}}, true, nil
+				return &authenticator.Response{User: &user.DefaultInfo{Tenant: "test-tenant", Name: "user", Groups: []string{"original"}}}, true, nil
 			}),
 			[]string{"added"},
 		),
@@ -52,10 +52,12 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 			inputUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{"some-group"},
+				Tenant: "test-tenant",
 			},
 			expectedUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{"some-group", user.AllAuthenticated},
+				Tenant: "test-tenant",
 			},
 		},
 		{
@@ -63,10 +65,12 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 			inputUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{user.AllAuthenticated, "some-group"},
+				Tenant: "test-tenant",
 			},
 			expectedUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{user.AllAuthenticated, "some-group"},
+				Tenant: "test-tenant",
 			},
 		},
 		{
@@ -74,10 +78,12 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 			inputUser: &user.DefaultInfo{
 				Name:   user.Anonymous,
 				Groups: []string{"some-group"},
+				Tenant: "test-tenant",
 			},
 			expectedUser: &user.DefaultInfo{
 				Name:   user.Anonymous,
 				Groups: []string{"some-group"},
+				Tenant: "test-tenant",
 			},
 		},
 		{
@@ -85,10 +91,12 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 			inputUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{user.AllUnauthenticated, "some-group"},
+				Tenant: "test-tenant",
 			},
 			expectedUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{user.AllUnauthenticated, "some-group"},
+				Tenant: "test-tenant",
 			},
 		},
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
@@ -26,11 +26,15 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
+const (
+	testTenant = "test-tenant"
+)
+
 func TestGroupAdder(t *testing.T) {
 	adder := authenticator.Request(
 		NewGroupAdder(
 			authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
-				return &authenticator.Response{User: &user.DefaultInfo{Tenant: "test-tenant", Name: "user", Groups: []string{"original"}}}, true, nil
+				return &authenticator.Response{User: &user.DefaultInfo{Tenant: testTenant, Name: "user", Groups: []string{"original"}}}, true, nil
 			}),
 			[]string{"added"},
 		),
@@ -53,12 +57,12 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 			inputUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{"some-group"},
-				Tenant: "test-tenant",
+				Tenant: testTenant,
 			},
 			expectedUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{"some-group", user.AllAuthenticated},
-				Tenant: "test-tenant",
+				Tenant: testTenant,
 			},
 		},
 		{
@@ -66,12 +70,12 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 			inputUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{user.AllAuthenticated, "some-group"},
-				Tenant: "test-tenant",
+				Tenant: testTenant,
 			},
 			expectedUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{user.AllAuthenticated, "some-group"},
-				Tenant: "test-tenant",
+				Tenant: testTenant,
 			},
 		},
 		{
@@ -79,12 +83,12 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 			inputUser: &user.DefaultInfo{
 				Name:   user.Anonymous,
 				Groups: []string{"some-group"},
-				Tenant: "test-tenant",
+				Tenant: testTenant,
 			},
 			expectedUser: &user.DefaultInfo{
 				Name:   user.Anonymous,
 				Groups: []string{"some-group"},
-				Tenant: "test-tenant",
+				Tenant: testTenant,
 			},
 		},
 		{
@@ -92,12 +96,12 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 			inputUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{user.AllUnauthenticated, "some-group"},
-				Tenant: "test-tenant",
+				Tenant: testTenant,
 			},
 			expectedUser: &user.DefaultInfo{
 				Name:   "user",
 				Groups: []string{user.AllUnauthenticated, "some-group"},
-				Tenant: "test-tenant",
+				Tenant: testTenant,
 			},
 		},
 	}

--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	testTenant string = metav1.TenantSystem
+	testTenant string = "fake-tenant"
 )
 
 // Inject into master an authorizer that uses user info.

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -318,7 +318,7 @@ func TestRBAC(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "read-pods"},
 						Subjects: []rbacapi.Subject{
-							{Kind: "User", Name: "system:pod-reader"},
+							{Kind: "User", Name: "pod-reader"},
 						},
 						RoleRef: rbacapi.RoleRef{Kind: "ClusterRole", Name: "read-pods"},
 					},
@@ -363,41 +363,41 @@ func TestRBAC(t *testing.T) {
 				clusterRoleBindings: []rbacapi.ClusterRoleBinding{
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "write-jobs"},
-						Subjects:   []rbacapi.Subject{{Kind: "User", Name: "system:job-writer"}},
+						Subjects:   []rbacapi.Subject{{Kind: "User", Name: "job-writer"}},
 						RoleRef:    rbacapi.RoleRef{Kind: "ClusterRole", Name: "write-jobs"},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "create-rolebindings"},
 						Subjects: []rbacapi.Subject{
-							{Kind: "User", Name: "system:job-writer"},
-							{Kind: "User", Name: "system:nonescalating-rolebinding-writer"},
-							{Kind: "User", Name: "system:any-rolebinding-writer"},
+							{Kind: "User", Name: "job-writer"},
+							{Kind: "User", Name: "nonescalating-rolebinding-writer"},
+							{Kind: "User", Name: "any-rolebinding-writer"},
 						},
 						RoleRef: rbacapi.RoleRef{Kind: "ClusterRole", Name: "create-rolebindings"},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "bind-any-clusterrole"},
-						Subjects:   []rbacapi.Subject{{Kind: "User", Name: "system:any-rolebinding-writer"}},
+						Subjects:   []rbacapi.Subject{{Kind: "User", Name: "any-rolebinding-writer"}},
 						RoleRef:    rbacapi.RoleRef{Kind: "ClusterRole", Name: "bind-any-clusterrole"},
 					},
 				},
 				roleBindings: []rbacapi.RoleBinding{
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "write-jobs", Namespace: "job-namespace"},
-						Subjects:   []rbacapi.Subject{{Kind: "User", Name: "system:job-writer-namespace"}},
+						Subjects:   []rbacapi.Subject{{Kind: "User", Name: "job-writer-namespace"}},
 						RoleRef:    rbacapi.RoleRef{Kind: "ClusterRole", Name: "write-jobs"},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "create-rolebindings", Namespace: "job-namespace"},
 						Subjects: []rbacapi.Subject{
-							{Kind: "User", Name: "system:job-writer-namespace"},
-							{Kind: "User", Name: "system:any-rolebinding-writer-namespace"},
+							{Kind: "User", Name: "job-writer-namespace"},
+							{Kind: "User", Name: "any-rolebinding-writer-namespace"},
 						},
 						RoleRef: rbacapi.RoleRef{Kind: "ClusterRole", Name: "create-rolebindings"},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "bind-any-clusterrole", Namespace: "job-namespace"},
-						Subjects:   []rbacapi.Subject{{Kind: "User", Name: "system:any-rolebinding-writer-namespace"}},
+						Subjects:   []rbacapi.Subject{{Kind: "User", Name: "any-rolebinding-writer-namespace"}},
 						RoleRef:    rbacapi.RoleRef{Kind: "ClusterRole", Name: "bind-any-clusterrole"},
 					},
 				},
@@ -465,7 +465,7 @@ func TestRBAC(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "update-limitranges"},
 						Subjects: []rbacapi.Subject{
-							{Kind: "User", Name: "system:limitrange-updater"},
+							{Kind: "User", Name: "limitrange-updater"},
 						},
 						RoleRef: rbacapi.RoleRef{Kind: "ClusterRole", Name: "update-limitranges"},
 					},
@@ -499,7 +499,7 @@ func TestRBAC(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "patch-limitranges"},
 						Subjects: []rbacapi.Subject{
-							{Kind: "User", Name: "system:limitrange-patcher"},
+							{Kind: "User", Name: "limitrange-patcher"},
 						},
 						RoleRef: rbacapi.RoleRef{Kind: "ClusterRole", Name: "patch-limitranges"},
 					},
@@ -522,17 +522,17 @@ func TestRBAC(t *testing.T) {
 		masterConfig := framework.NewIntegrationTestMasterConfig()
 		masterConfig.GenericConfig.Authorization.Authorizer = newRBACAuthorizer(masterConfig)
 		masterConfig.GenericConfig.Authentication.Authenticator = bearertoken.New(tokenfile.New(map[string]*user.DefaultInfo{
-			superUser:                                 {Name: "system:admin", Groups: []string{"system:masters"}, Tenant: "system"},
-			"system:any-rolebinding-writer":           {Name: "system:any-rolebinding-writer", Tenant: testTenant},
-			"system:any-rolebinding-writer-namespace": {Name: "system:any-rolebinding-writer-namespace", Tenant: testTenant},
+			superUser:                                 {Tenant: metav1.TenantSystem, Name: "admin", Groups: []string{"system:masters"}},
+			"system:any-rolebinding-writer":           {Tenant: metav1.TenantSystem, Name: "any-rolebinding-writer"},
+			"system:any-rolebinding-writer-namespace": {Tenant: metav1.TenantSystem, Name: "any-rolebinding-writer-namespace"},
 			"bob":                         {Name: "bob", Tenant: testTenant},
-			"system:job-writer":           {Name: "system:job-writer", Tenant: testTenant},
-			"system:job-writer-namespace": {Name: "system:job-writer-namespace", Tenant: testTenant},
-			"system:nonescalating-rolebinding-writer": {Name: "system:nonescalating-rolebinding-writer", Tenant: testTenant},
-			"system:pod-reader":                       {Name: "system:pod-reader", Tenant: testTenant},
-			"system:limitrange-updater":               {Name: "system:limitrange-updater", Tenant: testTenant},
-			"system:limitrange-patcher":               {Name: "system:limitrange-patcher", Tenant: testTenant},
-			"system:user-with-no-permissions":         {Name: "system:user-with-no-permissions", Tenant: testTenant},
+			"system:job-writer":           {Tenant: metav1.TenantSystem, Name: "job-writer"},
+			"system:job-writer-namespace": {Tenant: metav1.TenantSystem, Name: "job-writer-namespace"},
+			"system:nonescalating-rolebinding-writer": {Tenant: metav1.TenantSystem, Name: "nonescalating-rolebinding-writer"},
+			"system:pod-reader":                       {Tenant: metav1.TenantSystem, Name: "pod-reader"},
+			"system:limitrange-updater":               {Tenant: metav1.TenantSystem, Name: "limitrange-updater"},
+			"system:limitrange-patcher":               {Tenant: metav1.TenantSystem, Name: "limitrange-patcher"},
+			"system:user-with-no-permissions":         {Tenant: metav1.TenantSystem, Name: "user-with-no-permissions"},
 		}))
 		masterConfig.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
 		_, s, closeFn := framework.RunAMaster(masterConfig)
@@ -637,7 +637,7 @@ func TestBootstrapping(t *testing.T) {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authorization.Authorizer = newRBACAuthorizer(masterConfig)
 	masterConfig.GenericConfig.Authentication.Authenticator = bearertoken.New(tokenfile.New(map[string]*user.DefaultInfo{
-		superUser: {Name: "system:admin", Groups: []string{"system:masters"}, Tenant: "system"},
+		superUser: {Tenant: metav1.TenantSystem, Name: "admin", Groups: []string{"system:masters"}},
 	}))
 	_, s, closeFn := framework.RunAMaster(masterConfig)
 	defer closeFn()
@@ -700,7 +700,7 @@ func TestDiscoveryUpgradeBootstrapping(t *testing.T) {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authorization.Authorizer = newRBACAuthorizer(masterConfig)
 	masterConfig.GenericConfig.Authentication.Authenticator = bearertoken.New(tokenfile.New(map[string]*user.DefaultInfo{
-		superUser: {Name: "system:admin", Groups: []string{"system:masters"}, Tenant: "system"},
+		superUser: {Tenant: metav1.TenantSystem, Name: "admin", Groups: []string{"system:masters"}},
 	}))
 	_, s, tearDownFn := framework.RunAMaster(masterConfig)
 

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -64,7 +64,7 @@ const (
 type allowAliceAuthorizer struct{}
 
 func (allowAliceAuthorizer) Authorize(a authorizer.Attributes) (authorizer.Decision, string, error) {
-	if a.GetUser() != nil && a.GetUser().GetName() == "fake-tenant:alice" {
+	if a.GetUser() != nil && a.GetUser().GetName() == "alice" && a.GetUser().GetTenant() == testTenant {
 		return authorizer.DecisionAllow, "", nil
 	}
 	return authorizer.DecisionNoOpinion, "I can't allow that.  Go ask alice.", nil
@@ -155,8 +155,8 @@ func initStatusForbiddenMasterCongfig() *master.Config {
 func initUnauthorizedMasterCongfig() *master.Config {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	tokenAuthenticator := tokentest.New()
-	tokenAuthenticator.Tokens[AliceToken] = &user.DefaultInfo{Name: "fake-tenant:alice", UID: "1"}
-	tokenAuthenticator.Tokens[BobToken] = &user.DefaultInfo{Name: "fake-tenant:bob", UID: "2"}
+	tokenAuthenticator.Tokens[AliceToken] = &user.DefaultInfo{Name: "alice", UID: "1", Tenant: testTenant}
+	tokenAuthenticator.Tokens[BobToken] = &user.DefaultInfo{Name: "bob", UID: "2", Tenant: testTenant}
 	masterConfig.GenericConfig.Authentication.Authenticator = group.NewGroupAdder(bearertoken.New(tokenAuthenticator), []string{user.AllAuthenticated})
 	masterConfig.GenericConfig.Authorization.Authorizer = allowAliceAuthorizer{}
 	return masterConfig


### PR DESCRIPTION
These tests were using the old-format user info when the multi-tenancy cert and token work was not done. It is time to use the new tenant-aware user info now.