### PR TITLE
add missing rule policy to tenant admin clusterrole

### DIFF
--- a/pkg/controller/tenant/tenant_controller.go
+++ b/pkg/controller/tenant/tenant_controller.go
@@ -284,7 +284,7 @@ func (tc *TenantController) createInitialRoleAndBinding(tenant string) (error, b
 			Name:   InitialClusterRoleName,
 			Tenant: tenant,
 		},
-		Rules: []rbacv1.PolicyRule{initialClusterRoleRules()},
+		Rules: initialClusterRoleRules(),
 	}
 
 	binding := &rbacv1.ClusterRoleBinding{
@@ -308,11 +308,17 @@ func (tc *TenantController) createInitialRoleAndBinding(tenant string) (error, b
 	return flattenedError(failures, tenant)
 }
 
-func initialClusterRoleRules() rbacv1.PolicyRule {
-	return rbacv1.PolicyRule{
-		Verbs:     []string{"*"},
-		APIGroups: []string{"*"},
-		Resources: []string{"*"},
+func initialClusterRoleRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"*"},
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+		},
+		{
+			Verbs:           []string{"*"},
+			NonResourceURLs: []string{"*"},
+		},
 	}
 }
 func (tc *TenantController) getDefaultNetwork(tenant string, net *arktosv1.Network) error {

--- a/pkg/controller/tenant/tenant_controller_test.go
+++ b/pkg/controller/tenant/tenant_controller_test.go
@@ -262,7 +262,7 @@ func initialClusterRole(tenant string) *rbacv1.ClusterRole {
 			Name:   InitialClusterRoleName,
 			Tenant: tenant,
 		},
-		Rules: []rbacv1.PolicyRule{initialClusterRoleRules()},
+		Rules: initialClusterRoleRules(),
 	}
 }
 


### PR DESCRIPTION
fix for https://github.com/futurewei-cloud/arktos/issues/423

## Symptom
Admin user in a tenant cannot pass authorization to create pod

## Root cause
The cluster role and rolebinding created for admin user is missing rules for nonresourceurls. It was working before because previously we added system tenant rules as a workaround fix to make testing pass. This fix was removed in [this commit](https://github.com/futurewei-cloud/arktos/commit/e8c1a21242c33ff3b159c62522ba9ae5d21c7e09) and hence the problem was exposed.

## Fix
Added missing rules. 

## References
https://github.com/kubernetes/kubernetes/issues/53349

## Verification
Create pod and deployments following the process user used in the issue:

```bash
root@ip-172-31-27-32:~/code/src/k8s.io/arktos# kubectl create tenant tenant-1
setting storage cluster to system
tenant/tenant-1 created

root@ip-172-31-27-32:~/code/src/k8s.io/arktos# ./hack/setup-multi-tenancy/setup_client.sh tenant-1 admin
setting up context tenant-1-admin-context for tenant-1/admin in group tenant-1-group at host localhost
generating a client key tenant-1.key...
creating a sign request tenant-1.csr...
creating an tenant certificate tenant-1-admin.crt and get it signed by CA
Setting up tenant context...
cleaned up tenant-1.csr
Context has been setup for tenant tenant-1/admin in /var/run/kubernetes/admin.kubeconfig.
Use 'kubectl use-context tenant-1-admin-context' to set it as the default context

root@ip-172-31-27-32:~/code/src/k8s.io/arktos# kubectl --context=tenant-1-admin-context create -f ~/code/src/k8s.io/arktos/test/yaml/vanilla.yaml
pod/k8s-vanilla-pod created

root@ip-172-31-27-32:~/arktos_testing# kubectl --context=tenant-1-admin-context create -f futureweideployment.yaml
deployment.apps/futurewei-deployment created
```

Verified all pods were created successfully