### PR TITLE
extend integration test timeout

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -647,7 +647,7 @@ bazel-test-integration:
 	@echo "$$BAZEL_TEST_INTEGRATION_HELP_INFO"
 else
 bazel-test-integration:
-	bazel test --test_arg=-test.short --test_output=errors --config integration //test/integration/... //vendor/k8s.io/apiextensions-apiserver/test/integration/...
+	bazel test --test_arg=-test.short --test_output=errors --test_timeout=400 --config integration //test/integration/... //vendor/k8s.io/apiextensions-apiserver/test/integration/...
 endif
 
 ifeq ($(PRINT_HELP),y)


### PR DESCRIPTION
A trial to fix the "apimachinery" integration test timeout issue.