### PR TITLE
Multi tenancy/kubectl rollout/scale

### DIFF
--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -47,6 +47,8 @@ type ResumeOptions struct {
 	Resumer          polymorphichelpers.ObjectResumerFunc
 	Namespace        string
 	EnforceNamespace bool
+	Tenant           string
+	EnforceTenant    bool
 
 	resource.FilenameOptions
 	genericclioptions.IOStreams
@@ -110,6 +112,10 @@ func (o *ResumeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 	if err != nil {
 		return err
 	}
+	o.Tenant, o.EnforceTenant, err = f.ToRawKubeConfigLoader().Tenant()
+	if err != nil {
+		return err
+	}
 
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
 		o.PrintFlags.NamePrintFlags.Operation = operation
@@ -132,8 +138,9 @@ func (o *ResumeOptions) Validate() error {
 func (o ResumeOptions) RunResume() error {
 	r := o.Builder().
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		TenantParam(o.Tenant).DefaultTenant().
 		NamespaceParam(o.Namespace).DefaultNamespace().
-		FilenameParam(o.EnforceNamespace, &o.FilenameOptions).
+		FilenameParamWithMultiTenancy(o.EnforceTenant, o.EnforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, o.Resources...).
 		ContinueOnError().
 		Latest().
@@ -178,7 +185,7 @@ func (o ResumeOptions) RunResume() error {
 			continue
 		}
 
-		obj, err := resource.NewHelper(info.Clients, info.Mapping).Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
+		obj, err := resource.NewHelper(info.Clients, info.Mapping).PatchWithMultiTenancy(info.Tenant, info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("failed to patch: %v", err))
 			continue

--- a/pkg/kubectl/cmd/scale/scale.go
+++ b/pkg/kubectl/cmd/scale/scale.go
@@ -84,6 +84,8 @@ type ScaleOptions struct {
 	builder                      *resource.Builder
 	namespace                    string
 	enforceNamespace             bool
+	tenant                       string
+	enforceTenant                bool
 	args                         []string
 	shortOutput                  bool
 	clientSet                    kubernetes.Interface
@@ -155,6 +157,10 @@ func (o *ScaleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	if err != nil {
 		return err
 	}
+	o.tenant, o.enforceTenant, err = f.ToRawKubeConfigLoader().Tenant()
+	if err != nil {
+		return err
+	}
 	o.builder = f.NewBuilder()
 	o.args = args
 	o.shortOutput = cmdutil.GetFlagString(cmd, "output") == "name"
@@ -185,8 +191,9 @@ func (o *ScaleOptions) RunScale() error {
 	r := o.builder.
 		Unstructured().
 		ContinueOnError().
+		TenantParam(o.tenant).DefaultTenant().
 		NamespaceParam(o.namespace).DefaultNamespace().
-		FilenameParam(o.enforceNamespace, &o.FilenameOptions).
+		FilenameParamWithMultiTenancy(o.enforceTenant, o.enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(o.All, o.args...).
 		Flatten().
 		LabelSelectorParam(o.Selector).
@@ -228,7 +235,7 @@ func (o *ScaleOptions) RunScale() error {
 		}
 
 		mapping := info.ResourceMapping()
-		if err := o.scaler.Scale(info.Namespace, info.Name, uint(o.Replicas), precondition, retry, waitForReplicas, mapping.Resource.GroupResource()); err != nil {
+		if err := o.scaler.Scale(info.Tenant, info.Namespace, info.Name, uint(o.Replicas), precondition, retry, waitForReplicas, mapping.Resource.GroupResource()); err != nil {
 			return err
 		}
 
@@ -243,7 +250,7 @@ func (o *ScaleOptions) RunScale() error {
 
 			// scale is a single client job
 			helper := resource.NewHelper([]resource.RESTClient{client}, mapping)
-			if _, err := helper.Patch(info.Namespace, info.Name, types.MergePatchType, mergePatch, nil); err != nil {
+			if _, err := helper.PatchWithMultiTenancy(info.Tenant, info.Namespace, info.Name, types.MergePatchType, mergePatch, nil); err != nil {
 				klog.V(4).Infof("error recording reason: %v", err)
 			}
 		}

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -1183,6 +1183,7 @@ func TestRollingUpdater_cleanupWithClients(t *testing.T) {
 			objs = append(objs, tt.responses...)
 			fake := fake.NewSimpleClientset(objs...)
 			updater := &RollingUpdater{
+				tenant:    metav1.TenantSystem,
 				ns:        "default",
 				rcClient:  fake.CoreV1(),
 				podClient: fake.CoreV1(),
@@ -1325,7 +1326,7 @@ func TestFindSourceController(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(tt.list)
-			ctrl, err := FindSourceController(fakeClient.CoreV1(), "default", tt.name)
+			ctrl, err := FindSourceController(fakeClient.CoreV1(), metav1.TenantSystem, "default", tt.name)
 			if tt.expectError && err == nil {
 				t.Errorf("unexpected non-error")
 			}
@@ -1439,7 +1440,7 @@ func TestUpdateExistingReplicationController(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			fakeClient := fake.NewSimpleClientset(tt.expectedRc)
-			rc, err := UpdateExistingReplicationController(fakeClient.CoreV1(), fakeClient.CoreV1(), tt.rc, "default", tt.name, tt.deploymentKey, tt.deploymentValue, buffer)
+			rc, err := UpdateExistingReplicationController(fakeClient.CoreV1(), fakeClient.CoreV1(), tt.rc, metav1.TenantSystem, "default", tt.name, tt.deploymentKey, tt.deploymentValue, buffer)
 			if !reflect.DeepEqual(rc, tt.expectedRc) {
 				t.Errorf("expected:\n%#v\ngot:\n%#v\n", tt.expectedRc, rc)
 			}
@@ -1550,7 +1551,7 @@ func TestUpdateRcWithRetries(t *testing.T) {
 	clientset := kubernetes.New(restClient)
 
 	if rc, err := updateRcWithRetries(
-		clientset.CoreV1(), "default", rc, func(c *corev1.ReplicationController) {
+		clientset.CoreV1(), metav1.TenantSystem, "default", rc, func(c *corev1.ReplicationController) {
 			c.Spec.Selector["baz"] = "foobar"
 		}); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -1658,7 +1659,7 @@ func TestAddDeploymentHash(t *testing.T) {
 	restClient.Client = fakeClient.Client
 	clientset := kubernetes.New(restClient)
 
-	if _, err := AddDeploymentKeyToReplicationController(rc, clientset.CoreV1(), clientset.CoreV1(), "dk", "hash", metav1.NamespaceDefault, buf); err != nil {
+	if _, err := AddDeploymentKeyToReplicationController(rc, clientset.CoreV1(), clientset.CoreV1(), "dk", "hash", metav1.TenantSystem, metav1.NamespaceDefault, buf); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	for _, pod := range podList.Items {

--- a/pkg/kubectl/scale_test.go
+++ b/pkg/kubectl/scale_test.go
@@ -44,8 +44,9 @@ func TestReplicationControllerScaleRetry(t *testing.T) {
 	count := uint(3)
 	name := "foo-v1"
 	namespace := metav1.NamespaceDefault
+	tenant := metav1.TenantSystem
 
-	scaleFunc := ScaleCondition(scaler, &preconditions, namespace, name, count, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
+	scaleFunc := ScaleCondition(scaler, &preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -54,7 +55,7 @@ func TestReplicationControllerScaleRetry(t *testing.T) {
 		t.Errorf("Did not expect an error on update conflict failure, got %v", err)
 	}
 	preconditions = ScalePrecondition{3, ""}
-	scaleFunc = ScaleCondition(scaler, &preconditions, namespace, name, count, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
+	scaleFunc = ScaleCondition(scaler, &preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
 	pass, err = scaleFunc()
 	if err == nil {
 		t.Errorf("Expected error on precondition failure")
@@ -81,8 +82,9 @@ func TestReplicationControllerScaleInvalid(t *testing.T) {
 	count := uint(3)
 	name := "foo-v1"
 	namespace := "default"
+	tenant := metav1.TenantSystem
 
-	scaleFunc := ScaleCondition(scaler, &preconditions, namespace, name, count, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
+	scaleFunc := ScaleCondition(scaler, &preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -108,7 +110,7 @@ func TestReplicationControllerScale(t *testing.T) {
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
 	name := "foo-v1"
-	err := scaler.Scale("default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
+	err := scaler.Scale(metav1.TenantSystem, "default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
 
 	if err != nil {
 		t.Fatalf("unexpected error occurred = %v while scaling the resource", err)
@@ -131,7 +133,7 @@ func TestReplicationControllerScaleFailsPreconditions(t *testing.T) {
 	preconditions := ScalePrecondition{2, ""}
 	count := uint(3)
 	name := "foo"
-	err := scaler.Scale("default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
+	err := scaler.Scale(metav1.TenantSystem, "default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "", Resource: "replicationcontrollers"})
 	if err == nil {
 		t.Fatal("expected to get an error but none was returned")
 	}
@@ -157,8 +159,9 @@ func TestDeploymentScaleRetry(t *testing.T) {
 	count := uint(3)
 	name := "foo"
 	namespace := "default"
+	tenant := metav1.TenantSystem
 
-	scaleFunc := ScaleCondition(scaler, preconditions, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
+	scaleFunc := ScaleCondition(scaler, preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
 	pass, err := scaleFunc()
 	if pass != false {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -167,7 +170,7 @@ func TestDeploymentScaleRetry(t *testing.T) {
 		t.Errorf("Did not expect an error on update failure, got %v", err)
 	}
 	preconditions = &ScalePrecondition{3, ""}
-	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
+	scaleFunc = ScaleCondition(scaler, preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
 	pass, err = scaleFunc()
 	if err == nil {
 		t.Error("Expected error on precondition failure")
@@ -190,7 +193,7 @@ func TestDeploymentScale(t *testing.T) {
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
 	name := "foo"
-	err := scaler.Scale("default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
+	err := scaler.Scale(metav1.TenantSystem, "default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,8 +219,9 @@ func TestDeploymentScaleInvalid(t *testing.T) {
 	count := uint(3)
 	name := "foo"
 	namespace := "default"
+	tenant := metav1.TenantSystem
 
-	scaleFunc := ScaleCondition(scaler, &preconditions, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
+	scaleFunc := ScaleCondition(scaler, &preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -243,7 +247,7 @@ func TestDeploymentScaleFailsPreconditions(t *testing.T) {
 	preconditions := ScalePrecondition{2, ""}
 	count := uint(3)
 	name := "foo"
-	err := scaler.Scale("default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
+	err := scaler.Scale(metav1.TenantSystem, "default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "apps", Resource: "deployments"})
 	if err == nil {
 		t.Fatal("exptected to get an error but none was returned")
 	}
@@ -265,7 +269,7 @@ func TestStatefulSetScale(t *testing.T) {
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
 	name := "foo"
-	err := scaler.Scale("default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "apps", Resource: "statefulset"})
+	err := scaler.Scale(metav1.TenantSystem, "default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "apps", Resource: "statefulset"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,8 +295,9 @@ func TestStatefulSetScaleRetry(t *testing.T) {
 	count := uint(3)
 	name := "foo"
 	namespace := "default"
+	tenant := metav1.TenantSystem
 
-	scaleFunc := ScaleCondition(scaler, preconditions, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "statefulsets"})
+	scaleFunc := ScaleCondition(scaler, preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "statefulsets"})
 	pass, err := scaleFunc()
 	if pass != false {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -301,7 +306,7 @@ func TestStatefulSetScaleRetry(t *testing.T) {
 		t.Errorf("Did not expect an error on update failure, got %v", err)
 	}
 	preconditions = &ScalePrecondition{3, ""}
-	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "statefulsets"})
+	scaleFunc = ScaleCondition(scaler, preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "statefulsets"})
 	pass, err = scaleFunc()
 	if err == nil {
 		t.Error("Expected error on precondition failure")
@@ -328,8 +333,9 @@ func TestStatefulSetScaleInvalid(t *testing.T) {
 	count := uint(3)
 	name := "foo"
 	namespace := "default"
+	tenant := metav1.TenantSystem
 
-	scaleFunc := ScaleCondition(scaler, &preconditions, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "statefulsets"})
+	scaleFunc := ScaleCondition(scaler, &preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "apps", Resource: "statefulsets"})
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -355,7 +361,7 @@ func TestStatefulSetScaleFailsPreconditions(t *testing.T) {
 	preconditions := ScalePrecondition{2, ""}
 	count := uint(3)
 	name := "foo"
-	err := scaler.Scale("default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "apps", Resource: "statefulsets"})
+	err := scaler.Scale(metav1.TenantSystem, "default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "apps", Resource: "statefulsets"})
 	if err == nil {
 		t.Fatal("expected to get an error but none was returned")
 	}
@@ -377,7 +383,7 @@ func TestReplicaSetScale(t *testing.T) {
 	preconditions := ScalePrecondition{-1, ""}
 	count := uint(3)
 	name := "foo"
-	err := scaler.Scale("default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
+	err := scaler.Scale(metav1.TenantSystem, "default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -403,8 +409,9 @@ func TestReplicaSetScaleRetry(t *testing.T) {
 	count := uint(3)
 	name := "foo"
 	namespace := "default"
+	tenant := metav1.TenantSystem
 
-	scaleFunc := ScaleCondition(scaler, preconditions, namespace, name, count, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
+	scaleFunc := ScaleCondition(scaler, preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
 	pass, err := scaleFunc()
 	if pass != false {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -413,7 +420,7 @@ func TestReplicaSetScaleRetry(t *testing.T) {
 		t.Errorf("Did not expect an error on update failure, got %v", err)
 	}
 	preconditions = &ScalePrecondition{3, ""}
-	scaleFunc = ScaleCondition(scaler, preconditions, namespace, name, count, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
+	scaleFunc = ScaleCondition(scaler, preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
 	pass, err = scaleFunc()
 	if err == nil {
 		t.Error("Expected error on precondition failure")
@@ -440,8 +447,9 @@ func TestReplicaSetScaleInvalid(t *testing.T) {
 	count := uint(3)
 	name := "foo"
 	namespace := "default"
+	tenant := metav1.TenantSystem
 
-	scaleFunc := ScaleCondition(scaler, &preconditions, namespace, name, count, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
+	scaleFunc := ScaleCondition(scaler, &preconditions, tenant, namespace, name, count, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
 	pass, err := scaleFunc()
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
@@ -467,7 +475,7 @@ func TestReplicaSetsGetterFailsPreconditions(t *testing.T) {
 	preconditions := ScalePrecondition{2, ""}
 	count := uint(3)
 	name := "foo"
-	err := scaler.Scale("default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
+	err := scaler.Scale(metav1.TenantSystem, "default", name, count, &preconditions, nil, nil, schema.GroupResource{Group: "extensions", Resource: "replicasets"})
 	if err == nil {
 		t.Fatal("expected to get an error but non was returned")
 	}
@@ -552,7 +560,7 @@ func TestGenericScaleSimple(t *testing.T) {
 		t.Run(fmt.Sprintf("running scenario %d: %s", index+1, scenario.name), func(t *testing.T) {
 			target := NewScaler(scenario.scaleGetter)
 
-			resVersion, err := target.ScaleSimple("default", scenario.resName, &scenario.precondition, uint(scenario.newSize), scenario.targetGR)
+			resVersion, err := target.ScaleSimple(metav1.TenantSystem, "default", scenario.resName, &scenario.precondition, uint(scenario.newSize), scenario.targetGR)
 
 			if scenario.expectError && err == nil {
 				t.Fatal("expected an error but was not returned")
@@ -620,7 +628,7 @@ func TestGenericScale(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			target := NewScaler(scenario.scaleGetter)
 
-			err := target.Scale("default", scenario.resName, uint(scenario.newSize), &scenario.precondition, nil, scenario.waitForReplicas, scenario.targetGR)
+			err := target.Scale(metav1.TenantSystem, "default", scenario.resName, uint(scenario.newSize), &scenario.precondition, nil, scenario.waitForReplicas, scenario.targetGR)
 
 			if scenario.expectError && err == nil {
 				t.Fatal("expected an error but was not returned")

--- a/pkg/kubectl/util/deployment/deployment.go
+++ b/pkg/kubectl/util/deployment/deployment.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/client-go/scale/BUILD
+++ b/staging/src/k8s.io/client-go/scale/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/staging/src/k8s.io/client-go/scale/fake/BUILD
+++ b/staging/src/k8s.io/client-go/scale/fake/BUILD
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/client-go/scale:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",

--- a/staging/src/k8s.io/client-go/scale/interfaces.go
+++ b/staging/src/k8s.io/client-go/scale/interfaces.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +26,7 @@ import (
 // for a particular namespace.
 type ScalesGetter interface {
 	Scales(namespace string) ScaleInterface
+	ScalesWithMultiTenancy(namespace, tenant string) ScaleInterface
 }
 
 // ScaleInterface can fetch and update scales for

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/scale"
@@ -52,10 +54,10 @@ func ScaleResourceWithRetries(scalesGetter scale.ScalesGetter, namespace, name s
 		ResourceVersion: "",
 	}
 	waitForReplicas := kubectl.NewRetryParams(waitRetryInterval, waitRetryTimeout)
-	cond := RetryErrorCondition(kubectl.ScaleCondition(scaler, preconditions, namespace, name, size, nil, gr))
+	cond := RetryErrorCondition(kubectl.ScaleCondition(scaler, preconditions, metav1.TenantSystem, namespace, name, size, nil, gr))
 	err := wait.PollImmediate(updateRetryInterval, updateRetryTimeout, cond)
 	if err == nil {
-		err = kubectl.WaitForScaleHasDesiredReplicas(scalesGetter, gr, name, namespace, size, waitForReplicas)
+		err = kubectl.WaitForScaleHasDesiredReplicas(scalesGetter, gr, name, namespace, metav1.TenantSystem, size, waitForReplicas)
 	}
 	if err != nil {
 		return fmt.Errorf("Error while scaling %s to %d replicas: %v", name, size, err)


### PR DESCRIPTION
This PR makes the command "kubectl scale" and "kubectl rollout" support the command line option of "--tenant".

This PR also fixed the issues of https://github.com/futurewei-cloud/arktos/issues/434 and https://github.com/futurewei-cloud/arktos/issues/433.

## Verification:

### verification that the "--tenant" option in "kubectl scale" is now effective.

Without this change, the "kubectl scale" command would report "not found" error.

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get deployment sample-nginx-deployment --tenant sample-tenant-1 --namespace sample-namespace-a
NAME                      HASHKEY               READY   UP-TO-DATE   AVAILABLE   AGE
sample-nginx-deployment   4296895824068558264   0/3     3            0           1s
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl scale --replicas=5 deployment/sample-nginx-deployment --tenant sample-tenant-1 --namespace sample-namespace-a --record=true
deployment.extensions/sample-nginx-deployment scaled
```

### verification that the "--tenant" option in "kubectl rollout" is now effective.
Without this change, the following commands would report "not found" error.
"kubectl rollout" has multiple sub-commands, and each of them was test as shown below:

```
ianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout history deployment sample-nginx-deployment --tenant sample-tenant-1 --namespace sample-namespace-a
deployment.extensions/sample-nginx-deployment 
REVISION  CHANGE-CAUSE
1         kubectl scale deployment/sample-nginx-deployment --replicas=5 --tenant=sample-tenant-1 --namespace=sample-namespace-a --record=true

 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout status deployment sample-nginx-deployment --tenant sample-tenant-1 --namespace sample-namespace-a
Waiting for deployment "sample-nginx-deployment" rollout to finish: 0 of 5 updated replicas are available...
Waiting for deployment "sample-nginx-deployment" rollout to finish: 1 of 5 updated replicas are available...
Waiting for deployment "sample-nginx-deployment" rollout to finish: 2 of 5 updated replicas are available...
Waiting for deployment "sample-nginx-deployment" rollout to finish: 3 of 5 updated replicas are available...
Waiting for deployment "sample-nginx-deployment" rollout to finish: 4 of 5 updated replicas are available...
deployment "sample-nginx-deployment" successfully rolled out
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout pause deployment sample-nginx-deployment --tenant sample-tenant-1 --namespace sample-namespace-a
deployment.extensions/sample-nginx-deployment paused
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout status deployment sample-nginx-deployment --tenant sample-tenant-1 --namespace sample-namespace-a
deployment "sample-nginx-deployment" successfully rolled out
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout resume deployment sample-nginx-deployment --tenant sample-tenant-1 --namespace sample-namespace-a
deployment.extensions/sample-nginx-deployment resumed
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout restart deployment sample-nginx-deployment --tenant sample-tenant-1 --namespace sample-namespace-a
deployment.extensions/sample-nginx-deployment restarted
```

### verfication that issue https://github.com/futurewei-cloud/arktos/issues/433 is fixed.
As shown below, in a regular-tenant context, "kubectl scale" is working now.
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=qian-admin-context get deployment sample-nginx-deployment 
NAME                      HASHKEY               READY   UP-TO-DATE   AVAILABLE   AGE
sample-nginx-deployment   2526903197574092367   0/1     1            0           0s
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=qian-admin-context scale --replicas=5 deployment/sample-nginx-deployment --record=true
deployment.extensions/sample-nginx-deployment scaled
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=qian-admin-context get deployment sample-nginx-deployment 
NAME                      HASHKEY               READY   UP-TO-DATE   AVAILABLE   AGE
sample-nginx-deployment   2526903197574092367   0/5     5            0           1s
```

### verification that issue https://github.com/futurewei-cloud/arktos/issues/434 is fixed.

As shown below, in a regular-tenant context, all "kubectl rollout" subcommands are working now.
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout history deployment sample-nginx-deployment --context=qian-admin-context
REVISION  CHANGE-CAUSE
1         kubectl scale deployment/sample-nginx-deployment --context=qian-admin-context --replicas=5 --record=true

 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout status deployment sample-nginx-deployment --context=qian-admin-context
Waiting for deployment "sample-nginx-deployment" rollout to finish: 0 of 5 updated replicas are available...
Waiting for deployment "sample-nginx-deployment" rollout to finish: 1 of 5 updated replicas are available...
Waiting for deployment "sample-nginx-deployment" rollout to finish: 2 of 5 updated replicas are available...
Waiting for deployment "sample-nginx-deployment" rollout to finish: 3 of 5 updated replicas are available...
Waiting for deployment "sample-nginx-deployment" rollout to finish: 4 of 5 updated replicas are available...
deployment "sample-nginx-deployment" successfully rolled out
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout pause deployment sample-nginx-deployment --context=qian-admin-context
deployment.extensions/sample-nginx-deployment paused
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout status deployment sample-nginx-deployment --context=qian-admin-context
deployment "sample-nginx-deployment" successfully rolled out
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout resume deployment sample-nginx-deployment --context=qian-admin-context
deployment.extensions/sample-nginx-deployment resumed
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl rollout restart deployment sample-nginx-deployment --context=qian-admin-context
deployment.extensions/sample-nginx-deployment restarted
```