### PR TITLE
fix issue 393

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -65,6 +66,10 @@ func forbiddenMessage(attributes authorizer.Attributes) string {
 
 	if ns := attributes.GetNamespace(); len(ns) > 0 {
 		return fmt.Sprintf("User %q cannot %s resource %q in API group %q in the namespace %q", username, attributes.GetVerb(), resource, attributes.GetAPIGroup(), ns)
+	}
+
+	if tenant := attributes.GetTenant(); len(tenant) > 0 {
+		return fmt.Sprintf("User %q cannot %s resource %q in API group %q in the tenant %q", username, attributes.GetVerb(), resource, attributes.GetAPIGroup(), tenant)
 	}
 
 	return fmt.Sprintf("User %q cannot %s resource %q in API group %q at the cluster scope", username, attributes.GetVerb(), resource, attributes.GetAPIGroup())

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -72,6 +73,8 @@ func TestForbidden(t *testing.T) {
 `, authorizer.AttributesRecord{User: u, Verb: "get", Resource: "pod", ResourceRequest: true, Name: "mypod"}, "", "application/json"},
 		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pod.v2 is forbidden: User \"NAME\" cannot get resource \"pod/quota\" in API group \"v2\" in the namespace \"test\"","reason":"Forbidden","details":{"group":"v2","kind":"pod"},"code":403}
 `, authorizer.AttributesRecord{User: u, Verb: "get", Namespace: "test", APIGroup: "v2", Resource: "pod", Subresource: "quota", ResourceRequest: true}, "", "application/json"},
+		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespace is forbidden: User \"NAME\" cannot get resource \"namespace/status\" in API group \"\" in the tenant \"test-tenant\"","reason":"Forbidden","details":{"kind":"namespace"},"code":403}
+`, authorizer.AttributesRecord{User: u, Verb: "get", Tenant: "test-tenant", Namespace: "", APIGroup: "", Resource: "namespace", Subresource: "status", ResourceRequest: true}, "", "application/json"},
 	}
 	for _, test := range cases {
 		observer := httptest.NewRecorder()

--- a/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
@@ -17,6 +17,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",


### PR DESCRIPTION
This PR fixes issue https://github.com/futurewei-cloud/arktos/issues/393.

Error will occur if a regular-tenant user use "--tenant system" in the kubectl command, instead of working towards the space of the tenant itself.

### Bug analysis and explanation about fix

The bug was caused by the combination of the following two facts:
1. When client-go creates the HTTP URL, if the tenant is system, the section of "tenants/system" in the HTTP URL is skipped for backwards compatibility. 
2. With the introduction of "short path" in URL resolution, no tenant in the URL means a request to the user tenant. 

To fix the bug 393, a simple way is to put the section of "tenants/system" in the url. It fixes the issue. However, more than 100 test cases will fail as the backwards compatibility is broken. 

I tried different ways to let client-go create different URLs based on the user tenants:
1. the "tenants/system" section in URL is skipped if it is a request from a user of system tenant
2  the "tenants/system" section in URL is NOT skipped if it is a request from a user of regular tenant

However, the component of client-go URL generator and the component to resolve the user tenant from the kubeconfig or command line option in kubectl are far away from each other. They are almost at the two ends of the command process workflow in kubectl. To make the client-go URL generator check or have the info whether the request is from a user tenant, I tried several different ways. However, they either need pervasive code change, or pollute the componentization design in kubectl.

That is why I finally settled down with the solution given in this PR. I let kubectl do the check. "--tenant system" is not a valid command line option is the user tenant is a regular one.


### verification in Dev box

Created a tenant, "qian" and the tenant-admin user, "qian-admin". A corresponding context was also set up. The following commands were tested:

```
qianchen@qianchen-VirtualBox:~$ kubectl --context=qian-admin-context get ns
NAME          STATUS   AGE   TENANT
default       Active   3s    qian
kube-public   Active   2s    qian
kube-system   Active   3s    qian

qianchen@qianchen-VirtualBox:~$ kubectl --context=qian-admin-context get ns --tenant system
error: System space is not accessible for tenant qian

qianchen@qianchen-VirtualBox:~$ kubectl config use-context qian-admin-context
Switched to context "qian-admin-context".

qianchen@qianchen-VirtualBox:~$ kubectl get ns
NAME          STATUS   AGE   TENANT
default       Active   91s   qian
kube-public   Active   90s   qian
kube-system   Active   91s   qian

qianchen@qianchen-VirtualBox:~$ kubectl get ns --tenant system
error: System space is not accessible for tenant qian

qianchen@qianchen-VirtualBox:~$ kubectl get ns --tenant qian
NAME          STATUS   AGE    TENANT
default       Active   104s   qian
kube-public   Active   103s   qian
kube-system   Active   104s   qian
```
