### PR TITLE
remove out-dated code in request.go

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -765,12 +765,6 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 	}
 
 	// TODO: added to catch programmer errors (invoking operations with an object with an empty namespace)
-	if (r.verb == "GET" || r.verb == "PUT" || r.verb == "DELETE") && r.tenantSet && len(r.resourceName) > 0 && len(r.tenant) == 0 {
-		r = r.Tenant(metav1.TenantSystem)
-	}
-	if (r.verb == "POST") && r.tenantSet && len(r.tenant) == 0 {
-		r = r.Tenant(metav1.TenantSystem)
-	}
 	if (r.verb == "GET" || r.verb == "PUT" || r.verb == "DELETE") && r.namespaceSet && len(r.resourceName) > 0 && len(r.namespace) == 0 {
 		return fmt.Errorf("an empty namespace may not be set when a resource name is provided")
 	}


### PR DESCRIPTION
These code was in place to set the tenant value in the REST request before "short-path" was introduced. With the introduction of "short-path", this logic is no longer needed.

### Simple Test 

It verifies the system is still working after this change
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubeclt create tenant aaaa
kubeclt: command not found
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant aaaa
setting storage cluster to system
tenant/aaaa created
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create ns bbbb --tenant aaaa
namespace/bbbb created
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get ns -AT
TENANT   NAME              STATUS   AGE   TENANT
aaaa     bbbb              Active   9s    aaaa
aaaa     default           Active   33s   aaaa
aaaa     kube-public       Active   33s   aaaa
aaaa     kube-system       Active   33s   aaaa
system   default           Active   30m   system
system   kube-node-lease   Active   30m   system
system   kube-public       Active   30m   system
system   kube-system       Active   30m   system
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl run pod --image=nginx --tenant aaaa --namespace bbbb
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
deployment.apps/pod created
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get pods -AT
TENANT   NAMESPACE     NAME                        HASHKEY               READY   STATUS    RESTARTS   AGE
aaaa     bbbb          pod-cd94cd8c7-zgxl9         5335242183041674688   1/1     Running   0          11s
system   kube-system   kube-dns-5d69f5657d-pnmk6   4878035319673552892   3/3     Running   0          30m
system   kube-system   virtlet-k269r               8258007122832117825   3/3     Running   0          30m
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl delete tenant aaaa
tenant "aaaa" deleted

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get pods -AT
TENANT   NAMESPACE     NAME                        HASHKEY               READY   STATUS    RESTARTS   AGE
system   kube-system   kube-dns-5d69f5657d-pnmk6   4878035319673552892   3/3     Running   0          32m
system   kube-system   virtlet-k269r               8258007122832117825   3/3     Running   0          31m

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get tenants
NAME     STORAGEID   STATUS   AGE
system   system      Active   35m


```