### PR TITLE
fix kubectl-create-tenant break due to StorageClusterId type change

### DIFF
--- a/pkg/kubectl/cmd/create/create_tenant.go
+++ b/pkg/kubectl/cmd/create/create_tenant.go
@@ -41,7 +41,7 @@ var (
 
 	//TODO: to refer the default value defined in future storage cluster work, instead of hard-coded
 	//tracking issue: https://github.com/futurewei-cloud/arktos/issues/326
-	defaultStorageClusterId = "system"
+	defaultStorageClusterId = "0"
 )
 
 // TenantOpts is the options for 'create tenant' sub command

--- a/pkg/kubectl/generate/versioned/BUILD
+++ b/pkg/kubectl/generate/versioned/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",

--- a/pkg/kubectl/generate/versioned/tenant.go
+++ b/pkg/kubectl/generate/versioned/tenant.go
@@ -18,10 +18,10 @@ package versioned
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/kubectl/generate"
 )
 
@@ -82,8 +82,9 @@ func (g *TenantGeneratorV1) validate() error {
 	if len(g.Name) == 0 {
 		return fmt.Errorf("name must be specified")
 	}
-	if len(strings.TrimSpace(g.StorageClusterId)) == 0 {
-		return fmt.Errorf("StorageClusterId can not be empty")
+
+	if _, err := diff.GetClusterIdFromString(g.StorageClusterId); err != nil {
+		return fmt.Errorf("Invalid StorageClusterId: %v", err)
 	}
 	return nil
 }

--- a/pkg/kubectl/generate/versioned/tenant_test.go
+++ b/pkg/kubectl/generate/versioned/tenant_test.go
@@ -124,6 +124,32 @@ func TestTenantGenerate(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "test11",
+			params: map[string]interface{}{
+				"name":           "foo",
+				"storagecluster": "non-integer",
+			},
+			expectErr: true,
+		},
+		{
+			name: "test12",
+			params: map[string]interface{}{
+				"name": "foo",
+				// the value must be 0-63
+				"storagecluster": "-1",
+			},
+			expectErr: true,
+		},
+		{
+			name: "test13",
+			params: map[string]interface{}{
+				"name": "foo",
+				// the value must be 0-63
+				"storagecluster": "64",
+			},
+			expectErr: true,
+		},
 	}
 	generator := TenantGeneratorV1{}
 	for index, tt := range tests {


### PR DESCRIPTION
This PR fix the break in command "kubectl create tenant" due to the recent change in the type of StorageClusterId.

### verification in my dev box

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant abcdef
setting storage cluster to 0
tenant/abcdef created
```

before this change, the command breaks as follows:
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant abcdef
setting storage cluster to system
The Tenant "abcdef" is invalid: spec.storageClusterId: Invalid value: "system": must be integer 0-63
```
