### PR TITLE
fix issue 393

### DIFF
--- a/cmd/kubelet/app/server_bootstrap_test.go
+++ b/cmd/kubelet/app/server_bootstrap_test.go
@@ -274,7 +274,7 @@ func (s *csrSimulator) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	switch {
-	case req.Method == "POST" && req.URL.Path == "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests":
+	case req.Method == "POST" && req.URL.Path == "/apis/certificates.k8s.io/v1beta1/tenants/system/certificatesigningrequests":
 		csr, err := getCSR(req)
 		if err != nil {
 			t.Fatal(err)
@@ -318,7 +318,7 @@ func (s *csrSimulator) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		s.csr = csr
 
-	case req.Method == "GET" && req.URL.Path == "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests" && req.URL.RawQuery == "fieldSelector=metadata.name%3Dtest-csr&limit=500&resourceVersion=0":
+	case req.Method == "GET" && req.URL.Path == "/apis/certificates.k8s.io/v1beta1/tenants/system/certificatesigningrequests" && req.URL.RawQuery == "fieldSelector=metadata.name%3Dtest-csr&limit=500&resourceVersion=0":
 		if s.csr == nil {
 			t.Fatalf("no csr")
 		}
@@ -335,7 +335,7 @@ func (s *csrSimulator) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(data)
 
-	case req.Method == "GET" && req.URL.Path == "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests" && req.URL.RawQuery == "fieldSelector=metadata.name%3Dtest-csr&resourceVersion=2&watch=true":
+	case req.Method == "GET" && req.URL.Path == "/apis/certificates.k8s.io/v1beta1/tenants/system/certificatesigningrequests" && req.URL.RawQuery == "fieldSelector=metadata.name%3Dtest-csr&resourceVersion=2&watch=true":
 		if s.csr == nil {
 			t.Fatalf("no csr")
 		}

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -374,7 +374,7 @@ func (g TestGroup) ResourcePathWithPrefixWithMultiTenancy(prefix, resource, tena
 	if prefix != "" {
 		path = path + "/" + prefix
 	}
-	if tenant != "" && tenant != metav1.TenantSystem {
+	if tenant != "" {
 		path = path + "/tenants/" + tenant
 	}
 	if namespace != "" {

--- a/pkg/api/testapi/testapi_test.go
+++ b/pkg/api/testapi/testapi_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,11 +34,11 @@ func TestResourcePathWithPrefix(t *testing.T) {
 		name      string
 		expected  string
 	}{
-		{"prefix", "resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/prefix/namespaces/mynamespace/resource/myresource"},
-		{"prefix", "resource", "", "myresource", "/api/" + Default.GroupVersion().Version + "/prefix/resource/myresource"},
-		{"prefix", "resource", "mynamespace", "", "/api/" + Default.GroupVersion().Version + "/prefix/namespaces/mynamespace/resource"},
-		{"prefix", "resource", "", "", "/api/" + Default.GroupVersion().Version + "/prefix/resource"},
-		{"", "resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/namespaces/mynamespace/resource/myresource"},
+		{"prefix", "resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/prefix/tenants/system/namespaces/mynamespace/resource/myresource"},
+		{"prefix", "resource", "", "myresource", "/api/" + Default.GroupVersion().Version + "/prefix/tenants/system/resource/myresource"},
+		{"prefix", "resource", "mynamespace", "", "/api/" + Default.GroupVersion().Version + "/prefix/tenants/system/namespaces/mynamespace/resource"},
+		{"prefix", "resource", "", "", "/api/" + Default.GroupVersion().Version + "/prefix/tenants/system/resource"},
+		{"", "resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/tenants/system/namespaces/mynamespace/resource/myresource"},
 	}
 	for _, item := range testCases {
 		if actual := Default.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name); actual != item.expected {
@@ -52,11 +53,11 @@ func TestResourcePathWithPrefix(t *testing.T) {
 		name      string
 		expected  string
 	}{
-		{"prefix", "resource", "mynamespace", "myresource", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/prefix/namespaces/mynamespace/resource/myresource"},
-		{"prefix", "resource", "", "myresource", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/prefix/resource/myresource"},
-		{"prefix", "resource", "mynamespace", "", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/prefix/namespaces/mynamespace/resource"},
-		{"prefix", "resource", "", "", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/prefix/resource"},
-		{"", "resource", "mynamespace", "myresource", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/namespaces/mynamespace/resource/myresource"},
+		{"prefix", "resource", "mynamespace", "myresource", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/prefix/tenants/system/namespaces/mynamespace/resource/myresource"},
+		{"prefix", "resource", "", "myresource", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/prefix/tenants/system/resource/myresource"},
+		{"prefix", "resource", "mynamespace", "", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/prefix/tenants/system/namespaces/mynamespace/resource"},
+		{"prefix", "resource", "", "", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/prefix/tenants/system/resource"},
+		{"", "resource", "mynamespace", "myresource", "/apis/" + Admission.GroupVersion().Group + "/" + Admission.GroupVersion().Version + "/tenants/system/namespaces/mynamespace/resource/myresource"},
 	}
 	for _, item := range testGroupCases {
 		if actual := Admission.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name); actual != item.expected {
@@ -72,10 +73,10 @@ func TestResourcePath(t *testing.T) {
 		name      string
 		expected  string
 	}{
-		{"resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/namespaces/mynamespace/resource/myresource"},
-		{"resource", "", "myresource", "/api/" + Default.GroupVersion().Version + "/resource/myresource"},
-		{"resource", "mynamespace", "", "/api/" + Default.GroupVersion().Version + "/namespaces/mynamespace/resource"},
-		{"resource", "", "", "/api/" + Default.GroupVersion().Version + "/resource"},
+		{"resource", "mynamespace", "myresource", "/api/" + Default.GroupVersion().Version + "/tenants/system/namespaces/mynamespace/resource/myresource"},
+		{"resource", "", "myresource", "/api/" + Default.GroupVersion().Version + "/tenants/system/resource/myresource"},
+		{"resource", "mynamespace", "", "/api/" + Default.GroupVersion().Version + "/tenants/system/namespaces/mynamespace/resource"},
+		{"resource", "", "", "/api/" + Default.GroupVersion().Version + "/tenants/system/resource"},
 	}
 	for _, item := range testCases {
 		if actual := Default.ResourcePath(item.resource, item.namespace, item.name); actual != item.expected {
@@ -92,10 +93,10 @@ func TestSubResourcePath(t *testing.T) {
 		sub       string
 		expected  string
 	}{
-		{"resource", "mynamespace", "myresource", "mysub", "/api/" + Default.GroupVersion().Version + "/namespaces/mynamespace/resource/myresource/mysub"},
-		{"resource", "", "myresource", "mysub", "/api/" + Default.GroupVersion().Version + "/resource/myresource/mysub"},
-		{"resource", "mynamespace", "", "mysub", "/api/" + Default.GroupVersion().Version + "/namespaces/mynamespace/resource/mysub"},
-		{"resource", "", "", "mysub", "/api/" + Default.GroupVersion().Version + "/resource/mysub"},
+		{"resource", "mynamespace", "myresource", "mysub", "/api/" + Default.GroupVersion().Version + "/tenants/system/namespaces/mynamespace/resource/myresource/mysub"},
+		{"resource", "", "myresource", "mysub", "/api/" + Default.GroupVersion().Version + "/tenants/system/resource/myresource/mysub"},
+		{"resource", "mynamespace", "", "mysub", "/api/" + Default.GroupVersion().Version + "/tenants/system/namespaces/mynamespace/resource/mysub"},
+		{"resource", "", "", "mysub", "/api/" + Default.GroupVersion().Version + "/tenants/system/resource/mysub"},
 	}
 	for _, item := range testCases {
 		if actual := Default.SubResourcePath(item.resource, item.namespace, item.name, item.sub); actual != item.expected {

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -117,9 +117,6 @@ func addNotReadyPodsWithSpecifiedRestartPolicyAndPhase(store cache.Store, tenant
 }
 
 func makeEndpointsResourcePath(tenant, namespace, name string) string {
-	if tenant == "" || tenant == metav1.TenantSystem {
-		return testapi.Default.ResourcePath("endpoints", namespace, name)
-	}
 
 	return testapi.Default.ResourcePathWithMultiTenancy("endpoints", tenant, namespace, name)
 }
@@ -130,13 +127,8 @@ func makeTestServer(t *testing.T, tenant, namespace string) (*httptest.Server, *
 		ResponseBody: runtime.EncodeOrDie(testapi.Default.Codec(), &v1.Endpoints{}),
 	}
 	mux := http.NewServeMux()
-	if tenant == "" || tenant == metav1.TenantSystem {
-		mux.Handle(testapi.Default.ResourcePath("endpoints", namespace, ""), &fakeEndpointsHandler)
-		mux.Handle(testapi.Default.ResourcePath("endpoints/", namespace, ""), &fakeEndpointsHandler)
-	} else {
-		mux.Handle(testapi.Default.ResourcePathWithMultiTenancy("endpoints", tenant, namespace, ""), &fakeEndpointsHandler)
-		mux.Handle(testapi.Default.ResourcePathWithMultiTenancy("endpoints/", tenant, namespace, ""), &fakeEndpointsHandler)
-	}
+	mux.Handle(testapi.Default.ResourcePathWithMultiTenancy("endpoints", tenant, namespace, ""), &fakeEndpointsHandler)
+	mux.Handle(testapi.Default.ResourcePathWithMultiTenancy("endpoints/", tenant, namespace, ""), &fakeEndpointsHandler)
 
 	mux.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
 		t.Errorf("unexpected request: %v", req.RequestURI)

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -132,27 +132,17 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 	groupVersionResources, _ := discovery.GroupVersionResources(resources)
 	for groupVersionResource := range groupVersionResources {
 		var urlPath string
-		if tenant == metav1.TenantSystem {
-			urlPath = path.Join([]string{
-				dynamic.LegacyAPIPathResolverFunc(schema.GroupVersionKind{Group: groupVersionResource.Group, Version: groupVersionResource.Version}),
-				groupVersionResource.Group,
-				groupVersionResource.Version,
-				"namespaces",
-				namespaceName,
-				groupVersionResource.Resource,
-			}...)
-		} else {
-			urlPath = path.Join([]string{
-				dynamic.LegacyAPIPathResolverFunc(schema.GroupVersionKind{Group: groupVersionResource.Group, Version: groupVersionResource.Version}),
-				groupVersionResource.Group,
-				groupVersionResource.Version,
-				"tenants",
-				tenant,
-				"namespaces",
-				namespaceName,
-				groupVersionResource.Resource,
-			}...)
-		}
+
+		urlPath = path.Join([]string{
+			dynamic.LegacyAPIPathResolverFunc(schema.GroupVersionKind{Group: groupVersionResource.Group, Version: groupVersionResource.Version}),
+			groupVersionResource.Group,
+			groupVersionResource.Version,
+			"tenants",
+			tenant,
+			"namespaces",
+			namespaceName,
+			groupVersionResource.Resource,
+		}...)
 
 		dynamicClientActionSet.Insert((&fakeAction{method: "GET", path: urlPath}).String())
 		dynamicClientActionSet.Insert((&fakeAction{method: "DELETE", path: urlPath}).String())

--- a/pkg/kubectl/cmd/annotate/annotate_test.go
+++ b/pkg/kubectl/cmd/annotate/annotate_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -464,7 +465,7 @@ func TestAnnotateObject(t *testing.T) {
 			switch req.Method {
 			case "GET":
 				switch req.URL.Path {
-				case "/namespaces/test/pods/foo":
+				case "/tenants/system/namespaces/test/pods/foo":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -472,7 +473,7 @@ func TestAnnotateObject(t *testing.T) {
 				}
 			case "PATCH":
 				switch req.URL.Path {
-				case "/namespaces/test/pods/foo":
+				case "/tenants/system/namespaces/test/pods/foo":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -517,7 +518,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 			switch req.Method {
 			case "GET":
 				switch req.URL.Path {
-				case "/namespaces/test/replicationcontrollers/cassandra":
+				case "/tenants/system/namespaces/test/replicationcontrollers/cassandra":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -525,7 +526,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 				}
 			case "PATCH":
 				switch req.URL.Path {
-				case "/namespaces/test/replicationcontrollers/cassandra":
+				case "/tenants/system/namespaces/test/replicationcontrollers/cassandra":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -601,7 +602,7 @@ func TestAnnotateMultipleObjects(t *testing.T) {
 			switch req.Method {
 			case "GET":
 				switch req.URL.Path {
-				case "/namespaces/test/pods":
+				case "/tenants/system/namespaces/test/pods":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -609,9 +610,9 @@ func TestAnnotateMultipleObjects(t *testing.T) {
 				}
 			case "PATCH":
 				switch req.URL.Path {
-				case "/namespaces/test/pods/foo":
+				case "/tenants/system/namespaces/test/pods/foo":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
-				case "/namespaces/test/pods/bar":
+				case "/tenants/system/namespaces/test/pods/bar":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[1])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/apply/apply_test.go
+++ b/pkg/kubectl/cmd/apply/apply_test.go
@@ -280,7 +280,7 @@ func walkMapPath(t *testing.T, start map[string]interface{}, path []string) map[
 func TestRunApplyPrintsValidObjectList(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	configMapList := readConfigMapList(t, filenameCM)
-	pathCM := "/namespaces/test/configmaps"
+	pathCM := "/tenants/system/namespaces/test/configmaps"
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
@@ -340,7 +340,7 @@ func TestRunApplyViewLastApplied(t *testing.T) {
 	_, rcBytesWithConfig := readReplicationController(t, filenameRCLASTAPPLIED)
 	_, rcBytesWithArgs := readReplicationController(t, filenameRCLastAppliedArgs)
 	nameRC, rcBytes := readReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers/" + nameRC
 
 	tests := []struct {
 		name, nameRC, pathRC, filePath, outputFormat, expectedErr, expectedOut, selector string
@@ -434,9 +434,9 @@ func TestRunApplyViewLastApplied(t *testing.T) {
 					case p == "/namespaces/test/replicationcontrollers" && m == "GET":
 						bodyRC := ioutil.NopCloser(bytes.NewReader(test.respBytes))
 						return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
-					case p == "/namespaces/test/replicationcontrollers/no-match" && m == "GET":
+					case p == "/tenants/system/namespaces/test/replicationcontrollers/no-match" && m == "GET":
 						return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.Pod{})}, nil
-					case p == "/api/v1/namespaces/test" && m == "GET":
+					case p == "/api/v1/tenants/system/namespaces/test" && m == "GET":
 						return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.Namespace{})}, nil
 					default:
 						t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -475,7 +475,7 @@ func TestRunApplyViewLastApplied(t *testing.T) {
 func TestApplyObjectWithoutAnnotation(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	nameRC, rcBytes := readReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers/" + nameRC
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
@@ -518,7 +518,7 @@ func TestApplyObjectWithoutAnnotation(t *testing.T) {
 func TestApplyObject(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers/" + nameRC
 
 	for _, fn := range testingOpenAPISchemaFns {
 		t.Run("test apply when a local object is specified", func(t *testing.T) {
@@ -566,7 +566,7 @@ func TestApplyObject(t *testing.T) {
 func TestApplyObjectOutput(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers/" + nameRC
 
 	// Add some extra data to the post-patch object
 	postPatchObj := &unstructured.Unstructured{}
@@ -631,7 +631,7 @@ func TestApplyObjectOutput(t *testing.T) {
 func TestApplyRetry(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers/" + nameRC
 
 	for _, fn := range testingOpenAPISchemaFns {
 		t.Run("test apply retries on conflict error", func(t *testing.T) {
@@ -694,7 +694,7 @@ func TestApplyRetry(t *testing.T) {
 
 func TestApplyNonExistObject(t *testing.T) {
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers"
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers"
 	pathNameRC := pathRC + "/" + nameRC
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
@@ -704,7 +704,7 @@ func TestApplyNonExistObject(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api/v1/namespaces/test" && m == "GET":
+			case p == "/api/v1/tenants/system/namespaces/test" && m == "GET":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
 			case p == pathNameRC && m == "GET":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
@@ -735,7 +735,7 @@ func TestApplyNonExistObject(t *testing.T) {
 func TestApplyEmptyPatch(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	nameRC, _ := readAndAnnotateReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers"
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers"
 	pathNameRC := pathRC + "/" + nameRC
 
 	verifyPost := false
@@ -750,7 +750,7 @@ func TestApplyEmptyPatch(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api/v1/namespaces/test" && m == "GET":
+			case p == "/api/v1/tenants/system/namespaces/test" && m == "GET":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
 			case p == pathNameRC && m == "GET":
 				if body == nil {
@@ -808,10 +808,10 @@ func TestApplyMultipleObjectsAsFiles(t *testing.T) {
 
 func testApplyMultipleObjects(t *testing.T, asList bool) {
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers/" + nameRC
 
 	nameSVC, currentSVC := readAndAnnotateService(t, filenameSVC)
-	pathSVC := "/namespaces/test/services/" + nameSVC
+	pathSVC := "/tenants/system/namespaces/test/services/" + nameSVC
 
 	for _, fn := range testingOpenAPISchemaFns {
 		t.Run("test apply on multiple objects", func(t *testing.T) {
@@ -889,7 +889,7 @@ func readDeploymentFromFile(t *testing.T, file string) []byte {
 func TestApplyNULLPreservation(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	deploymentName := "nginx-deployment"
-	deploymentPath := "/namespaces/test/deployments/" + deploymentName
+	deploymentPath := "/tenants/system/namespaces/test/deployments/" + deploymentName
 
 	verifiedPatch := false
 	deploymentBytes := readDeploymentFromFile(t, filenameDeployObjServerside)
@@ -965,7 +965,7 @@ func TestApplyNULLPreservation(t *testing.T) {
 func TestUnstructuredApply(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	name, curr := readAndAnnotateUnstructured(t, filenameWidgetClientside)
-	path := "/namespaces/test/widgets/" + name
+	path := "/tenants/system/namespaces/test/widgets/" + name
 
 	verifiedPatch := false
 
@@ -1035,7 +1035,7 @@ func TestUnstructuredIdempotentApply(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	path := "/namespaces/test/widgets/widget"
+	path := "/tenants/system/namespaces/test/widgets/widget"
 
 	for _, fn := range testingOpenAPISchemaFns {
 		t.Run("test repeated apply operations on an unstructured object", func(t *testing.T) {
@@ -1217,8 +1217,8 @@ func TestForceApply(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 	scheme := runtime.NewScheme()
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)
-	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
-	pathRCList := "/namespaces/test/replicationcontrollers"
+	pathRC := "/tenants/system/namespaces/test/replicationcontrollers/" + nameRC
+	pathRCList := "/tenants/system/namespaces/test/replicationcontrollers"
 	expected := map[string]int{
 		"getOk":       6,
 		"getNotFound": 1,

--- a/pkg/kubectl/cmd/attach/attach_test.go
+++ b/pkg/kubectl/cmd/attach/attach_test.go
@@ -449,9 +449,5 @@ func attachPod(tenant string) *corev1.Pod {
 }
 
 func podFetchPath(tenant string) string {
-	if tenant == metav1.TenantSystem {
-		return "/namespaces/test/pods/foo"
-	} else {
-		return "/tenants/" + tenant + "/namespaces/test/pods/foo"
-	}
+	return "/tenants/" + tenant + "/namespaces/test/pods/foo"
 }

--- a/pkg/kubectl/cmd/auth/cani_test.go
+++ b/pkg/kubectl/cmd/auth/cani_test.go
@@ -134,7 +134,7 @@ func TestRunAccessCheck(t *testing.T) {
 				GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
 				NegotiatedSerializer: ns,
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					expectPath := "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews"
+					expectPath := "/apis/authorization.k8s.io/v1/tenants/system/selfsubjectaccessreviews"
 					if req.URL.Path != expectPath {
 						t.Errorf("%s: expected %v, got %v", test.name, expectPath, req.URL.Path)
 						return nil, nil
@@ -207,7 +207,7 @@ func TestRunAccessList(t *testing.T) {
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				switch req.URL.Path {
-				case "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews":
+				case "/apis/authorization.k8s.io/v1/tenants/system/selfsubjectrulesreviews":
 					body := ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, getSelfSubjectRulesReview()))))
 					return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
 				default:

--- a/pkg/kubectl/cmd/create/create_configmap_test.go
+++ b/pkg/kubectl/cmd/create/create_configmap_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +43,7 @@ func TestCreateConfigMap(t *testing.T) {
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/configmaps" && m == "POST":
+			case p == "/tenants/system/namespaces/test/configmaps" && m == "POST":
 				return &http.Response{StatusCode: 201, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, configMap)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/create/create_rolebinding_test.go
+++ b/pkg/kubectl/cmd/create/create_rolebinding_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -84,7 +85,7 @@ func TestCreateRoleBinding(t *testing.T) {
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				switch p, m := req.URL.Path, req.Method; {
-				case p == "/namespaces/test/rolebindings" && m == "POST":
+				case p == "/tenants/system/namespaces/test/rolebindings" && m == "POST":
 					bodyBits, err := ioutil.ReadAll(req.Body)
 					if err != nil {
 						t.Fatalf("TestCreateRoleBinding error: %v", err)

--- a/pkg/kubectl/cmd/create/create_secret_test.go
+++ b/pkg/kubectl/cmd/create/create_secret_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -47,7 +48,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/secrets" && m == "POST":
+			case p == "/tenants/system/namespaces/test/secrets" && m == "POST":
 				return &http.Response{StatusCode: 201, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, secretObject)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -79,7 +80,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/secrets" && m == "POST":
+			case p == "/tenants/system/namespaces/test/secrets" && m == "POST":
 				return &http.Response{StatusCode: 201, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, secretObject)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/create/create_service_test.go
+++ b/pkg/kubectl/cmd/create/create_service_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +43,7 @@ func TestCreateService(t *testing.T) {
 		NegotiatedSerializer: negSer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == "POST":
+			case p == "/tenants/system/namespaces/test/services" && m == "POST":
 				return &http.Response{StatusCode: 201, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, service)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -75,7 +76,7 @@ func TestCreateServiceNodePort(t *testing.T) {
 		NegotiatedSerializer: negSer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == http.MethodPost:
+			case p == "/tenants/system/namespaces/test/services" && m == http.MethodPost:
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, service)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -108,7 +109,7 @@ func TestCreateServiceExternalName(t *testing.T) {
 		NegotiatedSerializer: negSer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == http.MethodPost:
+			case p == "/tenants/system/namespaces/test/services" && m == http.MethodPost:
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, service)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/create/create_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/create/create_serviceaccount_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +43,7 @@ func TestCreateServiceAccount(t *testing.T) {
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/serviceaccounts" && m == "POST":
+			case p == "/tenants/system/namespaces/test/serviceaccounts" && m == "POST":
 				return &http.Response{StatusCode: 201, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, serviceAccountObject)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/create/create_test.go
+++ b/pkg/kubectl/cmd/create/create_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -56,7 +57,7 @@ func TestCreateObject(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers" && m == http.MethodPost:
+			case p == "/tenants/system/namespaces/test/replicationcontrollers" && m == http.MethodPost:
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -91,9 +92,9 @@ func TestCreateMultipleObject(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == http.MethodPost:
+			case p == "/tenants/system/namespaces/test/services" && m == http.MethodPost:
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
-			case p == "/namespaces/test/replicationcontrollers" && m == http.MethodPost:
+			case p == "/tenants/system/namespaces/test/replicationcontrollers" && m == http.MethodPost:
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -130,7 +131,7 @@ func TestCreateDirectory(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers" && m == http.MethodPost:
+			case p == "/tenants/system/namespaces/test/replicationcontrollers" && m == http.MethodPost:
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/delete/delete_test.go
+++ b/pkg/kubectl/cmd/delete/delete_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -60,11 +61,11 @@ func TestDeleteObjectByTuple(t *testing.T) {
 			switch p, m := req.URL.Path, req.Method; {
 
 			// replication controller with cascade off
-			case p == "/namespaces/test/replicationcontrollers/redis-master-controller" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/redis-master-controller" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 
 			// secret with cascade on, but no client-side reaper
-			case p == "/namespaces/test/secrets/mysecret" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/secrets/mysecret" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 
 			default:
@@ -125,7 +126,7 @@ func TestOrphanDependentsInDeleteObject(t *testing.T) {
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m, b := req.URL.Path, req.Method, req.Body; {
 
-			case p == "/namespaces/test/secrets/mysecret" && m == "DELETE" && hasExpectedPropagationPolicy(b, policy):
+			case p == "/tenants/system/namespaces/test/secrets/mysecret" && m == "DELETE" && hasExpectedPropagationPolicy(b, policy):
 
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
@@ -176,11 +177,11 @@ func TestDeleteNamedObject(t *testing.T) {
 			switch p, m := req.URL.Path, req.Method; {
 
 			// replication controller with cascade off
-			case p == "/namespaces/test/replicationcontrollers/redis-master-controller" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/redis-master-controller" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 
 			// secret with cascade on, but no client-side reaper
-			case p == "/namespaces/test/secrets/mysecret" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/secrets/mysecret" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 
 			default:
@@ -226,7 +227,7 @@ func TestDeleteObject(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -263,7 +264,7 @@ func TestDeleteObjectGraceZero(t *testing.T) {
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			t.Logf("got request %s %s", req.Method, req.URL.Path)
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/pods/nginx" && m == "GET":
+			case p == "/tenants/system/namespaces/test/pods/nginx" && m == "GET":
 				count++
 				switch count {
 				case 1, 2, 3:
@@ -271,9 +272,9 @@ func TestDeleteObjectGraceZero(t *testing.T) {
 				default:
 					return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &metav1.Status{})}, nil
 				}
-			case p == "/api/v1/namespaces/test" && m == "GET":
+			case p == "/api/v1/tenants/system/namespaces/test" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.Namespace{})}, nil
-			case p == "/namespaces/test/pods/nginx" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/pods/nginx" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -306,7 +307,7 @@ func TestDeleteObjectNotFound(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -343,7 +344,7 @@ func TestDeleteObjectIgnoreNotFound(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -381,11 +382,11 @@ func TestDeleteAllNotFound(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == "GET":
+			case p == "/tenants/system/namespaces/test/services" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svc)}, nil
-			case p == "/namespaces/test/services/foo" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/services/foo" && m == "DELETE":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, notFoundError)}, nil
-			case p == "/namespaces/test/services/baz" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/services/baz" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -431,11 +432,11 @@ func TestDeleteAllIgnoreNotFound(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == "GET":
+			case p == "/tenants/system/namespaces/test/services" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svc)}, nil
-			case p == "/namespaces/test/services/foo" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/services/foo" && m == "DELETE":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, notFoundError)}, nil
-			case p == "/namespaces/test/services/baz" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/services/baz" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -469,9 +470,9 @@ func TestDeleteMultipleObject(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
-			case p == "/namespaces/test/services/frontend" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/services/frontend" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -506,9 +507,9 @@ func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
-			case p == "/namespaces/test/services/frontend" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/services/frontend" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -553,13 +554,13 @@ func TestDeleteMultipleResourcesWithTheSameName(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers/baz" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/baz" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
-			case p == "/namespaces/test/replicationcontrollers/foo" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/foo" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
-			case p == "/namespaces/test/services/baz" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/services/baz" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
-			case p == "/namespaces/test/services/foo" && m == "DELETE":
+			case p == "/tenants/system/namespaces/test/services/foo" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
 			default:
 				// Ensures no GET is performed when deleting by name
@@ -593,7 +594,7 @@ func TestDeleteDirectory(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case strings.HasPrefix(p, "/namespaces/test/replicationcontrollers/") && m == "DELETE":
+			case strings.HasPrefix(p, "/tenants/system/namespaces/test/replicationcontrollers/") && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -627,19 +628,19 @@ func TestDeleteMultipleSelector(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/pods" && m == "GET":
+			case p == "/tenants/system/namespaces/test/pods" && m == "GET":
 				if req.URL.Query().Get(metav1.LabelSelectorQueryParam("v1")) != "a=b" {
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				}
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
-			case p == "/namespaces/test/services" && m == "GET":
+			case p == "/tenants/system/namespaces/test/services" && m == "GET":
 				if req.URL.Query().Get(metav1.LabelSelectorQueryParam("v1")) != "a=b" {
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				}
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svc)}, nil
-			case strings.HasPrefix(p, "/namespaces/test/pods/") && m == "DELETE":
+			case strings.HasPrefix(p, "/tenants/system/namespaces/test/pods/") && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
-			case strings.HasPrefix(p, "/namespaces/test/services/") && m == "DELETE":
+			case strings.HasPrefix(p, "/tenants/system/namespaces/test/services/") && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/delete/multi_tenancy_delete_test.go
+++ b/pkg/kubectl/cmd/delete/multi_tenancy_delete_test.go
@@ -244,7 +244,7 @@ func TestDeleteObjectGraceZeroWithMultiTenancy(t *testing.T) {
 				default:
 					return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &metav1.Status{})}, nil
 				}
-			case p == "/api/v1/namespaces/test" && m == "GET":
+			case p == "/api/v1/tenants/system/namespaces/test" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.Namespace{})}, nil
 			case p == "/tenants/test-te/namespaces/test/pods/nginx" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil

--- a/pkg/kubectl/cmd/describe/describe_test.go
+++ b/pkg/kubectl/cmd/describe/describe_test.go
@@ -115,7 +115,7 @@ func TestDescribeObject(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == "GET":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers/redis-master" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/drain/drain_test.go
+++ b/pkg/kubectl/cmd/drain/drain_test.go
@@ -788,19 +788,19 @@ func TestDrain(t *testing.T) {
 							return cmdtesting.GenResponseWithJsonEncodedBody(resourceList)
 						case m.isFor("GET", "/nodes/node"):
 							return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, test.node)}, nil
-						case m.isFor("GET", "/namespaces/default/replicationcontrollers/rc"):
+						case m.isFor("GET", "/tenants/system/namespaces/default/replicationcontrollers/rc"):
 							return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &test.rcs[0])}, nil
-						case m.isFor("GET", "/namespaces/default/daemonsets/ds"):
+						case m.isFor("GET", "/tenants/system/namespaces/default/daemonsets/ds"):
 							return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &ds)}, nil
-						case m.isFor("GET", "/namespaces/default/daemonsets/missing-ds"):
+						case m.isFor("GET", "/tenants/system/namespaces/default/daemonsets/missing-ds"):
 							return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &appsv1.DaemonSet{})}, nil
-						case m.isFor("GET", "/namespaces/default/jobs/job"):
+						case m.isFor("GET", "/tenants/system/namespaces/default/jobs/job"):
 							return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &job)}, nil
-						case m.isFor("GET", "/namespaces/default/replicasets/rs"):
+						case m.isFor("GET", "/tenants/system/namespaces/default/replicasets/rs"):
 							return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &test.replicaSets[0])}, nil
-						case m.isFor("GET", "/namespaces/default/pods/bar"):
+						case m.isFor("GET", "/tenants/system/namespaces/default/pods/bar"):
 							return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.Pod{})}, nil
-						case m.isFor("GET", "/pods"):
+						case m.isFor("GET", "/tenants/system/pods"):
 							values, err := url.ParseQuery(req.URL.RawQuery)
 							if err != nil {
 								t.Fatalf("%s: unexpected error: %v", test.description, err)
@@ -834,10 +834,10 @@ func TestDrain(t *testing.T) {
 								t.Fatalf("%s: expected:\n%v\nsaw:\n%v\n", test.description, test.expected.Spec, newNode.Spec)
 							}
 							return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, newNode)}, nil
-						case m.isFor("DELETE", "/namespaces/default/pods/bar"):
+						case m.isFor("DELETE", "/tenants/system/namespaces/default/pods/bar"):
 							atomic.AddInt32(&deletions, 1)
 							return &http.Response{StatusCode: 204, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &test.pods[0])}, nil
-						case m.isFor("POST", "/namespaces/default/pods/bar/eviction"):
+						case m.isFor("POST", "/tenants/system/namespaces/default/pods/bar/eviction"):
 
 							atomic.AddInt32(&evictions, 1)
 							return &http.Response{StatusCode: 201, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &policyv1beta1.Eviction{})}, nil

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/0.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/0.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "cm1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/configmaps/cm1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/configmaps/cm1",
         "uid": "cc08a131-3d6f-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3518",
         "creationTimestamp": "2017-05-20T15:20:03Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/1.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/1.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "svc1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/services/svc1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/services/svc1",
         "uid": "d8b96f0b-3d6f-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3525",
         "creationTimestamp": "2017-05-20T15:20:24Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/4.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/4.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "cm1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/configmaps/cm1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/configmaps/cm1",
         "uid": "cc08a131-3d6f-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3554",
         "creationTimestamp": "2017-05-20T15:20:03Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/5.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/5.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "svc1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/services/svc1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/services/svc1",
         "uid": "d8b96f0b-3d6f-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3555",
         "creationTimestamp": "2017-05-20T15:20:24Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list-fail/test.yaml
@@ -11,13 +11,13 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/myproject/configmaps/cm1
+  expectedPath: /api/v1/tenants/system/namespaces/myproject/configmaps/cm1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/myproject/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/myproject/services/svc1
   expectedInput: 1.request
   resultingStatusCode: 200
   resultingOutput: 1.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/0.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/0.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "cm1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/configmaps/cm1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/configmaps/cm1",
         "uid": "cc08a131-3d6f-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3518",
         "creationTimestamp": "2017-05-20T15:20:03Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/1.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/1.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "svc1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/services/svc1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/services/svc1",
         "uid": "d8b96f0b-3d6f-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3525",
         "creationTimestamp": "2017-05-20T15:20:24Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/3.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/3.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "cm1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/configmaps/cm1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/configmaps/cm1",
         "uid": "cc08a131-3d6f-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3554",
         "creationTimestamp": "2017-05-20T15:20:03Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/4.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/4.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "svc1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/services/svc1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/services/svc1",
         "uid": "d8b96f0b-3d6f-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3555",
         "creationTimestamp": "2017-05-20T15:20:24Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-list/test.yaml
@@ -11,13 +11,13 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/myproject/configmaps/cm1
+  expectedPath: /api/v1/tenants/system/namespaces/myproject/configmaps/cm1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/myproject/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/myproject/services/svc1
   expectedInput: 1.request
   resultingStatusCode: 200
   resultingOutput: 1.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-syntax-error/0.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-syntax-error/0.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "svc1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/services/svc1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/services/svc1",
         "uid": "1e16d988-3d72-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3731",
         "creationTimestamp": "2017-05-20T15:36:39Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-syntax-error/3.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-syntax-error/3.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "svc1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/services/svc1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/services/svc1",
         "uid": "1e16d988-3d72-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3857",
         "creationTimestamp": "2017-05-20T15:36:39Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-syntax-error/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied-syntax-error/test.yaml
@@ -9,7 +9,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/myproject/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/myproject/services/svc1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied/0.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied/0.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "svc1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/services/svc1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/services/svc1",
         "uid": "bc66b442-3d6a-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3036",
         "creationTimestamp": "2017-05-20T14:43:49Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied/2.response
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied/2.response
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "svc1",
         "namespace": "myproject",
-        "selfLink": "/api/v1/namespaces/myproject/services/svc1",
+        "selfLink": "/api/v1/tenants/system/namespaces/myproject/services/svc1",
         "uid": "bc66b442-3d6a-11e7-8ef0-c85b76034b7b",
         "resourceVersion": "3093",
         "creationTimestamp": "2017-05-20T14:43:49Z",

--- a/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-apply-edit-last-applied/test.yaml
@@ -11,7 +11,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/myproject/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/myproject/services/svc1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-edit-error-reedit/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-edit-error-reedit/test.yaml
@@ -12,7 +12,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/services/svc1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-edit-output-patch/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-edit-output-patch/test.yaml
@@ -16,7 +16,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/services/svc1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-list-record/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-list-record/test.yaml
@@ -11,13 +11,13 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/configmaps/cm1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/configmaps/cm1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/services/svc1
   expectedInput: 1.request
   resultingStatusCode: 200
   resultingOutput: 1.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-list/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-list/test.yaml
@@ -11,13 +11,13 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/configmaps/cm1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/configmaps/cm1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/services/svc1
   expectedInput: 1.request
   resultingStatusCode: 200
   resultingOutput: 1.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-missing-service/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-missing-service/test.yaml
@@ -9,7 +9,7 @@ expectedExitCode: 1
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/default/services/missing
+  expectedPath: /api/v1/tenants/system/namespaces/default/services/missing
   expectedInput: 0.request
   resultingStatusCode: 404
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-no-op/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-no-op/test.yaml
@@ -9,7 +9,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/default/configmaps/mymap
+  expectedPath: /api/v1/tenants/system/namespaces/default/configmaps/mymap
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-not-update-annotation/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-not-update-annotation/test.yaml
@@ -14,7 +14,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/services/svc1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-repeat-error/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-repeat-error/test.yaml
@@ -11,7 +11,7 @@ expectedExitCode: 1
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/default/services/kubernetes
+  expectedPath: /api/v1/tenants/system/namespaces/default/services/kubernetes
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-schemaless-list/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-schemaless-list/test.yaml
@@ -13,19 +13,19 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/default/services/kubernetes
+  expectedPath: /api/v1/tenants/system/namespaces/default/services/kubernetes
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response
 - type: request
   expectedMethod: GET
-  expectedPath: /apis/company.com/v1/namespaces/default/bars/test
+  expectedPath: /apis/company.com/v1/tenants/system/namespaces/default/bars/test
   expectedInput: 1.request
   resultingStatusCode: 200
   resultingOutput: 1.response
 - type: request
   expectedMethod: GET
-  expectedPath: /apis/company.com/v1/namespaces/default/bars/test2
+  expectedPath: /apis/company.com/v1/tenants/system/namespaces/default/bars/test2
   expectedInput: 2.request
   resultingStatusCode: 200
   resultingOutput: 2.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-single-service/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-single-service/test.yaml
@@ -13,7 +13,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/services/svc1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-syntax-error/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-syntax-error/test.yaml
@@ -9,7 +9,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/default/services/kubernetes
+  expectedPath: /api/v1/tenants/system/namespaces/default/services/kubernetes
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/edit/testdata/testcase-update-annotation/test.yaml
+++ b/pkg/kubectl/cmd/edit/testdata/testcase-update-annotation/test.yaml
@@ -14,7 +14,7 @@ expectedExitCode: 0
 steps:
 - type: request
   expectedMethod: GET
-  expectedPath: /api/v1/namespaces/edit-test/services/svc1
+  expectedPath: /api/v1/tenants/system/namespaces/edit-test/services/svc1
   expectedInput: 0.request
   resultingStatusCode: 200
   resultingOutput: 0.response

--- a/pkg/kubectl/cmd/exec/exec_test.go
+++ b/pkg/kubectl/cmd/exec/exec_test.go
@@ -305,11 +305,7 @@ func execPod(tenant string) *corev1.Pod {
 }
 
 func podFetchPath(tenant string) string {
-	if tenant == metav1.TenantSystem {
-		return "/namespaces/test/pods/foo"
-	} else {
-		return "/tenants/" + tenant + "/namespaces/test/pods/foo"
-	}
+	return "/tenants/" + tenant + "/namespaces/test/pods/foo"
 }
 
 func TestSetupTTY(t *testing.T) {

--- a/pkg/kubectl/cmd/expose/expose_test.go
+++ b/pkg/kubectl/cmd/expose/expose_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,8 +51,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -81,8 +82,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -112,8 +113,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "mayor"},
 			ns:   "default",
 			calls: map[string]string{
-				"GET":  "/namespaces/default/services/mayor",
-				"POST": "/namespaces/default/services",
+				"GET":  "/tenants/system/namespaces/default/services/mayor",
+				"POST": "/tenants/system/namespaces/default/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "mayor", Namespace: "default", ResourceVersion: "12"},
@@ -144,8 +145,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -175,8 +176,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -207,8 +208,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -239,8 +240,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -271,8 +272,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -297,8 +298,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/redis-master",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/redis-master",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "redis-master", Namespace: "test", ResourceVersion: "12"},
@@ -327,8 +328,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"pod", "a-name-that-is-toooo-big-for-a-service-because-it-can-only-handle-63-characters"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/pods/a-name-that-is-toooo-big-for-a-service-because-it-can-only-handle-63-characters",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/pods/a-name-that-is-toooo-big-for-a-service-because-it-can-only-handle-63-characters",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -355,8 +356,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "foo"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/foo",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/foo",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "", Labels: map[string]string{"svc": "multiport"}},
@@ -403,8 +404,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "foo"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/foo",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/foo",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "", Labels: map[string]string{"svc": "multiport"}},
@@ -473,8 +474,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -504,8 +505,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -535,8 +536,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
@@ -567,8 +568,8 @@ func TestRunExposeService(t *testing.T) {
 			args: []string{"service", "baz"},
 			ns:   "test",
 			calls: map[string]string{
-				"GET":  "/namespaces/test/services/baz",
-				"POST": "/namespaces/test/services",
+				"GET":  "/tenants/system/namespaces/test/services/baz",
+				"POST": "/tenants/system/namespaces/test/services",
 			},
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -282,25 +282,25 @@ func TestGetMultipleResourceTypesShowKinds(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/pods" && m == "GET":
+			case p == "/tenants/system/namespaces/test/pods" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
-			case p == "/namespaces/test/replicationcontrollers" && m == "GET":
+			case p == "/tenants/system/namespaces/test/replicationcontrollers" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.ReplicationControllerList{})}, nil
-			case p == "/namespaces/test/services" && m == "GET":
+			case p == "/tenants/system/namespaces/test/services" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svcs)}, nil
-			case p == "/namespaces/test/statefulsets" && m == "GET":
+			case p == "/tenants/system/namespaces/test/statefulsets" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &appsv1.StatefulSetList{})}, nil
-			case p == "/namespaces/test/horizontalpodautoscalers" && m == "GET":
+			case p == "/tenants/system/namespaces/test/horizontalpodautoscalers" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &autoscalingv1.HorizontalPodAutoscalerList{})}, nil
-			case p == "/namespaces/test/jobs" && m == "GET":
+			case p == "/tenants/system/namespaces/test/jobs" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &batchv1.JobList{})}, nil
-			case p == "/namespaces/test/cronjobs" && m == "GET":
+			case p == "/tenants/system/namespaces/test/cronjobs" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &batchv1beta1.CronJobList{})}, nil
-			case p == "/namespaces/test/daemonsets" && m == "GET":
+			case p == "/tenants/system/namespaces/test/daemonsets" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &appsv1.DaemonSetList{})}, nil
-			case p == "/namespaces/test/deployments" && m == "GET":
+			case p == "/tenants/system/namespaces/test/deployments" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &extensionsv1beta1.DeploymentList{})}, nil
-			case p == "/namespaces/test/replicasets" && m == "GET":
+			case p == "/tenants/system/namespaces/test/replicasets" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &extensionsv1beta1.ReplicaSetList{})}, nil
 
 			default:
@@ -360,7 +360,7 @@ func TestGetEmptyTable(t *testing.T) {
 "kind":"Table",
 "apiVersion":"meta.k8s.io/v1beta1",
 "metadata":{
-	"selfLink":"/api/v1/namespaces/default/pods",
+	"selfLink":"/api/v1/tenants/system/namespaces/default/pods",
 	"resourceVersion":"346"
 },
 "columnDefinitions":[
@@ -413,9 +413,9 @@ func TestGetObjectIgnoreNotFound(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/pods/nonexistentpod" && m == "GET":
+			case p == "/tenants/system/namespaces/test/pods/nonexistentpod" && m == "GET":
 				return &http.Response{StatusCode: 404, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
-			case p == "/api/v1/namespaces/test" && m == "GET":
+			case p == "/api/v1/tenants/system/namespaces/test" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &ns.Items[0])}, nil
 			default:
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
@@ -849,7 +849,7 @@ func TestGetMixedGenericObjects(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, structuredObj)}, nil
 			default:
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
@@ -898,9 +898,9 @@ func TestGetMultipleTypeObjects(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
-			case "/namespaces/test/services":
+			case "/tenants/system/namespaces/test/services":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svc)}, nil
 			default:
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
@@ -936,9 +936,9 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
-			case "/namespaces/test/services":
+			case "/tenants/system/namespaces/test/services":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svc)}, nil
 			default:
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
@@ -1041,9 +1041,9 @@ func TestGetMultipleTypeObjectsWithLabelSelector(t *testing.T) {
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
 			}
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
-			case "/namespaces/test/services":
+			case "/tenants/system/namespaces/test/services":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svc)}, nil
 			default:
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
@@ -1084,9 +1084,9 @@ func TestGetMultipleTypeObjectsWithFieldSelector(t *testing.T) {
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 			}
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
-			case "/namespaces/test/services":
+			case "/tenants/system/namespaces/test/services":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svc)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -1131,7 +1131,7 @@ func TestGetMultipleTypeObjectsWithDirectReference(t *testing.T) {
 			switch req.URL.Path {
 			case "/nodes/foo":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, node)}, nil
-			case "/namespaces/test/services/bar":
+			case "/tenants/system/namespaces/test/services/bar":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
@@ -1282,7 +1282,7 @@ func TestWatchLabelSelector(t *testing.T) {
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
 			}
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				if req.URL.Query().Get("watch") == "true" {
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: watchBody(codec, events[2:])}, nil
 				}
@@ -1333,7 +1333,7 @@ func TestWatchFieldSelector(t *testing.T) {
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 			}
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				if req.URL.Query().Get("watch") == "true" {
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: watchBody(codec, events[2:])}, nil
 				}
@@ -1375,9 +1375,9 @@ func TestWatchResource(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
-			case "/namespaces/test/pods/foo":
+			case "/tenants/system/namespaces/test/pods/foo":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods[1])}, nil
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				if req.URL.Query().Get("watch") == "true" && req.URL.Query().Get("fieldSelector") == "metadata.name=foo" {
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: watchBody(codec, events[1:])}, nil
 				}
@@ -1480,7 +1480,7 @@ func TestWatchResourceTable(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				if req.URL.Query().Get("watch") != "true" && req.URL.Query().Get("fieldSelector") == "" {
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, listTable)}, nil
 				}
@@ -1525,9 +1525,9 @@ func TestWatchResourceIdentifiedByFile(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
-			case "/namespaces/test/replicationcontrollers/cassandra":
+			case "/tenants/system/namespaces/test/replicationcontrollers/cassandra":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods[1])}, nil
-			case "/namespaces/test/replicationcontrollers":
+			case "/tenants/system/namespaces/test/replicationcontrollers":
 				if req.URL.Query().Get("watch") == "true" && req.URL.Query().Get("fieldSelector") == "metadata.name=cassandra" {
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: watchBody(codec, events[1:])}, nil
 				}
@@ -1569,9 +1569,9 @@ func TestWatchOnlyResource(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
-			case "/namespaces/test/pods/foo":
+			case "/tenants/system/namespaces/test/pods/foo":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods[1])}, nil
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				if req.URL.Query().Get("watch") == "true" && req.URL.Query().Get("fieldSelector") == "metadata.name=foo" {
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: watchBody(codec, events[1:])}, nil
 				}
@@ -1617,7 +1617,7 @@ func TestWatchOnlyList(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				if req.URL.Query().Get("watch") == "true" {
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: watchBody(codec, events[2:])}, nil
 				}
@@ -1670,10 +1670,10 @@ func TestGetMultipleTypeObjectsWithLabelRangeSelector(t *testing.T) {
 				t.Fatalf("The request does not have expected range params. Request url: %#v,and request: %#v", req.URL, req)
 			}
 			switch req.URL.Path {
-			case "/namespaces/test/pods":
+			case "/tenants/system/namespaces/test/pods":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
 			default:
-				t.Fatalf("The request url path does not start with /namespaces/test/pods. Request url: %#v,and request: %#v", req.URL, req)
+				t.Fatalf("The request url path does not start with /tenants/system/namespaces/test/pods. Request url: %#v,and request: %#v", req.URL, req)
 				return nil, nil
 			}
 		}),

--- a/pkg/kubectl/cmd/get/multi_tenancy_get_test.go
+++ b/pkg/kubectl/cmd/get/multi_tenancy_get_test.go
@@ -294,7 +294,7 @@ func TestGetEmptyTableWithMultiTenancy(t *testing.T) {
 "kind":"Table",
 "apiVersion":"meta.k8s.io/v1beta1",
 "metadata":{
-	"selfLink":"/api/v1/namespaces/default/pods",
+	"selfLink":"/api/v1/tenants/system/namespaces/default/pods",
 	"resourceVersion":"346"
 },
 "columnDefinitions":[

--- a/pkg/kubectl/cmd/label/label_test.go
+++ b/pkg/kubectl/cmd/label/label_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -367,7 +368,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 			switch req.Method {
 			case "GET":
 				switch req.URL.Path {
-				case "/namespaces/test/replicationcontrollers/cassandra":
+				case "/tenants/system/namespaces/test/replicationcontrollers/cassandra":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -375,7 +376,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 				}
 			case "PATCH":
 				switch req.URL.Path {
-				case "/namespaces/test/replicationcontrollers/cassandra":
+				case "/tenants/system/namespaces/test/replicationcontrollers/cassandra":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -454,7 +455,7 @@ func TestLabelMultipleObjects(t *testing.T) {
 			switch req.Method {
 			case "GET":
 				switch req.URL.Path {
-				case "/namespaces/test/pods":
+				case "/tenants/system/namespaces/test/pods":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -462,9 +463,9 @@ func TestLabelMultipleObjects(t *testing.T) {
 				}
 			case "PATCH":
 				switch req.URL.Path {
-				case "/namespaces/test/pods/foo":
+				case "/tenants/system/namespaces/test/pods/foo":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])}, nil
-				case "/namespaces/test/pods/bar":
+				case "/tenants/system/namespaces/test/pods/bar":
 					return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[1])}, nil
 				default:
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/patch/patch_test.go
+++ b/pkg/kubectl/cmd/patch/patch_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,7 +41,7 @@ func TestPatchObject(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services/frontend" && (m == "PATCH" || m == "GET"):
+			case p == "/tenants/system/namespaces/test/services/frontend" && (m == "PATCH" || m == "GET"):
 				obj := svc.Items[0]
 
 				// ensure patched object reflects successful
@@ -81,7 +82,7 @@ func TestPatchObjectFromFile(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services/frontend" && (m == "PATCH" || m == "GET"):
+			case p == "/tenants/system/namespaces/test/services/frontend" && (m == "PATCH" || m == "GET"):
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -118,9 +119,9 @@ func TestPatchNoop(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services/frontend" && m == "PATCH":
+			case p == "/tenants/system/namespaces/test/services/frontend" && m == "PATCH":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, patchObject)}, nil
-			case p == "/namespaces/test/services/frontend" && m == "GET":
+			case p == "/tenants/system/namespaces/test/services/frontend" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, getObject)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
@@ -165,9 +166,9 @@ func TestPatchObjectFromFileOutput(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services/frontend" && m == "GET":
+			case p == "/tenants/system/namespaces/test/services/frontend" && m == "GET":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &svc.Items[0])}, nil
-			case p == "/namespaces/test/services/frontend" && m == "PATCH":
+			case p == "/tenants/system/namespaces/test/services/frontend" && m == "PATCH":
 				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svcCopy)}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)

--- a/pkg/kubectl/cmd/portforward/portforward_test.go
+++ b/pkg/kubectl/cmd/portforward/portforward_test.go
@@ -604,11 +604,7 @@ func execPod(tenant string) *corev1.Pod {
 }
 
 func execPodPath(tenant string) string {
-	if tenant == metav1.TenantSystem {
-		return "/namespaces/test/pods/foo"
-	} else {
-		return "/tenants/" + tenant + "/namespaces/test/pods/foo"
-	}
+	return "/tenants/" + tenant + "/namespaces/test/pods/foo"
 }
 
 func TestConvertPodNamedPortToNumber(t *testing.T) {

--- a/pkg/kubectl/cmd/rollout/rollout_pause_test.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,7 +50,7 @@ func TestRolloutPause(t *testing.T) {
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				switch p, m := req.URL.Path, req.Method; {
-				case p == "/namespaces/test/deployments/nginx-deployment" && (m == "GET" || m == "PATCH"):
+				case (p == "/namespaces/test/deployments/nginx-deployment" || p == "/tenants/system/namespaces/test/deployments/nginx-deployment") && (m == "GET" || m == "PATCH"):
 					responseDeployment := &extensionsv1beta1.Deployment{}
 					responseDeployment.Name = deploymentName
 					body := ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(encoder, responseDeployment))))

--- a/pkg/kubectl/cmd/run/run_test.go
+++ b/pkg/kubectl/cmd/run/run_test.go
@@ -175,7 +175,7 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 				GroupVersion:         corev1.SchemeGroupVersion,
 				NegotiatedSerializer: ns,
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					if req.URL.Path == "/namespaces/test/replicationcontrollers" {
+					if req.URL.Path == "/tenants/system/namespaces/test/replicationcontrollers" {
 						return &http.Response{StatusCode: 201, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, rc)}, nil
 					}
 					return &http.Response{
@@ -336,7 +336,7 @@ func TestGenerateService(t *testing.T) {
 				NegotiatedSerializer: ns,
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
-					case test.expectPOST && m == "POST" && p == "/namespaces/test/services":
+					case test.expectPOST && m == "POST" && p == "/tenants/system/namespaces/test/services":
 						sawPOST = true
 						body := cmdtesting.ObjBody(codec, &test.service)
 						data, err := ioutil.ReadAll(req.Body)

--- a/pkg/kubectl/cmd/set/set_env_test.go
+++ b/pkg/kubectl/cmd/set/set_env_test.go
@@ -490,7 +490,7 @@ func TestSetEnvRemote(t *testing.T) {
 				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
-					case p == input.path && m == http.MethodGet:
+					case p == "/tenants/system"+input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: objBody(input.object)}, nil
 					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()
@@ -625,11 +625,11 @@ func TestSetEnvFromResource(t *testing.T) {
 				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
-					case p == "/namespaces/test/configmaps/testconfigmap" && m == http.MethodGet:
+					case p == "/tenants/system/namespaces/test/configmaps/testconfigmap" && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: objBody(mockConfigMap)}, nil
-					case p == "/namespaces/test/secrets/testsecret" && m == http.MethodGet:
+					case p == "/tenants/system/namespaces/test/secrets/testsecret" && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: objBody(mockSecret)}, nil
-					case p == "/namespaces/test/deployments/nginx" && m == http.MethodGet:
+					case p == "/tenants/system/namespaces/test/deployments/nginx" && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: objBody(mockDeployment)}, nil
 					case p == "/namespaces/test/deployments/nginx" && m == http.MethodPatch:
 						stream, err := req.GetBody()

--- a/pkg/kubectl/cmd/set/set_image_test.go
+++ b/pkg/kubectl/cmd/set/set_image_test.go
@@ -626,7 +626,7 @@ func TestSetImageRemote(t *testing.T) {
 				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
-					case p == input.path && m == http.MethodGet:
+					case p == "/tenants/system"+input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: objBody(input.object)}, nil
 					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()
@@ -738,7 +738,7 @@ func TestSetImageRemoteWithSpecificContainers(t *testing.T) {
 				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
-					case p == input.path && m == http.MethodGet:
+					case p == "/tenants/system"+input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: objBody(input.object)}, nil
 					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()

--- a/pkg/kubectl/cmd/set/set_resources_test.go
+++ b/pkg/kubectl/cmd/set/set_resources_test.go
@@ -476,7 +476,7 @@ func TestSetResourcesRemote(t *testing.T) {
 				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
-					case p == input.path && m == http.MethodGet:
+					case p == "/tenants/system"+input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: objBody(input.object)}, nil
 					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()

--- a/pkg/kubectl/cmd/set/set_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount_test.go
@@ -328,7 +328,7 @@ func TestSetServiceAccountRemote(t *testing.T) {
 				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					switch p, m := req.URL.Path, req.Method; {
-					case p == input.path && m == http.MethodGet:
+					case p == "/tenants/system"+input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: objBody(input.object)}, nil
 					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()

--- a/pkg/kubectl/cmd/top/top_node_test.go
+++ b/pkg/kubectl/cmd/top/top_node_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -97,7 +98,7 @@ func TestTopNodeAllMetrics(t *testing.T) {
 }
 
 func TestTopNodeAllMetricsCustomDefaults(t *testing.T) {
-	customBaseHeapsterServiceAddress := "/api/v1/namespaces/custom-namespace/services/https:custom-heapster-service:/proxy"
+	customBaseHeapsterServiceAddress := "/api/v1/tenants/system/namespaces/custom-namespace/services/https:custom-heapster-service:/proxy"
 	customBaseMetricsAddress := customBaseHeapsterServiceAddress + "/apis/metrics"
 
 	cmdtesting.InitTestErrorHandler(t)

--- a/pkg/kubectl/cmd/top/top_pod_test.go
+++ b/pkg/kubectl/cmd/top/top_pod_test.go
@@ -451,7 +451,7 @@ func (d *fakeDiscovery) RESTClients() []restclient.Interface {
 }
 
 func TestTopPodCustomDefaults(t *testing.T) {
-	customBaseHeapsterServiceAddress := "/api/v1/namespaces/custom-namespace/services/https:custom-heapster-service:/proxy"
+	customBaseHeapsterServiceAddress := "/api/v1/tenants/system/namespaces/custom-namespace/services/https:custom-heapster-service:/proxy"
 	customBaseMetricsAddress := customBaseHeapsterServiceAddress + "/apis/metrics"
 	customTopPathPrefix := customBaseMetricsAddress + "/" + metricsAPIVersion
 

--- a/pkg/kubectl/cmd/top/top_test.go
+++ b/pkg/kubectl/cmd/top/top_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,7 +36,7 @@ import (
 )
 
 const (
-	baseHeapsterServiceAddress = "/api/v1/namespaces/kube-system/services/http:heapster:/proxy"
+	baseHeapsterServiceAddress = "/api/v1/tenants/system/namespaces/kube-system/services/http:heapster:/proxy"
 	baseMetricsAddress         = baseHeapsterServiceAddress + "/apis/metrics"
 	baseMetricsServerAddress   = "/apis/metrics.k8s.io/v1beta1"
 	metricsAPIVersion          = "v1alpha1"

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -1515,7 +1515,7 @@ func TestUpdateRcWithRetries(t *testing.T) {
 		NegotiatedSerializer: scheme.Codecs,
 		Client: manualfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api/v1/namespaces/default/replicationcontrollers/rc" && m == "PUT":
+			case p == "/api/v1/tenants/system/namespaces/default/replicationcontrollers/rc" && m == "PUT":
 				update := updates[0]
 				updates = updates[1:]
 				// We should always get an update with a valid rc even when the get fails. The rc should always
@@ -1529,7 +1529,7 @@ func TestUpdateRcWithRetries(t *testing.T) {
 					delete(c.Spec.Selector, "baz")
 				}
 				return update, nil
-			case p == "/api/v1/namespaces/default/replicationcontrollers/rc" && m == "GET":
+			case p == "/api/v1/tenants/system/namespaces/default/replicationcontrollers/rc" && m == "GET":
 				get := gets[0]
 				gets = gets[1:]
 				return get, nil
@@ -1619,27 +1619,27 @@ func TestAddDeploymentHash(t *testing.T) {
 			header := http.Header{}
 			header.Set("Content-Type", runtime.ContentTypeJSON)
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api/v1/namespaces/default/pods" && m == "GET":
+			case p == "/api/v1/tenants/system/namespaces/default/pods" && m == "GET":
 				if req.URL.RawQuery != "labelSelector=foo%3Dbar" {
 					t.Errorf("Unexpected query string: %s", req.URL.RawQuery)
 				}
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, podList)}, nil
-			case p == "/api/v1/namespaces/default/pods/foo" && m == "PUT":
+			case p == "/api/v1/tenants/system/namespaces/default/pods/foo" && m == "PUT":
 				seen.Insert("foo")
 				obj := readOrDie(t, req, codec)
 				podList.Items[0] = *(obj.(*corev1.Pod))
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, &podList.Items[0])}, nil
-			case p == "/api/v1/namespaces/default/pods/bar" && m == "PUT":
+			case p == "/api/v1/tenants/system/namespaces/default/pods/bar" && m == "PUT":
 				seen.Insert("bar")
 				obj := readOrDie(t, req, codec)
 				podList.Items[1] = *(obj.(*corev1.Pod))
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, &podList.Items[1])}, nil
-			case p == "/api/v1/namespaces/default/pods/baz" && m == "PUT":
+			case p == "/api/v1/tenants/system/namespaces/default/pods/baz" && m == "PUT":
 				seen.Insert("baz")
 				obj := readOrDie(t, req, codec)
 				podList.Items[2] = *(obj.(*corev1.Pod))
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, &podList.Items[2])}, nil
-			case p == "/api/v1/namespaces/default/replicationcontrollers/rc" && m == "PUT":
+			case p == "/api/v1/tenants/system/namespaces/default/replicationcontrollers/rc" && m == "PUT":
 				updatedRc = true
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, rc)}, nil
 			default:

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -63,8 +64,12 @@ func forbiddenMessage(attributes authorizer.Attributes) string {
 		resource = resource + "/" + subresource
 	}
 
-	if ns := attributes.GetNamespace(); len(ns) > 0 {
+	if ns := attributes.GetNamespace(); len(ns) > 0 && resource != "namespaces" {
 		return fmt.Sprintf("User %q cannot %s resource %q in API group %q in the namespace %q", username, attributes.GetVerb(), resource, attributes.GetAPIGroup(), ns)
+	}
+
+	if tenant := attributes.GetTenant(); len(tenant) > 0 {
+		return fmt.Sprintf("User %q cannot %s resource %q in API group %q in the tenant %q", username, attributes.GetVerb(), resource, attributes.GetAPIGroup(), tenant)
 	}
 
 	return fmt.Sprintf("User %q cannot %s resource %q in API group %q at the cluster scope", username, attributes.GetVerb(), resource, attributes.GetAPIGroup())

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -72,6 +73,8 @@ func TestForbidden(t *testing.T) {
 `, authorizer.AttributesRecord{User: u, Verb: "get", Resource: "pod", ResourceRequest: true, Name: "mypod"}, "", "application/json"},
 		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pod.v2 is forbidden: User \"NAME\" cannot get resource \"pod/quota\" in API group \"v2\" in the namespace \"test\"","reason":"Forbidden","details":{"group":"v2","kind":"pod"},"code":403}
 `, authorizer.AttributesRecord{User: u, Verb: "get", Namespace: "test", APIGroup: "v2", Resource: "pod", Subresource: "quota", ResourceRequest: true}, "", "application/json"},
+		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespace is forbidden: User \"NAME\" cannot get resource \"namespace/status\" in API group \"\" in the tenant \"test-tenant\"","reason":"Forbidden","details":{"kind":"namespace"},"code":403}
+`, authorizer.AttributesRecord{User: u, Verb: "get", Tenant: "test-tenant", Namespace: "", APIGroup: "", Resource: "namespace", Subresource: "status", ResourceRequest: true}, "", "application/json"},
 	}
 	for _, test := range cases {
 		observer := httptest.NewRecorder()

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -839,7 +839,7 @@ func TestReplaceAliases(t *testing.T) {
 func TestResourceByName(t *testing.T) {
 	pods, _ := testData()
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
-		"/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
+		"/tenants/system/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
 	})).NamespaceParam("test")
 
 	test := &testVisitor{}
@@ -914,10 +914,10 @@ func TestRestMappingErrors(t *testing.T) {
 func TestMultipleResourceByTheSameName(t *testing.T) {
 	pods, svcs := testData()
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
-		"/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
-		"/namespaces/test/pods/baz":     runtime.EncodeOrDie(corev1Codec, &pods.Items[1]),
-		"/namespaces/test/services/foo": runtime.EncodeOrDie(corev1Codec, &svcs.Items[0]),
-		"/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, &svcs.Items[0]),
+		"/tenants/system/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
+		"/tenants/system/namespaces/test/pods/baz":     runtime.EncodeOrDie(corev1Codec, &pods.Items[1]),
+		"/tenants/system/namespaces/test/services/foo": runtime.EncodeOrDie(corev1Codec, &svcs.Items[0]),
+		"/tenants/system/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, &svcs.Items[0]),
 	})).
 		NamespaceParam("test")
 
@@ -994,8 +994,8 @@ func TestRequestModifier(t *testing.T) {
 func TestResourceNames(t *testing.T) {
 	pods, svc := testData()
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
-		"/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
-		"/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, &svc.Items[0]),
+		"/tenants/system/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
+		"/tenants/system/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, &svc.Items[0]),
 	})).NamespaceParam("test")
 
 	test := &testVisitor{}
@@ -1074,7 +1074,7 @@ func TestResourceByNameWithoutRequireObject(t *testing.T) {
 func TestResourceByNameAndEmptySelector(t *testing.T) {
 	pods, _ := testData()
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
-		"/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
+		"/tenants/system/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
 	})).
 		NamespaceParam("test").
 		LabelSelectorParam("").
@@ -1252,9 +1252,9 @@ func TestResourceTuple(t *testing.T) {
 				if requireObject {
 					pods, _ := testData()
 					expectedRequests = map[string]string{
-						"/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
-						"/namespaces/test/pods/bar": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
-						"/nodes/foo":                runtime.EncodeOrDie(corev1Codec, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}),
+						"/tenants/system/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
+						"/tenants/system/namespaces/test/pods/bar": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
+						"/nodes/foo": runtime.EncodeOrDie(corev1Codec, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}),
 					}
 				}
 				b := newDefaultBuilderWith(fakeClientWith(k, t, expectedRequests)).
@@ -1556,9 +1556,9 @@ func TestLatest(t *testing.T) {
 	}
 
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
-		"/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, newPod),
-		"/namespaces/test/pods/bar":     runtime.EncodeOrDie(corev1Codec, newPod2),
-		"/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, newSvc),
+		"/tenants/system/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, newPod),
+		"/tenants/system/namespaces/test/pods/bar":     runtime.EncodeOrDie(corev1Codec, newPod2),
+		"/tenants/system/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, newSvc),
 	})).
 		NamespaceParam("other").Stream(r, "STDIN").Flatten().Latest()
 

--- a/staging/src/k8s.io/client-go/deprecated-dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/deprecated-dynamic/client_test.go
@@ -101,7 +101,7 @@ func TestList(t *testing.T) {
 		{
 			name:      "namespaced_list",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
 			resp: getListJSON("vTest", "rTestList",
 				getJSON("vTest", "rTest", "item1"),
 				getJSON("vTest", "rTest", "item2")),
@@ -170,7 +170,7 @@ func TestGet(t *testing.T) {
 			resource:  "rtest",
 			namespace: "nstest",
 			name:      "namespaced_get",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_get",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_get",
 			resp:      getJSON("vTest", "rTest", "namespaced_get"),
 			want:      getObject("vTest", "rTest", "namespaced_get"),
 		},
@@ -185,7 +185,7 @@ func TestGet(t *testing.T) {
 			resource:  "rtest/srtest",
 			namespace: "nstest",
 			name:      "namespaced_subresource_get",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_get/srtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_get/srtest",
 			resp:      getJSON("vTest", "srTest", "namespaced_subresource_get"),
 			want:      getObject("vTest", "srTest", "namespaced_subresource_get"),
 		},
@@ -244,12 +244,12 @@ func TestDelete(t *testing.T) {
 		{
 			namespace: "nstest",
 			name:      "namespaced_delete",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete",
 		},
 		{
 			namespace:     "nstest",
 			name:          "namespaced_delete_with_options",
-			path:          "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete_with_options",
+			path:          "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete_with_options",
 			deleteOptions: &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}, PropagationPolicy: &background},
 		},
 	}
@@ -299,7 +299,7 @@ func TestDeleteCollection(t *testing.T) {
 		{
 			namespace: "nstest",
 			name:      "namespaced_delete_collection",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
 		},
 	}
 	for _, tc := range tcs {
@@ -349,7 +349,7 @@ func TestCreate(t *testing.T) {
 			resource:  "rtest",
 			name:      "namespaced_create",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
 			obj:       getObject("gtest/vTest", "rTest", "namespaced_create"),
 		},
 	}
@@ -411,7 +411,7 @@ func TestUpdate(t *testing.T) {
 			resource:  "rtest",
 			name:      "namespaced_update",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_update",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_update",
 			obj:       getObject("gtest/vTest", "rTest", "namespaced_update"),
 		},
 		{
@@ -424,7 +424,7 @@ func TestUpdate(t *testing.T) {
 			resource:  "rtest/srtest",
 			name:      "namespaced_subresource_update",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_update/srtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_update/srtest",
 			obj:       getObject("gtest/vTest", "srTest", "namespaced_update"),
 		},
 	}
@@ -489,7 +489,7 @@ func TestWatch(t *testing.T) {
 		{
 			name:      "namespaced_watch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
 			query:     "watch=true",
 			events: []watch.Event{
 				{Type: watch.Added, Object: getObject("gtest/vTest", "rTest", "namespaced_watch")},
@@ -559,7 +559,7 @@ func TestPatch(t *testing.T) {
 			resource:  "rtest",
 			name:      "namespaced_patch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_patch",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_patch",
 			patch:     getJSON("gtest/vTest", "rTest", "namespaced_patch"),
 			want:      getObject("gtest/vTest", "rTest", "namespaced_patch"),
 		},
@@ -574,7 +574,7 @@ func TestPatch(t *testing.T) {
 			resource:  "rtest/srtest",
 			name:      "namespaced_subresource_patch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_patch/srtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_patch/srtest",
 			patch:     getJSON("gtest/vTest", "srTest", "namespaced_subresource_patch"),
 			want:      getObject("gtest/vTest", "srTest", "namespaced_subresource_patch"),
 		},

--- a/staging/src/k8s.io/client-go/dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_test.go
@@ -82,7 +82,7 @@ func TestList(t *testing.T) {
 	}{
 		{
 			name: "normal_list",
-			path: "/apis/gtest/vtest/rtest",
+			path: "/apis/gtest/vtest/tenants/system/rtest",
 			resp: getListJSON("vTest", "rTestList",
 				getJSON("vTest", "rTest", "item1"),
 				getJSON("vTest", "rTest", "item2")),
@@ -100,7 +100,7 @@ func TestList(t *testing.T) {
 		{
 			name:      "namespaced_list",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
 			resp: getListJSON("vTest", "rTestList",
 				getJSON("vTest", "rTest", "item1"),
 				getJSON("vTest", "rTest", "item2")),
@@ -161,7 +161,7 @@ func TestGet(t *testing.T) {
 		{
 			resource: "rtest",
 			name:     "normal_get",
-			path:     "/apis/gtest/vtest/rtest/normal_get",
+			path:     "/apis/gtest/vtest/tenants/system/rtest/normal_get",
 			resp:     getJSON("vTest", "rTest", "normal_get"),
 			want:     getObject("vTest", "rTest", "normal_get"),
 		},
@@ -169,7 +169,7 @@ func TestGet(t *testing.T) {
 			resource:  "rtest",
 			namespace: "nstest",
 			name:      "namespaced_get",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_get",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_get",
 			resp:      getJSON("vTest", "rTest", "namespaced_get"),
 			want:      getObject("vTest", "rTest", "namespaced_get"),
 		},
@@ -177,7 +177,7 @@ func TestGet(t *testing.T) {
 			resource:    "rtest",
 			subresource: []string{"srtest"},
 			name:        "normal_subresource_get",
-			path:        "/apis/gtest/vtest/rtest/normal_subresource_get/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_subresource_get/srtest",
 			resp:        getJSON("vTest", "srTest", "normal_subresource_get"),
 			want:        getObject("vTest", "srTest", "normal_subresource_get"),
 		},
@@ -186,7 +186,7 @@ func TestGet(t *testing.T) {
 			subresource: []string{"srtest"},
 			namespace:   "nstest",
 			name:        "namespaced_subresource_get",
-			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_get/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_get/srtest",
 			resp:        getJSON("vTest", "srTest", "namespaced_subresource_get"),
 			want:        getObject("vTest", "srTest", "namespaced_subresource_get"),
 		},
@@ -240,28 +240,28 @@ func TestDelete(t *testing.T) {
 	}{
 		{
 			name: "normal_delete",
-			path: "/apis/gtest/vtest/rtest/normal_delete",
+			path: "/apis/gtest/vtest/tenants/system/rtest/normal_delete",
 		},
 		{
 			namespace: "nstest",
 			name:      "namespaced_delete",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete",
 		},
 		{
 			subresource: []string{"srtest"},
 			name:        "normal_delete",
-			path:        "/apis/gtest/vtest/rtest/normal_delete/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_delete/srtest",
 		},
 		{
 			subresource: []string{"srtest"},
 			namespace:   "nstest",
 			name:        "namespaced_delete",
-			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete/srtest",
 		},
 		{
 			namespace:     "nstest",
 			name:          "namespaced_delete_with_options",
-			path:          "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete_with_options",
+			path:          "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete_with_options",
 			deleteOptions: &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}, PropagationPolicy: &background},
 		},
 	}
@@ -305,12 +305,12 @@ func TestDeleteCollection(t *testing.T) {
 	}{
 		{
 			name: "normal_delete_collection",
-			path: "/apis/gtest/vtest/rtest",
+			path: "/apis/gtest/vtest/tenants/system/rtest",
 		},
 		{
 			namespace: "nstest",
 			name:      "namespaced_delete_collection",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
 		},
 	}
 	for _, tc := range tcs {
@@ -353,21 +353,21 @@ func TestCreate(t *testing.T) {
 		{
 			resource: "rtest",
 			name:     "normal_create",
-			path:     "/apis/gtest/vtest/rtest",
+			path:     "/apis/gtest/vtest/tenants/system/rtest",
 			obj:      getObject("gtest/vTest", "rTest", "normal_create"),
 		},
 		{
 			resource:  "rtest",
 			name:      "namespaced_create",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
 			obj:       getObject("gtest/vTest", "rTest", "namespaced_create"),
 		},
 		{
 			resource:    "rtest",
 			subresource: []string{"srtest"},
 			name:        "normal_subresource_create",
-			path:        "/apis/gtest/vtest/rtest/normal_subresource_create/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_subresource_create/srtest",
 			obj:         getObject("vTest", "srTest", "normal_subresource_create"),
 		},
 		{
@@ -375,7 +375,7 @@ func TestCreate(t *testing.T) {
 			subresource: []string{"srtest"},
 			name:        "namespaced_subresource_create",
 			namespace:   "nstest",
-			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_create/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_create/srtest",
 			obj:         getObject("vTest", "srTest", "namespaced_subresource_create"),
 		},
 	}
@@ -430,21 +430,21 @@ func TestUpdate(t *testing.T) {
 		{
 			resource: "rtest",
 			name:     "normal_update",
-			path:     "/apis/gtest/vtest/rtest/normal_update",
+			path:     "/apis/gtest/vtest/tenants/system/rtest/normal_update",
 			obj:      getObject("gtest/vTest", "rTest", "normal_update"),
 		},
 		{
 			resource:  "rtest",
 			name:      "namespaced_update",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_update",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_update",
 			obj:       getObject("gtest/vTest", "rTest", "namespaced_update"),
 		},
 		{
 			resource:    "rtest",
 			subresource: []string{"srtest"},
 			name:        "normal_subresource_update",
-			path:        "/apis/gtest/vtest/rtest/normal_update/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_update/srtest",
 			obj:         getObject("gtest/vTest", "srTest", "normal_update"),
 		},
 		{
@@ -452,7 +452,7 @@ func TestUpdate(t *testing.T) {
 			subresource: []string{"srtest"},
 			name:        "namespaced_subresource_update",
 			namespace:   "nstest",
-			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_update/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_update/srtest",
 			obj:         getObject("gtest/vTest", "srTest", "namespaced_update"),
 		},
 	}
@@ -505,7 +505,7 @@ func TestWatch(t *testing.T) {
 	}{
 		{
 			name:  "normal_watch",
-			path:  "/apis/gtest/vtest/rtest",
+			path:  "/apis/gtest/vtest/tenants/system/rtest",
 			query: "watch=true",
 			events: []watch.Event{
 				{Type: watch.Added, Object: getObject("gtest/vTest", "rTest", "normal_watch")},
@@ -516,7 +516,7 @@ func TestWatch(t *testing.T) {
 		{
 			name:      "namespaced_watch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
 			query:     "watch=true",
 			events: []watch.Event{
 				{Type: watch.Added, Object: getObject("gtest/vTest", "rTest", "namespaced_watch")},
@@ -578,7 +578,7 @@ func TestPatch(t *testing.T) {
 		{
 			resource: "rtest",
 			name:     "normal_patch",
-			path:     "/apis/gtest/vtest/rtest/normal_patch",
+			path:     "/apis/gtest/vtest/tenants/system/rtest/normal_patch",
 			patch:    getJSON("gtest/vTest", "rTest", "normal_patch"),
 			want:     getObject("gtest/vTest", "rTest", "normal_patch"),
 		},
@@ -586,7 +586,7 @@ func TestPatch(t *testing.T) {
 			resource:  "rtest",
 			name:      "namespaced_patch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_patch",
+			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_patch",
 			patch:     getJSON("gtest/vTest", "rTest", "namespaced_patch"),
 			want:      getObject("gtest/vTest", "rTest", "namespaced_patch"),
 		},
@@ -594,7 +594,7 @@ func TestPatch(t *testing.T) {
 			resource:    "rtest",
 			subresource: []string{"srtest"},
 			name:        "normal_subresource_patch",
-			path:        "/apis/gtest/vtest/rtest/normal_subresource_patch/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_subresource_patch/srtest",
 			patch:       getJSON("gtest/vTest", "srTest", "normal_subresource_patch"),
 			want:        getObject("gtest/vTest", "srTest", "normal_subresource_patch"),
 		},
@@ -603,7 +603,7 @@ func TestPatch(t *testing.T) {
 			subresource: []string{"srtest"},
 			name:        "namespaced_subresource_patch",
 			namespace:   "nstest",
-			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_patch/srtest",
+			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_patch/srtest",
 			patch:       getJSON("gtest/vTest", "srTest", "namespaced_subresource_patch"),
 			want:        getObject("gtest/vTest", "srTest", "namespaced_subresource_patch"),
 		},

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -392,7 +392,7 @@ func (c *dynamicResourceClient) makeURLSegments(name string) []string {
 	}
 	url = append(url, c.resource.Version)
 
-	if len(c.tenant) > 0 && c.tenant != metav1.TenantSystem {
+	if len(c.tenant) > 0 {
 		url = append(url, "tenants", c.tenant)
 	}
 

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -452,7 +452,7 @@ func (r *Request) Context(ctx context.Context) *Request {
 // URL returns the current working URL.
 func (r *Request) URL() *url.URL {
 	p := r.pathPrefix
-	if r.tenantSet && len(r.tenant) > 0 && r.tenant != metav1.TenantSystem {
+	if r.tenantSet && len(r.tenant) > 0 {
 		p = path.Join(p, "tenants", r.tenant)
 	}
 	if r.namespaceSet && len(r.namespace) > 0 {

--- a/staging/src/k8s.io/client-go/scale/client_test.go
+++ b/staging/src/k8s.io/client-go/scale/client_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -159,11 +160,11 @@ func fakeScaleClient(t *testing.T) (ScalesGetter, []schema.GroupResource) {
 	}
 
 	resourcePaths := map[string]runtime.Object{
-		"/api/v1/namespaces/default/replicationcontrollers/foo/scale":                  autoscalingScale,
-		"/apis/extensions/v1beta1/namespaces/default/replicasets/foo/scale":            extScale,
-		"/apis/apps/v1beta1/namespaces/default/statefulsets/foo/scale":                 appsV1beta1Scale,
-		"/apis/apps/v1beta2/namespaces/default/deployments/foo/scale":                  appsV1beta2Scale,
-		"/apis/cheese.testing.k8s.io/v27alpha15/namespaces/default/cheddars/foo/scale": extScale,
+		"/api/v1/tenants/system/namespaces/default/replicationcontrollers/foo/scale":                  autoscalingScale,
+		"/apis/extensions/v1beta1/tenants/system/namespaces/default/replicasets/foo/scale":            extScale,
+		"/apis/apps/v1beta1/tenants/system/namespaces/default/statefulsets/foo/scale":                 appsV1beta1Scale,
+		"/apis/apps/v1beta2/tenants/system/namespaces/default/deployments/foo/scale":                  appsV1beta2Scale,
+		"/apis/cheese.testing.k8s.io/v27alpha15/tenants/system/namespaces/default/cheddars/foo/scale": extScale,
 	}
 
 	fakeReqHandler := func(req *http.Request) (*http.Response, error) {

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -98,19 +98,35 @@ func getTestWebhookTokenAuth(serverURL string) (authenticator.Request, error) {
 }
 
 func path(resource, namespace, name string) string {
-	return testapi.Default.ResourcePath(resource, namespace, name)
+	return pathWithMultiTenancy(resource, metav1.TenantSystem, namespace, name)
 }
 
 func pathWithPrefix(prefix, resource, namespace, name string) string {
-	return testapi.Default.ResourcePathWithPrefix(prefix, resource, namespace, name)
+	return pathWithPrefixWithMultiTenancy(prefix, resource, metav1.TenantSystem, namespace, name)
 }
 
 func pathWithSubResource(resource, namespace, name, subresource string) string {
-	return testapi.Default.SubResourcePath(resource, namespace, name, subresource)
+	return pathWithSubResourceWithMultiTenancy(resource, metav1.TenantSystem, namespace, name, subresource)
 }
 
 func timeoutPath(resource, namespace, name string) string {
-	return addTimeoutFlag(testapi.Default.ResourcePath(resource, namespace, name))
+	return timeoutPathWithMultiTenancy(resource, metav1.TenantSystem, namespace, name)
+}
+
+func pathWithMultiTenancy(resource, tenant, namespace, name string) string {
+	return testapi.Default.ResourcePathWithMultiTenancy(resource, tenant, namespace, name)
+}
+
+func pathWithPrefixWithMultiTenancy(prefix, resource, tenant, namespace, name string) string {
+	return testapi.Default.ResourcePathWithPrefixWithMultiTenancy(prefix, resource, tenant, namespace, name)
+}
+
+func pathWithSubResourceWithMultiTenancy(resource, tenant, namespace, name, subresource string) string {
+	return testapi.Default.SubResourcePathWithMultiTenancy(resource, tenant, namespace, name, subresource)
+}
+
+func timeoutPathWithMultiTenancy(resource, tenant, namespace, name string) string {
+	return addTimeoutFlag(testapi.Default.ResourcePathWithMultiTenancy(resource, tenant, namespace, name))
 }
 
 // Bodies for requests used in subsequent tests.
@@ -358,11 +374,11 @@ func getTestRequests(namespace string) []struct {
 		{"DELETE", timeoutPath("endpoints", namespace, "a"), "", integration.Code200},
 
 		// Normal methods on nodes
-		{"GET", path("nodes", "", ""), "", integration.Code200},
-		{"POST", timeoutPath("nodes", "", ""), aNode, integration.Code201},
-		{"PUT", timeoutPath("nodes", "", "a"), aNode, integration.Code200},
-		{"GET", path("nodes", "", "a"), "", integration.Code200},
-		{"DELETE", timeoutPath("nodes", "", "a"), "", integration.Code200},
+		{"GET", pathWithMultiTenancy("nodes", "", "", ""), "", integration.Code200},
+		{"POST", timeoutPathWithMultiTenancy("nodes", "", "", ""), aNode, integration.Code201},
+		{"PUT", timeoutPathWithMultiTenancy("nodes", "", "", "a"), aNode, integration.Code200},
+		{"GET", pathWithMultiTenancy("nodes", "", "", "a"), "", integration.Code200},
+		{"DELETE", timeoutPathWithMultiTenancy("nodes", "", "", "a"), "", integration.Code200},
 
 		// Normal methods on events
 		{"GET", path("events", "", ""), "", integration.Code200},
@@ -388,8 +404,8 @@ func getTestRequests(namespace string) []struct {
 		{"DELETE", timeoutPath("foo", namespace, ""), "", integration.Code404},
 
 		// Special verbs on nodes
-		{"GET", pathWithSubResource("nodes", namespace, "a", "proxy"), "", integration.Code404},
-		{"GET", pathWithPrefix("redirect", "nodes", namespace, "a"), "", integration.Code404},
+		{"GET", pathWithSubResourceWithMultiTenancy("nodes", "", namespace, "a", "proxy"), "", integration.Code404},
+		{"GET", pathWithPrefixWithMultiTenancy("redirect", "nodes", "", namespace, "a"), "", integration.Code404},
 		// TODO: test .../watch/..., which doesn't end before the test timeout.
 		// TODO: figure out how to create a node so that it can successfully proxy/redirect.
 

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -297,7 +297,7 @@ func (c *allClient) cleanup(all *[]cleanupData) error {
 		obj := (*all)[i].obj
 		gvr := (*all)[i].resource
 
-		if err := c.dynamicClient.Resource(gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), nil); err != nil {
+		if err := c.dynamicClient.Resource(gvr).NamespaceWithMultiTenancy(obj.GetNamespace(), obj.GetTenant()).Delete(obj.GetName(), nil); err != nil {
 			return err
 		}
 	}

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -313,7 +313,12 @@ func JSONToUnstructured(stub, namespace string, mapping *meta.RESTMapping, dynam
 		namespace = ""
 	}
 
-	return dynamicClient.Resource(mapping.Resource).Namespace(namespace), &unstructured.Unstructured{Object: typeMetaAdder}, nil
+	tenant := metav1.TenantSystem
+	if mapping.Scope == meta.RESTScopeRoot {
+		tenant = metav1.TenantNone
+	}
+
+	return dynamicClient.Resource(mapping.Resource).NamespaceWithMultiTenancy(namespace, tenant), &unstructured.Unstructured{Object: typeMetaAdder}, nil
 }
 
 func JSONToUnstructuredWithMultiTenancy(stub, tenant, namespace string, mapping *meta.RESTMapping, dynamicClient dynamic.Interface) (dynamic.ResourceInterface, *unstructured.Unstructured, error) {

--- a/test/integration/master/audit_dynamic_test.go
+++ b/test/integration/master/audit_dynamic_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -239,7 +240,7 @@ func simpleOp(name string, kubeclient kubernetes.Interface) ([]utils.AuditEvent,
 		{
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps/%s", namespace, name),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps/%s", namespace, name),
 			Verb:              "get",
 			Code:              404,
 			User:              auditTestUser,

--- a/test/integration/master/audit_test.go
+++ b/test/integration/master/audit_test.go
@@ -65,7 +65,7 @@ rules:
 		{
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps", namespace),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps", namespace),
 			Verb:              "create",
 			Code:              201,
 			User:              auditTestUser,
@@ -77,7 +77,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps/audit-configmap", namespace),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps/audit-configmap", namespace),
 			Verb:              "get",
 			Code:              200,
 			User:              auditTestUser,
@@ -89,7 +89,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps", namespace),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps", namespace),
 			Verb:              "list",
 			Code:              200,
 			User:              auditTestUser,
@@ -101,7 +101,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseStarted,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
 			Verb:              "watch",
 			Code:              200,
 			User:              auditTestUser,
@@ -113,7 +113,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
 			Verb:              "watch",
 			Code:              200,
 			User:              auditTestUser,
@@ -125,7 +125,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps/audit-configmap", namespace),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps/audit-configmap", namespace),
 			Verb:              "update",
 			Code:              200,
 			User:              auditTestUser,
@@ -137,7 +137,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps/audit-configmap", namespace),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps/audit-configmap", namespace),
 			Verb:              "patch",
 			Code:              200,
 			User:              auditTestUser,
@@ -149,7 +149,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps/audit-configmap", namespace),
+			RequestURI:        fmt.Sprintf("/api/v1/tenants/system/namespaces/%s/configmaps/audit-configmap", namespace),
 			Verb:              "delete",
 			Code:              200,
 			User:              auditTestUser,

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -121,7 +121,7 @@ func TestEmptyList(t *testing.T) {
 	_, s, closeFn := framework.RunAMaster(nil)
 	defer closeFn()
 
-	u := s.URL + "/api/v1/namespaces/default/pods"
+	u := s.URL + "/api/v1/tenants/system/namespaces/default/pods"
 	resp, err := http.Get(u)
 	if err != nil {
 		t.Fatalf("unexpected error getting %s: %v", u, err)
@@ -175,7 +175,7 @@ func TestStatus(t *testing.T) {
 			name:         "404",
 			masterConfig: nil,
 			statusCode:   http.StatusNotFound,
-			reqPath:      "/apis/batch/v1/namespaces/default/jobs/foo",
+			reqPath:      "/apis/batch/v1/tenants/system/namespaces/default/jobs/foo",
 			reason:       "NotFound",
 			message:      `jobs.batch "foo" not found`,
 		},


### PR DESCRIPTION
This PR fixes the issue https://github.com/futurewei-cloud/arktos/issues/393.

As the PR changes the REST url when the target tenant is "system", more than 200 test cases are affected. For the convenience of code reviewing, the PR is split into two commits:
1. code change of fix
2. updated tests

### verification done in my dev box:

Created a tenant called pokemon and corresponding admin user and the context. The following commands were run:

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=pokemon-admin-context get ns 
NAME          STATUS   AGE   TENANT
default       Active   1s    pokemon
kube-public   Active   1s    pokemon
kube-system   Active   1s    pokemon
 
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=pokemon-admin-context get ns --tenant system
Error from server (Forbidden): namespaces is forbidden: User "pokemon-admin" cannot list resource "namespaces" in API group "" in the tenant "system"

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=pokemon-admin-context create ns trial --tenant system
Error from server (Forbidden): namespaces is forbidden: User "pokemon-admin" cannot create resource "namespaces" in API group "" in the tenant "system"

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=pokemon-admin-context create ns trial
namespace/trial created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl --context=pokemon-admin-context delete ns trial --tenant system
Error from server (Forbidden): namespaces "trial" is forbidden: User "pokemon-admin" cannot delete resource "namespaces" in API group "" in the tenant "system"
```