### PR TITLE
Networkcontroller only start when using Neutron as network

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -368,6 +368,7 @@ func KnownControllers() []string {
 var ControllersDisabledByDefault = sets.NewString(
 	"bootstrapsigner",
 	"tokencleaner",
+	"network",
 )
 
 const (
@@ -417,10 +418,7 @@ func NewControllerInitializers(loopMode ControllerLoopMode) map[string]InitFunc 
 	controllers["pv-protection"] = startPVProtectionController
 	controllers["ttl-after-finished"] = startTTLAfterFinishedController
 	controllers["root-ca-cert-publisher"] = startRootCACertPublisher
-	networkController, set := os.LookupEnv("network")
-	if set && networkController == "neutron" {
-		controllers["network"] = startNetworkController
-	}
+	controllers["network"] = startNetworkController
 
 	return controllers
 }

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -417,7 +417,10 @@ func NewControllerInitializers(loopMode ControllerLoopMode) map[string]InitFunc 
 	controllers["pv-protection"] = startPVProtectionController
 	controllers["ttl-after-finished"] = startTTLAfterFinishedController
 	controllers["root-ca-cert-publisher"] = startRootCACertPublisher
-	controllers["network"] = startNetworkController
+	networkController, set := os.LookupEnv("network")
+	if set && networkController == "neutron" {
+		controllers["network"] = startNetworkController
+	}
 
 	return controllers
 }

--- a/pkg/controller/network/network_controller.go
+++ b/pkg/controller/network/network_controller.go
@@ -153,10 +153,6 @@ func (nc *NetworkController) updatePort(old, cur interface{}) {
 	needCreate := false
 	needUpdate := false
 
-	if new.Spec.NodeName != prev.Spec.NodeName {
-		needUpdate = true
-	}
-
 	client := GetOpenstackClient()
 	pod := new.DeepCopy()
 	for i, nic := range pod.Spec.Nics {
@@ -164,7 +160,8 @@ func (nc *NetworkController) updatePort(old, cur interface{}) {
 			// create port : pod.Spec.Nics[index].PortId
 			pod.Spec.Nics[i].PortId = CreatePort(client, pod.Spec.VPC, nic.SubnetName, pod.Spec.NodeName)
 			needCreate = true
-		} else if needUpdate {
+		} else if new.Spec.NodeName != prev.Spec.NodeName {
+			needUpdate = true
 			// update port binding host only
 			UpdatePort(client, pod.Spec.Nics[i].PortId, new.Spec.NodeName)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Disalbe NetworkController by default. Current NetworkController is only for Neutron Network, so
disable it by default and only enable it when using Neutron



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # issue #471

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
