### PR TITLE
fix issue 479

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -264,11 +264,8 @@ func testAdmissionNamespaceTerminating(t *testing.T, tenant string) {
 
 	// verify delete of namespace default can never proceed
 	err = handler.Admit(admission.NewAttributesRecord(nil, nil, v1.SchemeGroupVersion.WithKind("Namespace").GroupKind().WithVersion("version"), tenant, "", metav1.NamespaceDefault, v1.Resource("namespaces").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil), nil)
-	if tenant == metav1.TenantSystem && err == nil {
-		t.Errorf("Expected an error that namespace %s/%s can never be deleted", tenant, metav1.NamespaceDefault)
-	}
-	if tenant != metav1.TenantSystem && err != nil {
-		t.Errorf("Did not expect an error %v", err)
+	if err == nil {
+		t.Errorf("Expected an error that namespace %s/%s can not be deleted", tenant, metav1.NamespaceDefault)
 	}
 
 	// verify delete of namespace other than default can proceed


### PR DESCRIPTION
This PR fixes the issue https://github.com/futurewei-cloud/arktos/issues/479

### verification in my dev box

```
qianchen@qianchen-VirtualBox:~$ kubectl create tenant aaa
setting storage cluster to 0
tenant/aaa created

qianchen@qianchen-VirtualBox:~$ kubectl get ns --tenant aaa
NAME          STATUS   AGE   TENANT
default       Active   7s    aaa
kube-public   Active   7s    aaa
kube-system   Active   7s    aaa

qianchen@qianchen-VirtualBox:~$ kubectl delete ns default --tenant aaa
Error from server (Forbidden): namespaces "aaa/default" is forbidden: this namespace may not be deleted

qianchen@qianchen-VirtualBox:~$ kubectl delete ns kube-system --tenant aaa
Error from server (Forbidden): namespaces "aaa/kube-system" is forbidden: this namespace may not be deleted
```

### verification that there is no regression in tenant deleter

```
qianchen@qianchen-VirtualBox:~$ kubectl delete tenant aaa
tenant "aaa" deleted
qianchen@qianchen-VirtualBox:~$ kubectl get ns --tenant aaa
No resources found.

```
