### PR TITLE
Update scripts to be more compatible with sudo and also correct a comment typo

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -92,7 +92,7 @@ all:
 else
 all: generated_files
 	hack/make-rules/build.sh $(WHAT)
-	hack/arktos_copyright.sh $(PWD) $(OUT_DIR)
+	hack/arktos_copyright.sh $(shell pwd) $(OUT_DIR)
 endif
 
 define GINKGO_HELP_INFO
@@ -461,7 +461,7 @@ release-skip-tests quick-release: KUBE_RELEASE_RUN_TESTS = n
 release-skip-tests quick-release: KUBE_FASTBUILD = true
 release-skip-tests quick-release:
 	build/release.sh
-	hack/arktos_copyright.sh $(PWD) $(OUT_DIR)
+	hack/arktos_copyright.sh $(shell pwd) $(OUT_DIR)
 endif
 
 define QUICK_RELEASE_IMAGES_HELP_INFO
@@ -558,7 +558,7 @@ generated_files:
 else
 generated_files:
 	$(MAKE) -f Makefile.generated_files $@ CALLED_FROM_MAIN_MAKEFILE=1
-	hack/arktos_copyright.sh $(PWD) $(OUT_DIR)
+	hack/arktos_copyright.sh $(shell pwd) $(OUT_DIR)
 endif
 
 define HELP_INFO

--- a/hack/setup-dev-node.sh
+++ b/hack/setup-dev-node.sh
@@ -41,5 +41,5 @@ wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz -P /tmp
 sudo tar -C /usr/local -xzf /tmp/go${GOLANG_VERSION}.linux-amd64.tar.gz
 
 echo "Done."
-echo "Please run and add 'export PATH=\$PATH:/usr/local/go/bin' into your shell profile."
+echo "Please run and add 'export PATH=$PATH:/usr/local/go/bin' into your shell profile."
 echo "You can proceed to run arktos-up.sh if you want to launch a single-node cluster."


### PR DESCRIPTION

**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:

1) Make "sudo" working for Make targets like quick-release or other targets, instead of mandate "sudo -E".  By default "sudo" won't preserve the PWD environment variable.

2) Fix a comment typo in setup-dev-node.



