### PR TITLE
Bug fix for list from revision: pass lock address - fix concurrent map write issue

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -116,7 +116,7 @@ func (c *examples) List(opts metav1.ListOptions) (result *v1.ExampleList, err er
 		results := make(map[int]*v1.ExampleList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *examples, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ExampleList, errMap map[int]error) {
+			go func(c *examples, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ExampleList, errMap map[int]error) {
 				r := &v1.ExampleList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *examples) List(opts metav1.ListOptions) (result *v1.ExampleList, err er
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -113,7 +113,7 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *v1beta1.C
 		results := make(map[int]*v1beta1.CustomResourceDefinitionList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *customResourceDefinitions, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.CustomResourceDefinitionList, errMap map[int]error) {
+			go func(c *customResourceDefinitions, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.CustomResourceDefinitionList, errMap map[int]error) {
 				r := &v1beta1.CustomResourceDefinitionList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *v1beta1.C
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
@@ -114,7 +114,7 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextens
 		results := make(map[int]*apiextensions.CustomResourceDefinitionList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *customResourceDefinitions, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*apiextensions.CustomResourceDefinitionList, errMap map[int]error) {
+			go func(c *customResourceDefinitions, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*apiextensions.CustomResourceDefinitionList, errMap map[int]error) {
 				r := &apiextensions.CustomResourceDefinitionList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextens
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -105,7 +105,7 @@ func (c *mutatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1bet
 		results := make(map[int]*v1beta1.MutatingWebhookConfigurationList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *mutatingWebhookConfigurations, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.MutatingWebhookConfigurationList, errMap map[int]error) {
+			go func(c *mutatingWebhookConfigurations, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.MutatingWebhookConfigurationList, errMap map[int]error) {
 				r := &v1beta1.MutatingWebhookConfigurationList{}
 				err := ci.Get().
 					Resource("mutatingwebhookconfigurations").
@@ -119,7 +119,7 @@ func (c *mutatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1bet
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -105,7 +105,7 @@ func (c *validatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1b
 		results := make(map[int]*v1beta1.ValidatingWebhookConfigurationList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *validatingWebhookConfigurations, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.ValidatingWebhookConfigurationList, errMap map[int]error) {
+			go func(c *validatingWebhookConfigurations, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ValidatingWebhookConfigurationList, errMap map[int]error) {
 				r := &v1beta1.ValidatingWebhookConfigurationList{}
 				err := ci.Get().
 					Resource("validatingwebhookconfigurations").
@@ -119,7 +119,7 @@ func (c *validatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1b
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -116,7 +116,7 @@ func (c *controllerRevisions) List(opts metav1.ListOptions) (result *v1.Controll
 		results := make(map[int]*v1.ControllerRevisionList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *controllerRevisions, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ControllerRevisionList, errMap map[int]error) {
+			go func(c *controllerRevisions, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ControllerRevisionList, errMap map[int]error) {
 				r := &v1.ControllerRevisionList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *controllerRevisions) List(opts metav1.ListOptions) (result *v1.Controll
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -117,7 +117,7 @@ func (c *daemonSets) List(opts metav1.ListOptions) (result *v1.DaemonSetList, er
 		results := make(map[int]*v1.DaemonSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *daemonSets, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.DaemonSetList, errMap map[int]error) {
+			go func(c *daemonSets, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.DaemonSetList, errMap map[int]error) {
 				r := &v1.DaemonSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *daemonSets) List(opts metav1.ListOptions) (result *v1.DaemonSetList, er
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -121,7 +121,7 @@ func (c *deployments) List(opts metav1.ListOptions) (result *v1.DeploymentList, 
 		results := make(map[int]*v1.DeploymentList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *deployments, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.DeploymentList, errMap map[int]error) {
+			go func(c *deployments, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.DeploymentList, errMap map[int]error) {
 				r := &v1.DeploymentList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -136,7 +136,7 @@ func (c *deployments) List(opts metav1.ListOptions) (result *v1.DeploymentList, 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -121,7 +121,7 @@ func (c *replicaSets) List(opts metav1.ListOptions) (result *v1.ReplicaSetList, 
 		results := make(map[int]*v1.ReplicaSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *replicaSets, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ReplicaSetList, errMap map[int]error) {
+			go func(c *replicaSets, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ReplicaSetList, errMap map[int]error) {
 				r := &v1.ReplicaSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -136,7 +136,7 @@ func (c *replicaSets) List(opts metav1.ListOptions) (result *v1.ReplicaSetList, 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -121,7 +121,7 @@ func (c *statefulSets) List(opts metav1.ListOptions) (result *v1.StatefulSetList
 		results := make(map[int]*v1.StatefulSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *statefulSets, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.StatefulSetList, errMap map[int]error) {
+			go func(c *statefulSets, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.StatefulSetList, errMap map[int]error) {
 				r := &v1.StatefulSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -136,7 +136,7 @@ func (c *statefulSets) List(opts metav1.ListOptions) (result *v1.StatefulSetList
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -116,7 +116,7 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.Control
 		results := make(map[int]*v1beta1.ControllerRevisionList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *controllerRevisions, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.ControllerRevisionList, errMap map[int]error) {
+			go func(c *controllerRevisions, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ControllerRevisionList, errMap map[int]error) {
 				r := &v1beta1.ControllerRevisionList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.Control
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -117,7 +117,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 		results := make(map[int]*v1beta1.DeploymentList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.DeploymentList, errMap map[int]error) {
+			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.DeploymentList, errMap map[int]error) {
 				r := &v1beta1.DeploymentList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -117,7 +117,7 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetLis
 		results := make(map[int]*v1beta1.StatefulSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *statefulSets, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.StatefulSetList, errMap map[int]error) {
+			go func(c *statefulSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.StatefulSetList, errMap map[int]error) {
 				r := &v1beta1.StatefulSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetLis
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -116,7 +116,7 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta2.Control
 		results := make(map[int]*v1beta2.ControllerRevisionList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *controllerRevisions, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta2.ControllerRevisionList, errMap map[int]error) {
+			go func(c *controllerRevisions, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.ControllerRevisionList, errMap map[int]error) {
 				r := &v1beta2.ControllerRevisionList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta2.Control
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -117,7 +117,7 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta2.DaemonSetList, e
 		results := make(map[int]*v1beta2.DaemonSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *daemonSets, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta2.DaemonSetList, errMap map[int]error) {
+			go func(c *daemonSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.DaemonSetList, errMap map[int]error) {
 				r := &v1beta2.DaemonSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta2.DaemonSetList, e
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -117,7 +117,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList,
 		results := make(map[int]*v1beta2.DeploymentList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta2.DeploymentList, errMap map[int]error) {
+			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.DeploymentList, errMap map[int]error) {
 				r := &v1beta2.DeploymentList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList,
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -117,7 +117,7 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta2.ReplicaSetList,
 		results := make(map[int]*v1beta2.ReplicaSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *replicaSets, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta2.ReplicaSetList, errMap map[int]error) {
+			go func(c *replicaSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.ReplicaSetList, errMap map[int]error) {
 				r := &v1beta2.ReplicaSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta2.ReplicaSetList,
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -120,7 +120,7 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetLis
 		results := make(map[int]*v1beta2.StatefulSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *statefulSets, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta2.StatefulSetList, errMap map[int]error) {
+			go func(c *statefulSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.StatefulSetList, errMap map[int]error) {
 				r := &v1beta2.StatefulSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -135,7 +135,7 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetLis
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditsink.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditsink.go
@@ -113,7 +113,7 @@ func (c *auditSinks) List(opts v1.ListOptions) (result *v1alpha1.AuditSinkList, 
 		results := make(map[int]*v1alpha1.AuditSinkList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *auditSinks, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.AuditSinkList, errMap map[int]error) {
+			go func(c *auditSinks, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.AuditSinkList, errMap map[int]error) {
 				r := &v1alpha1.AuditSinkList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *auditSinks) List(opts v1.ListOptions) (result *v1alpha1.AuditSinkList, 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -117,7 +117,7 @@ func (c *horizontalPodAutoscalers) List(opts metav1.ListOptions) (result *v1.Hor
 		results := make(map[int]*v1.HorizontalPodAutoscalerList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.HorizontalPodAutoscalerList, errMap map[int]error) {
+			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.HorizontalPodAutoscalerList, errMap map[int]error) {
 				r := &v1.HorizontalPodAutoscalerList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *horizontalPodAutoscalers) List(opts metav1.ListOptions) (result *v1.Hor
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -117,7 +117,7 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta1.Ho
 		results := make(map[int]*v2beta1.HorizontalPodAutoscalerList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v2beta1.HorizontalPodAutoscalerList, errMap map[int]error) {
+			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v2beta1.HorizontalPodAutoscalerList, errMap map[int]error) {
 				r := &v2beta1.HorizontalPodAutoscalerList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta1.Ho
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -117,7 +117,7 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta2.Ho
 		results := make(map[int]*v2beta2.HorizontalPodAutoscalerList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v2beta2.HorizontalPodAutoscalerList, errMap map[int]error) {
+			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v2beta2.HorizontalPodAutoscalerList, errMap map[int]error) {
 				r := &v2beta2.HorizontalPodAutoscalerList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta2.Ho
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -117,7 +117,7 @@ func (c *jobs) List(opts metav1.ListOptions) (result *v1.JobList, err error) {
 		results := make(map[int]*v1.JobList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *jobs, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.JobList, errMap map[int]error) {
+			go func(c *jobs, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.JobList, errMap map[int]error) {
 				r := &v1.JobList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *jobs) List(opts metav1.ListOptions) (result *v1.JobList, err error) {
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -117,7 +117,7 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v1beta1.CronJobList, err e
 		results := make(map[int]*v1beta1.CronJobList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *cronJobs, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.CronJobList, errMap map[int]error) {
+			go func(c *cronJobs, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.CronJobList, errMap map[int]error) {
 				r := &v1beta1.CronJobList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v1beta1.CronJobList, err e
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
@@ -117,7 +117,7 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err 
 		results := make(map[int]*v2alpha1.CronJobList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *cronJobs, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v2alpha1.CronJobList, errMap map[int]error) {
+			go func(c *cronJobs, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v2alpha1.CronJobList, errMap map[int]error) {
 				r := &v2alpha1.CronJobList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -114,7 +114,7 @@ func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.
 		results := make(map[int]*v1beta1.CertificateSigningRequestList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *certificateSigningRequests, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.CertificateSigningRequestList, errMap map[int]error) {
+			go func(c *certificateSigningRequests, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.CertificateSigningRequestList, errMap map[int]error) {
 				r := &v1beta1.CertificateSigningRequestList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -116,7 +116,7 @@ func (c *leases) List(opts metav1.ListOptions) (result *v1.LeaseList, err error)
 		results := make(map[int]*v1.LeaseList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *leases, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.LeaseList, errMap map[int]error) {
+			go func(c *leases, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.LeaseList, errMap map[int]error) {
 				r := &v1.LeaseList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *leases) List(opts metav1.ListOptions) (result *v1.LeaseList, err error)
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -116,7 +116,7 @@ func (c *leases) List(opts v1.ListOptions) (result *v1beta1.LeaseList, err error
 		results := make(map[int]*v1beta1.LeaseList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *leases, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.LeaseList, errMap map[int]error) {
+			go func(c *leases, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.LeaseList, errMap map[int]error) {
 				r := &v1beta1.LeaseList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *leases) List(opts v1.ListOptions) (result *v1beta1.LeaseList, err error
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/action.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/action.go
@@ -116,7 +116,7 @@ func (c *actions) List(opts metav1.ListOptions) (result *v1.ActionList, err erro
 		results := make(map[int]*v1.ActionList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *actions, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ActionList, errMap map[int]error) {
+			go func(c *actions, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ActionList, errMap map[int]error) {
 				r := &v1.ActionList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *actions) List(opts metav1.ListOptions) (result *v1.ActionList, err erro
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -105,7 +105,7 @@ func (c *componentStatuses) List(opts metav1.ListOptions) (result *v1.ComponentS
 		results := make(map[int]*v1.ComponentStatusList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *componentStatuses, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ComponentStatusList, errMap map[int]error) {
+			go func(c *componentStatuses, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ComponentStatusList, errMap map[int]error) {
 				r := &v1.ComponentStatusList{}
 				err := ci.Get().
 					Resource("componentstatuses").
@@ -119,7 +119,7 @@ func (c *componentStatuses) List(opts metav1.ListOptions) (result *v1.ComponentS
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -116,7 +116,7 @@ func (c *configMaps) List(opts metav1.ListOptions) (result *v1.ConfigMapList, er
 		results := make(map[int]*v1.ConfigMapList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *configMaps, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ConfigMapList, errMap map[int]error) {
+			go func(c *configMaps, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ConfigMapList, errMap map[int]error) {
 				r := &v1.ConfigMapList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *configMaps) List(opts metav1.ListOptions) (result *v1.ConfigMapList, er
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/controllerinstance.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/controllerinstance.go
@@ -104,7 +104,7 @@ func (c *controllerInstances) List(opts metav1.ListOptions) (result *v1.Controll
 		results := make(map[int]*v1.ControllerInstanceList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *controllerInstances, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ControllerInstanceList, errMap map[int]error) {
+			go func(c *controllerInstances, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ControllerInstanceList, errMap map[int]error) {
 				r := &v1.ControllerInstanceList{}
 				err := ci.Get().
 					Resource("controllerinstances").
@@ -118,7 +118,7 @@ func (c *controllerInstances) List(opts metav1.ListOptions) (result *v1.Controll
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/datapartitionconfig.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/datapartitionconfig.go
@@ -104,7 +104,7 @@ func (c *dataPartitionConfigs) List(opts metav1.ListOptions) (result *v1.DataPar
 		results := make(map[int]*v1.DataPartitionConfigList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *dataPartitionConfigs, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.DataPartitionConfigList, errMap map[int]error) {
+			go func(c *dataPartitionConfigs, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.DataPartitionConfigList, errMap map[int]error) {
 				r := &v1.DataPartitionConfigList{}
 				err := ci.Get().
 					Resource("datapartitionconfigs").
@@ -118,7 +118,7 @@ func (c *dataPartitionConfigs) List(opts metav1.ListOptions) (result *v1.DataPar
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -116,7 +116,7 @@ func (c *endpoints) List(opts metav1.ListOptions) (result *v1.EndpointsList, err
 		results := make(map[int]*v1.EndpointsList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *endpoints, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.EndpointsList, errMap map[int]error) {
+			go func(c *endpoints, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.EndpointsList, errMap map[int]error) {
 				r := &v1.EndpointsList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *endpoints) List(opts metav1.ListOptions) (result *v1.EndpointsList, err
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -116,7 +116,7 @@ func (c *events) List(opts metav1.ListOptions) (result *v1.EventList, err error)
 		results := make(map[int]*v1.EventList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *events, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.EventList, errMap map[int]error) {
+			go func(c *events, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.EventList, errMap map[int]error) {
 				r := &v1.EventList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *events) List(opts metav1.ListOptions) (result *v1.EventList, err error)
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -116,7 +116,7 @@ func (c *limitRanges) List(opts metav1.ListOptions) (result *v1.LimitRangeList, 
 		results := make(map[int]*v1.LimitRangeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *limitRanges, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.LimitRangeList, errMap map[int]error) {
+			go func(c *limitRanges, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.LimitRangeList, errMap map[int]error) {
 				r := &v1.LimitRangeList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *limitRanges) List(opts metav1.ListOptions) (result *v1.LimitRangeList, 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -113,7 +113,7 @@ func (c *namespaces) List(opts metav1.ListOptions) (result *v1.NamespaceList, er
 		results := make(map[int]*v1.NamespaceList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *namespaces, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.NamespaceList, errMap map[int]error) {
+			go func(c *namespaces, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.NamespaceList, errMap map[int]error) {
 				r := &v1.NamespaceList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *namespaces) List(opts metav1.ListOptions) (result *v1.NamespaceList, er
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -106,7 +106,7 @@ func (c *nodes) List(opts metav1.ListOptions) (result *v1.NodeList, err error) {
 		results := make(map[int]*v1.NodeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *nodes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.NodeList, errMap map[int]error) {
+			go func(c *nodes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.NodeList, errMap map[int]error) {
 				r := &v1.NodeList{}
 				err := ci.Get().
 					Resource("nodes").
@@ -120,7 +120,7 @@ func (c *nodes) List(opts metav1.ListOptions) (result *v1.NodeList, err error) {
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -114,7 +114,7 @@ func (c *persistentVolumes) List(opts metav1.ListOptions) (result *v1.Persistent
 		results := make(map[int]*v1.PersistentVolumeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *persistentVolumes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.PersistentVolumeList, errMap map[int]error) {
+			go func(c *persistentVolumes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PersistentVolumeList, errMap map[int]error) {
 				r := &v1.PersistentVolumeList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *persistentVolumes) List(opts metav1.ListOptions) (result *v1.Persistent
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -117,7 +117,7 @@ func (c *persistentVolumeClaims) List(opts metav1.ListOptions) (result *v1.Persi
 		results := make(map[int]*v1.PersistentVolumeClaimList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *persistentVolumeClaims, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.PersistentVolumeClaimList, errMap map[int]error) {
+			go func(c *persistentVolumeClaims, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PersistentVolumeClaimList, errMap map[int]error) {
 				r := &v1.PersistentVolumeClaimList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *persistentVolumeClaims) List(opts metav1.ListOptions) (result *v1.Persi
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -117,7 +117,7 @@ func (c *pods) List(opts metav1.ListOptions) (result *v1.PodList, err error) {
 		results := make(map[int]*v1.PodList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *pods, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.PodList, errMap map[int]error) {
+			go func(c *pods, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PodList, errMap map[int]error) {
 				r := &v1.PodList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *pods) List(opts metav1.ListOptions) (result *v1.PodList, err error) {
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -116,7 +116,7 @@ func (c *podTemplates) List(opts metav1.ListOptions) (result *v1.PodTemplateList
 		results := make(map[int]*v1.PodTemplateList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *podTemplates, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.PodTemplateList, errMap map[int]error) {
+			go func(c *podTemplates, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PodTemplateList, errMap map[int]error) {
 				r := &v1.PodTemplateList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *podTemplates) List(opts metav1.ListOptions) (result *v1.PodTemplateList
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -121,7 +121,7 @@ func (c *replicationControllers) List(opts metav1.ListOptions) (result *v1.Repli
 		results := make(map[int]*v1.ReplicationControllerList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *replicationControllers, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ReplicationControllerList, errMap map[int]error) {
+			go func(c *replicationControllers, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ReplicationControllerList, errMap map[int]error) {
 				r := &v1.ReplicationControllerList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -136,7 +136,7 @@ func (c *replicationControllers) List(opts metav1.ListOptions) (result *v1.Repli
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -117,7 +117,7 @@ func (c *resourceQuotas) List(opts metav1.ListOptions) (result *v1.ResourceQuota
 		results := make(map[int]*v1.ResourceQuotaList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *resourceQuotas, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ResourceQuotaList, errMap map[int]error) {
+			go func(c *resourceQuotas, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ResourceQuotaList, errMap map[int]error) {
 				r := &v1.ResourceQuotaList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *resourceQuotas) List(opts metav1.ListOptions) (result *v1.ResourceQuota
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -116,7 +116,7 @@ func (c *secrets) List(opts metav1.ListOptions) (result *v1.SecretList, err erro
 		results := make(map[int]*v1.SecretList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *secrets, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.SecretList, errMap map[int]error) {
+			go func(c *secrets, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.SecretList, errMap map[int]error) {
 				r := &v1.SecretList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *secrets) List(opts metav1.ListOptions) (result *v1.SecretList, err erro
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -116,7 +116,7 @@ func (c *services) List(opts metav1.ListOptions) (result *v1.ServiceList, err er
 		results := make(map[int]*v1.ServiceList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *services, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ServiceList, errMap map[int]error) {
+			go func(c *services, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ServiceList, errMap map[int]error) {
 				r := &v1.ServiceList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *services) List(opts metav1.ListOptions) (result *v1.ServiceList, err er
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -116,7 +116,7 @@ func (c *serviceAccounts) List(opts metav1.ListOptions) (result *v1.ServiceAccou
 		results := make(map[int]*v1.ServiceAccountList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *serviceAccounts, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ServiceAccountList, errMap map[int]error) {
+			go func(c *serviceAccounts, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ServiceAccountList, errMap map[int]error) {
 				r := &v1.ServiceAccountList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *serviceAccounts) List(opts metav1.ListOptions) (result *v1.ServiceAccou
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/storagecluster.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/storagecluster.go
@@ -104,7 +104,7 @@ func (c *storageClusters) List(opts metav1.ListOptions) (result *v1.StorageClust
 		results := make(map[int]*v1.StorageClusterList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *storageClusters, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.StorageClusterList, errMap map[int]error) {
+			go func(c *storageClusters, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.StorageClusterList, errMap map[int]error) {
 				r := &v1.StorageClusterList{}
 				err := ci.Get().
 					Resource("storageclusters").
@@ -118,7 +118,7 @@ func (c *storageClusters) List(opts metav1.ListOptions) (result *v1.StorageClust
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/tenant.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/tenant.go
@@ -104,7 +104,7 @@ func (c *tenants) List(opts metav1.ListOptions) (result *v1.TenantList, err erro
 		results := make(map[int]*v1.TenantList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *tenants, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.TenantList, errMap map[int]error) {
+			go func(c *tenants, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TenantList, errMap map[int]error) {
 				r := &v1.TenantList{}
 				err := ci.Get().
 					Resource("tenants").
@@ -118,7 +118,7 @@ func (c *tenants) List(opts metav1.ListOptions) (result *v1.TenantList, err erro
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -116,7 +116,7 @@ func (c *events) List(opts v1.ListOptions) (result *v1beta1.EventList, err error
 		results := make(map[int]*v1beta1.EventList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *events, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.EventList, errMap map[int]error) {
+			go func(c *events, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.EventList, errMap map[int]error) {
 				r := &v1beta1.EventList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *events) List(opts v1.ListOptions) (result *v1beta1.EventList, err error
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -117,7 +117,7 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 		results := make(map[int]*v1beta1.DaemonSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *daemonSets, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.DaemonSetList, errMap map[int]error) {
+			go func(c *daemonSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.DaemonSetList, errMap map[int]error) {
 				r := &v1beta1.DaemonSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -120,7 +120,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 		results := make(map[int]*v1beta1.DeploymentList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.DeploymentList, errMap map[int]error) {
+			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.DeploymentList, errMap map[int]error) {
 				r := &v1beta1.DeploymentList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -135,7 +135,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -117,7 +117,7 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 		results := make(map[int]*v1beta1.IngressList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *ingresses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.IngressList, errMap map[int]error) {
+			go func(c *ingresses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.IngressList, errMap map[int]error) {
 				r := &v1beta1.IngressList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -116,7 +116,7 @@ func (c *networkPolicies) List(opts v1.ListOptions) (result *v1beta1.NetworkPoli
 		results := make(map[int]*v1beta1.NetworkPolicyList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *networkPolicies, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.NetworkPolicyList, errMap map[int]error) {
+			go func(c *networkPolicies, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.NetworkPolicyList, errMap map[int]error) {
 				r := &v1beta1.NetworkPolicyList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *networkPolicies) List(opts v1.ListOptions) (result *v1beta1.NetworkPoli
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -113,7 +113,7 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 		results := make(map[int]*v1beta1.PodSecurityPolicyList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *podSecurityPolicies, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.PodSecurityPolicyList, errMap map[int]error) {
+			go func(c *podSecurityPolicies, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PodSecurityPolicyList, errMap map[int]error) {
 				r := &v1beta1.PodSecurityPolicyList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -120,7 +120,7 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList,
 		results := make(map[int]*v1beta1.ReplicaSetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *replicaSets, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.ReplicaSetList, errMap map[int]error) {
+			go func(c *replicaSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ReplicaSetList, errMap map[int]error) {
 				r := &v1beta1.ReplicaSetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -135,7 +135,7 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList,
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -116,7 +116,7 @@ func (c *networkPolicies) List(opts metav1.ListOptions) (result *v1.NetworkPolic
 		results := make(map[int]*v1.NetworkPolicyList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *networkPolicies, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.NetworkPolicyList, errMap map[int]error) {
+			go func(c *networkPolicies, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.NetworkPolicyList, errMap map[int]error) {
 				r := &v1.NetworkPolicyList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *networkPolicies) List(opts metav1.ListOptions) (result *v1.NetworkPolic
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -117,7 +117,7 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 		results := make(map[int]*v1beta1.IngressList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *ingresses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.IngressList, errMap map[int]error) {
+			go func(c *ingresses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.IngressList, errMap map[int]error) {
 				r := &v1beta1.IngressList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -105,7 +105,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 		results := make(map[int]*v1alpha1.RuntimeClassList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.RuntimeClassList, errMap map[int]error) {
+			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.RuntimeClassList, errMap map[int]error) {
 				r := &v1alpha1.RuntimeClassList{}
 				err := ci.Get().
 					Resource("runtimeclasses").
@@ -119,7 +119,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -105,7 +105,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1beta1.RuntimeClass
 		results := make(map[int]*v1beta1.RuntimeClassList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.RuntimeClassList, errMap map[int]error) {
+			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.RuntimeClassList, errMap map[int]error) {
 				r := &v1beta1.RuntimeClassList{}
 				err := ci.Get().
 					Resource("runtimeclasses").
@@ -119,7 +119,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1beta1.RuntimeClass
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -117,7 +117,7 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDis
 		results := make(map[int]*v1beta1.PodDisruptionBudgetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *podDisruptionBudgets, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.PodDisruptionBudgetList, errMap map[int]error) {
+			go func(c *podDisruptionBudgets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PodDisruptionBudgetList, errMap map[int]error) {
 				r := &v1beta1.PodDisruptionBudgetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDis
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
@@ -113,7 +113,7 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 		results := make(map[int]*v1beta1.PodSecurityPolicyList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *podSecurityPolicies, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.PodSecurityPolicyList, errMap map[int]error) {
+			go func(c *podSecurityPolicies, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PodSecurityPolicyList, errMap map[int]error) {
 				r := &v1beta1.PodSecurityPolicyList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -113,7 +113,7 @@ func (c *clusterRoles) List(opts metav1.ListOptions) (result *v1.ClusterRoleList
 		results := make(map[int]*v1.ClusterRoleList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *clusterRoles, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ClusterRoleList, errMap map[int]error) {
+			go func(c *clusterRoles, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ClusterRoleList, errMap map[int]error) {
 				r := &v1.ClusterRoleList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *clusterRoles) List(opts metav1.ListOptions) (result *v1.ClusterRoleList
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -113,7 +113,7 @@ func (c *clusterRoleBindings) List(opts metav1.ListOptions) (result *v1.ClusterR
 		results := make(map[int]*v1.ClusterRoleBindingList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *clusterRoleBindings, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ClusterRoleBindingList, errMap map[int]error) {
+			go func(c *clusterRoleBindings, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ClusterRoleBindingList, errMap map[int]error) {
 				r := &v1.ClusterRoleBindingList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *clusterRoleBindings) List(opts metav1.ListOptions) (result *v1.ClusterR
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -116,7 +116,7 @@ func (c *roles) List(opts metav1.ListOptions) (result *v1.RoleList, err error) {
 		results := make(map[int]*v1.RoleList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *roles, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.RoleList, errMap map[int]error) {
+			go func(c *roles, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.RoleList, errMap map[int]error) {
 				r := &v1.RoleList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *roles) List(opts metav1.ListOptions) (result *v1.RoleList, err error) {
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -116,7 +116,7 @@ func (c *roleBindings) List(opts metav1.ListOptions) (result *v1.RoleBindingList
 		results := make(map[int]*v1.RoleBindingList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *roleBindings, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.RoleBindingList, errMap map[int]error) {
+			go func(c *roleBindings, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.RoleBindingList, errMap map[int]error) {
 				r := &v1.RoleBindingList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *roleBindings) List(opts metav1.ListOptions) (result *v1.RoleBindingList
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -113,7 +113,7 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleLi
 		results := make(map[int]*v1alpha1.ClusterRoleList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *clusterRoles, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.ClusterRoleList, errMap map[int]error) {
+			go func(c *clusterRoles, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.ClusterRoleList, errMap map[int]error) {
 				r := &v1alpha1.ClusterRoleList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleLi
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -113,7 +113,7 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cluste
 		results := make(map[int]*v1alpha1.ClusterRoleBindingList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *clusterRoleBindings, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.ClusterRoleBindingList, errMap map[int]error) {
+			go func(c *clusterRoleBindings, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.ClusterRoleBindingList, errMap map[int]error) {
 				r := &v1alpha1.ClusterRoleBindingList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cluste
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -116,7 +116,7 @@ func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error)
 		results := make(map[int]*v1alpha1.RoleList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *roles, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.RoleList, errMap map[int]error) {
+			go func(c *roles, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.RoleList, errMap map[int]error) {
 				r := &v1alpha1.RoleList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error)
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -116,7 +116,7 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingLi
 		results := make(map[int]*v1alpha1.RoleBindingList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *roleBindings, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.RoleBindingList, errMap map[int]error) {
+			go func(c *roleBindings, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.RoleBindingList, errMap map[int]error) {
 				r := &v1alpha1.RoleBindingList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingLi
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -113,7 +113,7 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleLis
 		results := make(map[int]*v1beta1.ClusterRoleList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *clusterRoles, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.ClusterRoleList, errMap map[int]error) {
+			go func(c *clusterRoles, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ClusterRoleList, errMap map[int]error) {
 				r := &v1beta1.ClusterRoleList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleLis
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -113,7 +113,7 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.Cluster
 		results := make(map[int]*v1beta1.ClusterRoleBindingList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *clusterRoleBindings, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.ClusterRoleBindingList, errMap map[int]error) {
+			go func(c *clusterRoleBindings, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ClusterRoleBindingList, errMap map[int]error) {
 				r := &v1beta1.ClusterRoleBindingList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -128,7 +128,7 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.Cluster
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -116,7 +116,7 @@ func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) 
 		results := make(map[int]*v1beta1.RoleList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *roles, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.RoleList, errMap map[int]error) {
+			go func(c *roles, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.RoleList, errMap map[int]error) {
 				r := &v1beta1.RoleList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -116,7 +116,7 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingLis
 		results := make(map[int]*v1beta1.RoleBindingList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *roleBindings, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.RoleBindingList, errMap map[int]error) {
+			go func(c *roleBindings, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.RoleBindingList, errMap map[int]error) {
 				r := &v1beta1.RoleBindingList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingLis
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -105,7 +105,7 @@ func (c *priorityClasses) List(opts metav1.ListOptions) (result *v1.PriorityClas
 		results := make(map[int]*v1.PriorityClassList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *priorityClasses, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.PriorityClassList, errMap map[int]error) {
+			go func(c *priorityClasses, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PriorityClassList, errMap map[int]error) {
 				r := &v1.PriorityClassList{}
 				err := ci.Get().
 					Resource("priorityclasses").
@@ -119,7 +119,7 @@ func (c *priorityClasses) List(opts metav1.ListOptions) (result *v1.PriorityClas
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -105,7 +105,7 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityCl
 		results := make(map[int]*v1alpha1.PriorityClassList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *priorityClasses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.PriorityClassList, errMap map[int]error) {
+			go func(c *priorityClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.PriorityClassList, errMap map[int]error) {
 				r := &v1alpha1.PriorityClassList{}
 				err := ci.Get().
 					Resource("priorityclasses").
@@ -119,7 +119,7 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityCl
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -105,7 +105,7 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1beta1.PriorityCla
 		results := make(map[int]*v1beta1.PriorityClassList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *priorityClasses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.PriorityClassList, errMap map[int]error) {
+			go func(c *priorityClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PriorityClassList, errMap map[int]error) {
 				r := &v1beta1.PriorityClassList{}
 				err := ci.Get().
 					Resource("priorityclasses").
@@ -119,7 +119,7 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1beta1.PriorityCla
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
@@ -116,7 +116,7 @@ func (c *podPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, 
 		results := make(map[int]*v1alpha1.PodPresetList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *podPresets, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.PodPresetList, errMap map[int]error) {
+			go func(c *podPresets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.PodPresetList, errMap map[int]error) {
 				r := &v1alpha1.PodPresetList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -131,7 +131,7 @@ func (c *podPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -105,7 +105,7 @@ func (c *storageClasses) List(opts metav1.ListOptions) (result *v1.StorageClassL
 		results := make(map[int]*v1.StorageClassList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *storageClasses, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.StorageClassList, errMap map[int]error) {
+			go func(c *storageClasses, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.StorageClassList, errMap map[int]error) {
 				r := &v1.StorageClassList{}
 				err := ci.Get().
 					Resource("storageclasses").
@@ -119,7 +119,7 @@ func (c *storageClasses) List(opts metav1.ListOptions) (result *v1.StorageClassL
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -114,7 +114,7 @@ func (c *volumeAttachments) List(opts metav1.ListOptions) (result *v1.VolumeAtta
 		results := make(map[int]*v1.VolumeAttachmentList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *volumeAttachments, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.VolumeAttachmentList, errMap map[int]error) {
+			go func(c *volumeAttachments, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.VolumeAttachmentList, errMap map[int]error) {
 				r := &v1.VolumeAttachmentList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *volumeAttachments) List(opts metav1.ListOptions) (result *v1.VolumeAtta
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -114,7 +114,7 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1alpha1.VolumeAt
 		results := make(map[int]*v1alpha1.VolumeAttachmentList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *volumeAttachments, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.VolumeAttachmentList, errMap map[int]error) {
+			go func(c *volumeAttachments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.VolumeAttachmentList, errMap map[int]error) {
 				r := &v1alpha1.VolumeAttachmentList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1alpha1.VolumeAt
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -105,7 +105,7 @@ func (c *cSIDrivers) List(opts v1.ListOptions) (result *v1beta1.CSIDriverList, e
 		results := make(map[int]*v1beta1.CSIDriverList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *cSIDrivers, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.CSIDriverList, errMap map[int]error) {
+			go func(c *cSIDrivers, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.CSIDriverList, errMap map[int]error) {
 				r := &v1beta1.CSIDriverList{}
 				err := ci.Get().
 					Resource("csidrivers").
@@ -119,7 +119,7 @@ func (c *cSIDrivers) List(opts v1.ListOptions) (result *v1beta1.CSIDriverList, e
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -105,7 +105,7 @@ func (c *cSINodes) List(opts v1.ListOptions) (result *v1beta1.CSINodeList, err e
 		results := make(map[int]*v1beta1.CSINodeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *cSINodes, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.CSINodeList, errMap map[int]error) {
+			go func(c *cSINodes, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.CSINodeList, errMap map[int]error) {
 				r := &v1beta1.CSINodeList{}
 				err := ci.Get().
 					Resource("csinodes").
@@ -119,7 +119,7 @@ func (c *cSINodes) List(opts v1.ListOptions) (result *v1beta1.CSINodeList, err e
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -105,7 +105,7 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 		results := make(map[int]*v1beta1.StorageClassList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *storageClasses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.StorageClassList, errMap map[int]error) {
+			go func(c *storageClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.StorageClassList, errMap map[int]error) {
 				r := &v1beta1.StorageClassList{}
 				err := ci.Get().
 					Resource("storageclasses").
@@ -119,7 +119,7 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -114,7 +114,7 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1beta1.VolumeAtt
 		results := make(map[int]*v1beta1.VolumeAttachmentList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *volumeAttachments, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.VolumeAttachmentList, errMap map[int]error) {
+			go func(c *volumeAttachments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.VolumeAttachmentList, errMap map[int]error) {
 				r := &v1beta1.VolumeAttachmentList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1beta1.VolumeAtt
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -110,7 +110,7 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 		results := make(map[int]*v1.ClusterTestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *clusterTestTypes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ClusterTestTypeList, errMap map[int]error) {
+			go func(c *clusterTestTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ClusterTestTypeList, errMap map[int]error) {
 				r := &v1.ClusterTestTypeList{}
 				err := ci.Get().
 					Resource("clustertesttypes").
@@ -124,7 +124,7 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -117,7 +117,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		results := make(map[int]*v1.TestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
+			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
@@ -117,7 +117,7 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example.TestTypeList, err
 		results := make(map[int]*example.TestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *testTypes, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*example.TestTypeList, errMap map[int]error) {
+			go func(c *testTypes, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*example.TestTypeList, errMap map[int]error) {
 				r := &example.TestTypeList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example.TestTypeList, err
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
@@ -117,7 +117,7 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example2.TestTypeList, er
 		results := make(map[int]*example2.TestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *testTypes, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*example2.TestTypeList, errMap map[int]error) {
+			go func(c *testTypes, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*example2.TestTypeList, errMap map[int]error) {
 				r := &example2.TestTypeList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example2.TestTypeList, er
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -117,7 +117,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		results := make(map[int]*v1.TestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
+			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -117,7 +117,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		results := make(map[int]*v1.TestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
+			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -110,7 +110,7 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 		results := make(map[int]*v1.ClusterTestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *clusterTestTypes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.ClusterTestTypeList, errMap map[int]error) {
+			go func(c *clusterTestTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ClusterTestTypeList, errMap map[int]error) {
 				r := &v1.ClusterTestTypeList{}
 				err := ci.Get().
 					Resource("clustertesttypes").
@@ -124,7 +124,7 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -117,7 +117,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		results := make(map[int]*v1.TestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
+			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -117,7 +117,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		results := make(map[int]*v1.TestTypeList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
+			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -479,7 +479,7 @@ func (c *$.type|privatePlural$) List(opts $.ListOptions|raw$) (result *$.resultT
 		results := make(map[int]*$.resultType|raw$List)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *$.type|privatePlural$, ci $.RESTClientInterface|raw$, opts $.ListOptions|raw$, lock $.syncMutex|raw$, pos int, resultMap map[int]*$.resultType|raw$List, errMap map[int]error) {
+			go func(c *$.type|privatePlural$, ci $.RESTClientInterface|raw$, opts $.ListOptions|raw$, lock *$.syncMutex|raw$, pos int, resultMap map[int]*$.resultType|raw$List, errMap map[int]error) {
 				r := &$.resultType|raw$List{}
 				err := ci.Get().
 					$if .namespaced$Tenant(c.te).Namespace(c.ns).$end$
@@ -495,7 +495,7 @@ func (c *$.type|privatePlural$) List(opts $.ListOptions|raw$) (result *$.resultT
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -114,7 +114,7 @@ func (c *aPIServices) List(opts metav1.ListOptions) (result *v1.APIServiceList, 
 		results := make(map[int]*v1.APIServiceList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *aPIServices, ci rest.Interface, opts metav1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1.APIServiceList, errMap map[int]error) {
+			go func(c *aPIServices, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.APIServiceList, errMap map[int]error) {
 				r := &v1.APIServiceList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *aPIServices) List(opts metav1.ListOptions) (result *v1.APIServiceList, 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -114,7 +114,7 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList,
 		results := make(map[int]*v1beta1.APIServiceList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *aPIServices, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.APIServiceList, errMap map[int]error) {
+			go func(c *aPIServices, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.APIServiceList, errMap map[int]error) {
 				r := &v1beta1.APIServiceList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList,
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
@@ -114,7 +114,7 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServ
 		results := make(map[int]*apiregistration.APIServiceList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *aPIServices, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*apiregistration.APIServiceList, errMap map[int]error) {
+			go func(c *aPIServices, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*apiregistration.APIServiceList, errMap map[int]error) {
 				r := &apiregistration.APIServiceList{}
 				err := ci.Get().
 					Tenant(c.te).
@@ -129,7 +129,7 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServ
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
@@ -99,7 +99,7 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetricsL
 		results := make(map[int]*v1alpha1.NodeMetricsList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *nodeMetricses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.NodeMetricsList, errMap map[int]error) {
+			go func(c *nodeMetricses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.NodeMetricsList, errMap map[int]error) {
 				r := &v1alpha1.NodeMetricsList{}
 				err := ci.Get().
 					Resource("nodes").
@@ -113,7 +113,7 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetricsL
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
@@ -110,7 +110,7 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetricsLis
 		results := make(map[int]*v1alpha1.PodMetricsList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *podMetricses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.PodMetricsList, errMap map[int]error) {
+			go func(c *podMetricses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.PodMetricsList, errMap map[int]error) {
 				r := &v1alpha1.PodMetricsList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -125,7 +125,7 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetricsLis
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
@@ -99,7 +99,7 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1beta1.NodeMetricsLi
 		results := make(map[int]*v1beta1.NodeMetricsList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *nodeMetricses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.NodeMetricsList, errMap map[int]error) {
+			go func(c *nodeMetricses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.NodeMetricsList, errMap map[int]error) {
 				r := &v1beta1.NodeMetricsList{}
 				err := ci.Get().
 					Resource("nodes").
@@ -113,7 +113,7 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1beta1.NodeMetricsLi
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
@@ -110,7 +110,7 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1beta1.PodMetricsList
 		results := make(map[int]*v1beta1.PodMetricsList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *podMetricses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.PodMetricsList, errMap map[int]error) {
+			go func(c *podMetricses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PodMetricsList, errMap map[int]error) {
 				r := &v1beta1.PodMetricsList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -125,7 +125,7 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1beta1.PodMetricsList
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
@@ -105,7 +105,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 		results := make(map[int]*v1alpha1.RuntimeClassList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.RuntimeClassList, errMap map[int]error) {
+			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.RuntimeClassList, errMap map[int]error) {
 				r := &v1alpha1.RuntimeClassList{}
 				err := ci.Get().
 					Resource("runtimeclasses").
@@ -119,7 +119,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
@@ -105,7 +105,7 @@ func (c *fischers) List(opts v1.ListOptions) (result *v1alpha1.FischerList, err 
 		results := make(map[int]*v1alpha1.FischerList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *fischers, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.FischerList, errMap map[int]error) {
+			go func(c *fischers, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.FischerList, errMap map[int]error) {
 				r := &v1alpha1.FischerList{}
 				err := ci.Get().
 					Resource("fischers").
@@ -119,7 +119,7 @@ func (c *fischers) List(opts v1.ListOptions) (result *v1alpha1.FischerList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
@@ -117,7 +117,7 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err 
 		results := make(map[int]*v1alpha1.FlunderList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *flunders, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.FlunderList, errMap map[int]error) {
+			go func(c *flunders, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.FlunderList, errMap map[int]error) {
 				r := &v1alpha1.FlunderList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err 
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -117,7 +117,7 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1beta1.FlunderList, err e
 		results := make(map[int]*v1beta1.FlunderList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *flunders, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1beta1.FlunderList, errMap map[int]error) {
+			go func(c *flunders, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.FlunderList, errMap map[int]error) {
 				r := &v1beta1.FlunderList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1beta1.FlunderList, err e
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
@@ -117,7 +117,7 @@ func (c *foos) List(opts v1.ListOptions) (result *v1alpha1.FooList, err error) {
 		results := make(map[int]*v1alpha1.FooList)
 		errs := make(map[int]error)
 		for i, client := range c.clients {
-			go func(c *foos, ci rest.Interface, opts v1.ListOptions, lock sync.Mutex, pos int, resultMap map[int]*v1alpha1.FooList, errMap map[int]error) {
+			go func(c *foos, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.FooList, errMap map[int]error) {
 				r := &v1alpha1.FooList{}
 				err := ci.Get().
 					Tenant(c.te).Namespace(c.ns).
@@ -132,7 +132,7 @@ func (c *foos) List(opts v1.ListOptions) (result *v1alpha1.FooList, err error) {
 				errMap[pos] = err
 				lock.Unlock()
 				wg.Done()
-			}(c, client, opts, listLock, i, results, errs)
+			}(c, client, opts, &listLock, i, results, errs)
 		}
 		wg.Wait()
 


### PR DESCRIPTION
Problem:

![webwxgetmsgimg (1)](https://user-images.githubusercontent.com/7363144/89107495-4910d480-d3e6-11ea-90fb-1e9275150f89.jpg)

Test:
`                var listLock sync.Mutex`
`+               var simLock sync.Mutex`
`+               klog.Infof("Lock address origin 1 %p, 2 %p", &listLock, &simLock)`

`+                       go func(c *pods, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, slock sync.Mutex, pos int, resultMap map[int]*v1.PodList, errMap map[int]error) {`
`+                               log.Logf("Lock address go routine: pos %d, 1 %p, 2 %p", pos, lock, &slock)`

`+                       }(c, client, opts, &listLock, simLock, i, results, errs)`

output:
$ cat /tmp/kube-controller-manager.log | grep "Lock address"
I0801 15:44:27.753210   10466 pod.go:116] Lock address origin 1 0xc003a23a30, 2 0xc003a23a38
Aug  1 15:44:27.753: INFO: Lock address go routine: pos 1, 1 0xc003a23a30, 2 0xc003a23a48
Aug  1 15:44:27.753: INFO: Lock address go routine: pos 0, 1 0xc003a23a30, 2 0xc002ea7ce8
