### PR TITLE
Fix Issue 525: "kubectl API-resources" gives erros in displaying system-crd in the context of a regular tenant

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -185,12 +185,14 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 
 	versionDiscoveryHandler := &versionDiscoveryHandler{
-		discoveryMap: map[string]map[schema.GroupVersion]*discovery.APIVersionHandler{},
-		delegate:     delegateHandler,
+		discoveryMap:             map[string]map[schema.GroupVersion]*discovery.APIVersionHandler{},
+		systemSharedCrdDiscovery: map[schema.GroupVersion]*discovery.APIVersionHandler{},
+		delegate:                 delegateHandler,
 	}
 	groupDiscoveryHandler := &groupDiscoveryHandler{
-		discoveryMap: map[string]map[string]*discovery.APIGroupHandler{},
-		delegate:     delegateHandler,
+		discoveryMap:             map[string]map[string]*discovery.APIGroupHandler{},
+		systemSharedCrdDiscovery: map[string]*discovery.APIGroupHandler{},
+		delegate:                 delegateHandler,
 	}
 	establishingController := establish.NewEstablishingController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), crdClient.Apiextensions())
 	crdHandler, err := NewCustomResourceDefinitionHandler(

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -224,7 +224,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 
 	crd := obj.(*apiextensions.CustomResourceDefinition)
 	if IsCrdSystemForced(crd) && tenant != metav1.TenantSystem {
-		return nil, false, nil
+		return nil, false, fmt.Errorf("%v is a system CRD, you cannot delete it.", name)
 	}
 
 	// Ensure we have a UID precondition

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/BUILD
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/BUILD
@@ -20,6 +20,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/arktos/multi-tenancy/forced_crd.yaml
+++ b/test/e2e/arktos/multi-tenancy/forced_crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: burgers.arktos.futurewei.com
+  labels:
+    arktos.futurewei.com/crd-sharing-policy: forced
+spec:
+  group: arktos.futurewei.com
+  version: v1alpha1
+  names:
+    kind: Burger
+    plural: burgers
+  scope: Namespaced

--- a/test/e2e/arktos/multi-tenancy/helper/config-e2e-test.sh
+++ b/test/e2e/arktos/multi-tenancy/helper/config-e2e-test.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 base_dir=$(cd $(dirname $0)/../../../.. ; pwd)
+testdata_dir=${base_dir}/test/e2e/arktos/multi-tenancy/testdata/
+setup_client_script=${base_dir}/hack/setup-multi-tenancy/setup_client.sh
 
 # By default we use the kubectl binary built in the Arktos repository.
 kubectl=${base_dir}/_output/bin/kubectl
@@ -36,6 +38,12 @@ max_retry_interval=30
 
 # create a test tenant name of 8 random characters
 new_tenant="$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)"
+
+printf "creating admin context for tenant ${new_tenant} ...."
+
+${setup_client_script} ${new_tenant} admin
+
+new_tenant_context=${new_tenant}-admin-context
 
 new_namespace="$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 5 | head -n 1)"
 

--- a/test/e2e/arktos/multi-tenancy/testcase/new_tenant_tests
+++ b/test/e2e/arktos/multi-tenancy/testcase/new_tenant_tests
@@ -21,6 +21,42 @@ ExpectOutput: default
 Command: ${kubectl} get serviceaccounts --tenant ${new_tenant} --namespace kube-system
 ExpectOutput: default
 
+#creating admin context for tenant ${new_tenant}
+Command: ${setup_client_script} ${new_tenant} admin
+
+### Protection against issue https://github.com/futurewei-cloud/arktos/issues/525
+# create a system forced sharing CRD
+Command: ${kubectl} apply -f ${testdata_dir}/system_forced_crd.yaml
+ExpectOutput: "customresourcedefinition.apiextensions.k8s.io/burgers.arktos.futurewei.com"
+
+#create a regular per-tenant CRD
+Command: ${kubectl} apply -f ${testdata_dir}/regular_crd.yaml --tenant ${new_tenant}
+ExpectOutput: "customresourcedefinition.apiextensions.k8s.io/fakeregularstuffs.samples.mars.com"
+
+# the system tenant should see both CRDs under the regular tenant
+Command: ${kubectl} get crds --tenant ${new_tenant}
+ExpectOutput: "fakeregularstuffs.samples.mars.com" "burgers.arktos.futurewei.com"
+
+# the regulart tenant should see both CRDs when using his context
+Command: ${kubectl} get crds --context ${new_tenant_context}
+ExpectOutput: "fakeregularstuffs.samples.mars.com" "burgers.arktos.futurewei.com"
+
+# system tenant finds his CRD only under his "API-resources"
+Command: ${kubectl} api-resources
+ExpectOutput: "burgers" "arktos.futurewei.com"
+
+Command: ${kubectl} api-versions
+ExpectOutput: "arktos.futurewei.com"
+
+# The regular tenant should see the per-tenant CRD and the system CRD
+Command: ${kubectl} api-resources  --context ${new_tenant}-admin-context
+ExpectOutput: "burgers" "arktos.futurewei.com" "fakeregularstuffs" "samples.mars.com"
+
+Command: ${kubectl} api-versions --context ${new_tenant}-admin-context
+ExpectOutput: "arktos.futurewei.com" "samples.mars.com"
+
+### End of test for protection against issue https://github.com/futurewei-cloud/arktos/issues/525
+
 Command: ${kubectl} delete tenant ${new_tenant}
 ExpectOutput: "${new_tenant},deleted"
 Timeout: 60

--- a/test/e2e/arktos/multi-tenancy/testdata/regular_crd.yaml
+++ b/test/e2e/arktos/multi-tenancy/testdata/regular_crd.yaml
@@ -1,0 +1,11 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: fakeregularstuffs.samples.mars.com
+spec:
+  group: samples.mars.com
+  version: v1alpha1
+  names:
+    kind: Fakeregularstuff
+    plural: fakeregularstuffs
+  scope: Namespaced

--- a/test/e2e/arktos/multi-tenancy/testdata/system_forced_crd.yaml
+++ b/test/e2e/arktos/multi-tenancy/testdata/system_forced_crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: burgers.arktos.futurewei.com
+  labels:
+    arktos.futurewei.com/crd-sharing-policy: forced
+spec:
+  group: arktos.futurewei.com
+  version: v1alpha1
+  names:
+    kind: Burger
+    plural: burgers
+  scope: Namespaced


### PR DESCRIPTION
This PR fixes issue https://github.com/futurewei-cloud/arktos/issues/525. Also added new tests to e2e multi-tenancy tests to avoid regression.

I did the following verification in my dev box: 
Tenant "x" and its admin context were created and then the following commands are run:

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl apply -f test/e2e/arktos/multi-tenancy/testdata/system_forced_crd.yaml
customresourcedefinition.apiextensions.k8s.io/burgers.arktos.futurewei.com created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get crds --tenant x
NAME                           AGE
burgers.arktos.futurewei.com   9s

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl api-resources --context x-admin-context | grep futurewei
burgers                                   arktos.futurewei.com        true       true         Burger

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl api-versions --context x-admin-context | grep futurewei
arktos.futurewei.com/v1alpha1
```
