### PR TITLE
Perf-test changes

### DIFF
--- a/perf-tests/clusterloader2/cmd/BUILD
+++ b/perf-tests/clusterloader2/cmd/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//perf-tests/clusterloader2/pkg/execservice:go_default_library",
         "//perf-tests/clusterloader2/pkg/flags:go_default_library",
         "//perf-tests/clusterloader2/pkg/framework:go_default_library",
+        "//perf-tests/clusterloader2/pkg/framework/config:go_default_library",
         "//perf-tests/clusterloader2/pkg/imagepreload:go_default_library",
         "//perf-tests/clusterloader2/pkg/measurement/common:go_default_library",
         "//perf-tests/clusterloader2/pkg/measurement/common/bundle:go_default_library",

--- a/perf-tests/clusterloader2/cmd/clusterloader.go
+++ b/perf-tests/clusterloader2/cmd/clusterloader.go
@@ -18,11 +18,12 @@ package main
 
 import (
 	"fmt"
-	clientconfig "k8s.io/kubernetes/perf-tests/clusterloader2/pkg/framework/config"
-	"k8s.io/kubernetes/pkg/master/ports"
 	"os"
 	"path"
 	"time"
+
+	clientconfig "k8s.io/kubernetes/perf-tests/clusterloader2/pkg/framework/config"
+	"k8s.io/kubernetes/pkg/master/ports"
 
 	ginkgoconfig "github.com/onsi/ginkgo/config"
 	ginkgoreporters "github.com/onsi/ginkgo/reporters"
@@ -63,6 +64,7 @@ var (
 func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.KubeConfigPath, "kubeconfig", "KUBECONFIG", "", "Path to the kubeconfig file")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.Nodes, "nodes", "NUM_NODES", 0, "number of nodes")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.Apiserverextranum, "apiserver-extra-num", "APISERVERS_EXTRA_NUM", 0, "number of extra apiservers")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.KubeletPort, "kubelet-port", "KUBELET_PORT", ports.KubeletPort, "Port of the kubelet to use")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.Provider, "provider", "PROVIDER", "", "Cluster provider")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdCertificatePath, "etcd-certificate", "ETCD_CERTIFICATE", "/etc/srv/kubernetes/pki/etcd-apiserver-server.crt", "Path to the etcd certificate on the master machine")
@@ -92,7 +94,7 @@ func validateClusterFlags() *errors.ErrorList {
 }
 
 func initFlags() {
-	flags.StringVar(&apiServerAddresses, "api-server-addresses", "","Addresses of partitioned api servers")
+	flags.StringVar(&apiServerAddresses, "api-server-addresses", "", "Addresses of partitioned api servers")
 	flags.StringVar(&clusterLoaderConfig.ReportDir, "report-dir", "", "Path to the directory where the reports should be saved. Default is empty, which cause reports being written to standard output.")
 	flags.BoolEnvVar(&clusterLoaderConfig.EnableExecService, "enable-exec-service", "ENABLE_EXEC_SERVICE", false, "Whether to enable exec service that allows executing arbitrary commands from a pod running in the cluster.")
 	// TODO(https://github.com/kubernetes/perf-tests/issues/641): Remove testconfig and testoverrides flags when test suite is fully supported.
@@ -226,7 +228,6 @@ func main() {
 	if errList := validateFlags(); !errList.IsEmpty() {
 		klog.Exitf("Parsing flags error: %v", errList.String())
 	}
-
 
 	mclient, err := framework.NewMultiClientSet(clusterLoaderConfig.ClusterConfig.KubeConfigPath, 1)
 	if err != nil {

--- a/perf-tests/clusterloader2/pkg/config/cluster.go
+++ b/perf-tests/clusterloader2/pkg/config/cluster.go
@@ -41,6 +41,7 @@ type ClusterConfig struct {
 	MasterInternalIPs          []string
 	MasterName                 string
 	KubemarkRootKubeConfigPath string
+	Apiserverextranum          int //APISERVER_EXTRA_NUM
 	DeleteStaleNamespaces      bool
 	// SSHToMasterSupported determines whether SSH access to master machines is possible.
 	// If false (impossible for many  providers), ClusterLoader will skip operations requiring it.

--- a/perf-tests/clusterloader2/pkg/framework/BUILD
+++ b/perf-tests/clusterloader2/pkg/framework/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//perf-tests/clusterloader2/pkg/errors:go_default_library",
         "//perf-tests/clusterloader2/pkg/framework/client:go_default_library",
         "//perf-tests/clusterloader2/pkg/framework/config:go_default_library",
+        "//perf-tests/clusterloader2/pkg/util:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/perf-tests/clusterloader2/pkg/framework/config/BUILD
+++ b/perf-tests/clusterloader2/pkg/framework/config/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//staging/src/k8s.io/client-go/transport:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/perf-tests/clusterloader2/pkg/framework/config/client_config.go
+++ b/perf-tests/clusterloader2/pkg/framework/config/client_config.go
@@ -51,11 +51,11 @@ func SetAPIServers(apiServerAddresses string) error {
 
 	addrs := strings.Split(apiServerAddresses, ";")
 	for _, item := range addrs {
-		extraAPIServerAddresses = append(extraAPIServerAddresses, item)
+		extraAPIServerAddresses = append(extraAPIServerAddresses, strings.TrimSpace(item))
 	}
 
 	if len(extraAPIServerAddresses) == 0 {
-		klog.Infof("Passed in api server addresses [%s]. Keep kubeconfig value instead.", apiServerAddresses)
+		klog.Infof("Passed in extra api server addresses [%s]. Keep kubeconfig value.", apiServerAddresses)
 	}
 	return nil
 }

--- a/perf-tests/clusterloader2/pkg/util/util.go
+++ b/perf-tests/clusterloader2/pkg/util/util.go
@@ -245,11 +245,20 @@ func CloneMap(src map[string]interface{}) map[string]interface{} {
 }
 
 // RandomDNS1123String generates random string of a given length.
-func RandomDNS1123String(length int) string {
+func RandomDNS1123String(length int, startpos int, endpos int) string {
 	characters := []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	characters_pos := characters
+	if startpos < endpos {
+		characters_pos = []rune(string(characters[startpos:endpos]))
+	}
 	s := make([]rune, length)
 	for i := range s {
 		s[i] = characters[rand.Intn(len(characters))]
+		if i == 0 {
+			s[i] = characters_pos[rand.Intn(len(characters_pos))]
+		} else {
+			s[i] = characters[rand.Intn(len(characters))]
+		}
 	}
 	return string(s)
 }

--- a/staging/src/k8s.io/client-go/dynamic/BUILD
+++ b/staging/src/k8s.io/client-go/dynamic/BUILD
@@ -33,6 +33,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/dynamic",
     importpath = "k8s.io/client-go/dynamic",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
@@ -43,6 +44,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"math/rand"
 	"sync"
 	"time"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 )


### PR DESCRIPTION
. Allow perf-test to get all api servers in partitioned api server environment
   . Support list from revision in dynamic client
. Sonya: dynamic to create namespaces and force to average namespace name per apiserver number


Scheduling throughput on 2 partitioned api servers:
{
  "perc50": 20,
  "perc90": 20,
  "perc99": 20.2,
  "max": 23.4
}

for Arktos changes:
https://github.com/Sindica/arktos/commits/2apiserver-sonya-verified

![image](https://user-images.githubusercontent.com/7363144/89250823-6ef6ce80-d5ca-11ea-8599-df52fdb8e7ef.png)

