### PR TITLE
Remove partition for secrets & serviceaccounts because create pod req…

### DIFF
--- a/hack/apiserver.config
+++ b/hack/apiserver.config
@@ -21,8 +21,6 @@
 /registry/podtemplates/,,
 /registry/replicasets/,,
 /registry/resourcequotas/,,
-/registry/secrets/,,
-/registry/serviceaccounts/,,
 /registry/statefulsets/,,
 /registry/volumeattachments/,,
 


### PR DESCRIPTION
…uest returns 500 error. (Need to fix to more identifiable error if partiton is required)

