### PR TITLE
Fix a timing issue where the pod.spec.workloadinfo can be used concurrently by PLEG and podUpdate routines

### DIFF
--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -43,11 +43,12 @@ func GetPodQOS(pod *v1.Pod) v1.PodQOSClass {
 	zeroQuantity := resource.MustParse("0")
 	isGuaranteed := true
 
-	defer func() {
-		pod.Spec.WorkloadInfo = nil
-	}()
+	// Since pod.Spec.Workload() can potentially change the spec.WorkloadInfo slice in the pod
+	// make a local copy for calculate the QoS class for a given pod, instead lock the function
+	// for possible perf impact
+	specLocal := pod.Spec.DeepCopy()
 
-	for _, workload := range pod.Spec.Workloads() {
+	for _, workload := range specLocal.Workloads() {
 		// process requests
 		for name, quantity := range workload.Resources.Requests {
 			if !isSupportedQoSComputeResource(name) {


### PR DESCRIPTION

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Fix a timing issue encountered in perf testing

**Which issue(s) this PR fixes**:
Fixes # 552

**Special notes for your reviewer**:
there are 3 possible options in fixing this bug:
1. Always set spec.workloadinfo when admitting the pod, so all subsequent calls when assuming the workloadinfo set already, and pod.spec will be all read-only operations
2. R/W lock to the QoS () function
3. use a localcopy of spec instead of the global *pod.

the current fix picks #3 which is least invasive and safe fix to unblock perf testing.

**Does this PR introduce a user-facing change?**:
None
