### PR TITLE
Miscellanous fix of WCM:

### DIFF
--- a/cmd/workload-controller-manager/app/controllermanager.go
+++ b/cmd/workload-controller-manager/app/controllermanager.go
@@ -93,8 +93,6 @@ const (
 	ownerKind_ReplicaSet = "ReplicaSet"
 )
 
-var resyncPeriod = time.Duration(60 * time.Second)
-
 func StartControllerManager(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 	// Setup any healthz checks we will want to use.
 	var checks []healthz.HealthzChecker
@@ -135,7 +133,8 @@ func StartControllerManager(c *config.CompletedConfig, stopCh <-chan struct{}) e
 
 	ctx := context.TODO()
 
-	controllerContext, err := CreateControllerContext(rootClientBuilder, clientBuilder, heartBeatClientBuilder, ctx.Done())
+	controllerContext, err := CreateControllerContext(rootClientBuilder, clientBuilder, heartBeatClientBuilder,
+		c.Config.ControllerTypeConfig.GetDeafultResyncPeriod(), ctx.Done())
 
 	if err != nil {
 		klog.Fatalf("error building controller context: %v", err)
@@ -162,7 +161,7 @@ func StartControllerManager(c *config.CompletedConfig, stopCh <-chan struct{}) e
 }
 
 //func CreateControllerContext(s *config.CompletedConfig, rootClientBuilder, clientBuilder controller.ControllerClientBuilder, stop <-chan struct{}) (ControllerContext, error) {
-func CreateControllerContext(rootClientBuilder, clientBuilder, heatBeatClientBuilder controller.ControllerClientBuilder, stop <-chan struct{}) (ControllerContext, error) {
+func CreateControllerContext(rootClientBuilder, clientBuilder, heatBeatClientBuilder controller.ControllerClientBuilder, resyncPeriod time.Duration, stop <-chan struct{}) (ControllerContext, error) {
 	versionedClient := rootClientBuilder.ClientOrDie("shared-informers")
 	sharedInformers := informers.NewSharedInformerFactory(versionedClient, resyncPeriod)
 

--- a/cmd/workload-controller-manager/config/controllerconfig.json
+++ b/cmd/workload-controller-manager/config/controllerconfig.json
@@ -1,5 +1,6 @@
 {
     "reportHealthIntervalInSecond": 10,
+    "resyncPeriod": "12h0m0s",
     "qps": 20,
     "controllers": [
         {

--- a/pkg/cloudfabric-controller/controllerframework/controllerinstancemanager.go
+++ b/pkg/cloudfabric-controller/controllerframework/controllerinstancemanager.go
@@ -78,7 +78,7 @@ func NewControllerInstanceManager(coInformer coreinformers.ControllerInstanceInf
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().EventsWithMultiTenancy(metav1.NamespaceAll, metav1.TenantAll)})
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("job_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		metrics.RegisterMetricAndTrackRateLimiterUsage("controller_instance_manager", kubeClient.CoreV1().RESTClient().GetRateLimiter())
 	}
 
 	manager := &ControllerInstanceManager{

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -251,7 +251,8 @@ func (r *Reflector) resyncChan() (<-chan time.Time, func() bool) {
 // and then use the resource version to watch.
 // It returns error if ListAndWatch didn't even try to initialize watch.
 func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
-	klog.V(3).Infof("ListAndWatch %v. filter bounds %+v. name %s", r.expectedType, r.filterBounds, r.name)
+	klog.V(3).Infof("ListAndWatch %v. filter bounds %+v. name %s. Watch page size %v. resync period %v",
+		r.expectedType, r.filterBounds, r.name, r.WatchListPageSize, r.resyncPeriod)
 	var resourceVersion string
 
 	// Explicitly set "0" as resource version - it's fine for the List()


### PR DESCRIPTION
    . Use 12 hours as the base of resync Period (same as kube controller manager)
    . Correct controller instance manager metrics
    . Add resyncPeriod & WatchListPageSize to ListAndWatch log

