### PR TITLE
Update controller name generation logic for data distribution efficiency

### DIFF
--- a/pkg/cloudfabric-controller/controllerframework/cim_test.go
+++ b/pkg/cloudfabric-controller/controllerframework/cim_test.go
@@ -33,7 +33,7 @@ func newControllerInstance(cim *ControllerInstanceManager, controllerType string
 		WorkloadNum:    workloadNum,
 	}
 
-	GetInstanceHandler = func () *ControllerInstanceManager {
+	GetInstanceHandler = func() *ControllerInstanceManager {
 		return cim
 	}
 	controllerInstance.Name = generateControllerName(controllerType, nil)

--- a/pkg/cloudfabric-controller/controllerframework/cim_test.go
+++ b/pkg/cloudfabric-controller/controllerframework/cim_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 )
 
-func newControllerInstance(controllerType string, controllerKey int64, workloadNum int32, isLocked bool) *v1.ControllerInstance {
+func newControllerInstance(cim *ControllerInstanceManager, controllerType string, controllerKey int64, workloadNum int32) *v1.ControllerInstance {
 	controllerInstance := &v1.ControllerInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: "100",
@@ -33,7 +33,11 @@ func newControllerInstance(controllerType string, controllerKey int64, workloadN
 		WorkloadNum:    workloadNum,
 	}
 
-	controllerInstance.Name = generateControllerName(nil)
+	GetInstanceHandler = func () *ControllerInstanceManager {
+		return cim
+	}
+	controllerInstance.Name = generateControllerName(controllerType, nil)
+	GetInstanceHandler = getControllerInstanceManager
 
 	return controllerInstance
 }
@@ -41,7 +45,7 @@ func newControllerInstance(controllerType string, controllerKey int64, workloadN
 func testAddEvent(t *testing.T, cim *ControllerInstanceManager, notifyTimes int) (*v1.ControllerInstance, string, map[string]v1.ControllerInstance) {
 	// add event
 	controllerType := "foo"
-	controllerInstance1 := newControllerInstance(controllerType, 10000, 999, false)
+	controllerInstance1 := newControllerInstance(cim, controllerType, 10000, 999)
 	cim.addControllerInstance(controllerInstance1)
 
 	controllerInstanceMap, err := cim.ListControllerInstances(controllerType)
@@ -153,7 +157,7 @@ func TestDeleteControllerInstanceDoesNotExist(t *testing.T) {
 	cim, _ := CreateTestControllerInstanceManager(stopCh)
 	notifyTimes = 0
 
-	controllerInstance1 := newControllerInstance("bar", 10000, 999, false)
+	controllerInstance1 := newControllerInstance(cim, "bar", 10000, 999)
 	cim.deleteControllerInstance(controllerInstance1)
 
 	controllerInstanceMap, err := cim.ListControllerInstances(controllerInstance1.ControllerType)
@@ -166,16 +170,20 @@ func TestAddMultipleControllerInstancesForSameControllerType(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	cim, _ := CreateTestControllerInstanceManager(stopCh)
+	cim1, _ := CreateTestControllerInstanceManager(stopCh)
+	cim2, _ := CreateTestControllerInstanceManager(stopCh)
 	notifyTimes = 0
 
 	// add event
-	controllerInstance1, controllerType1, _ := testAddEvent(t, cim, 1)
-	controllerInstance2, controllerType2, _ := testAddEvent(t, cim, 2)
+	controllerInstance1, controllerType1, _ := testAddEvent(t, cim1, 1)
+	controllerInstance2, controllerType2, _ := testAddEvent(t, cim2, 2)
 	assert.Equal(t, controllerType1, controllerType2)
 	assert.NotEqual(t, controllerInstance1.Name, controllerInstance2.Name)
 
-	controllerInstanceMap, err := cim.ListControllerInstances(controllerType1)
+	// cim 1 got controller 2 creation event
+	cim1.addControllerInstance(controllerInstance2)
+
+	controllerInstanceMap, err := cim1.ListControllerInstances(controllerType1)
 	assert.Nil(t, err)
 	assert.NotNil(t, controllerInstanceMap)
 	controllerInstanceRead1, isOK1 := controllerInstanceMap[controllerInstance1.Name]
@@ -227,21 +235,27 @@ func TestErrorHandlingInListControllerInstances(t *testing.T) {
 	cim, _ := CreateTestControllerInstanceManager(stopCh)
 	notifyTimes = 0
 
-	_, controllerType, _ := testAddEvent(t, cim, 1)
+	controllerInstance1, controllerType, _ := testAddEvent(t, cim, 1)
 	testAddEvent(t, cim, 2)
 
-	controllerInstance3 := newControllerInstance("foo2", 10000, 999, false)
-	cim.addControllerInstance(controllerInstance3)
+	controllerInstance2 := newControllerInstance(cim, "foo2", 10000, 999)
+	cim.addControllerInstance(controllerInstance2)
 
 	cim.isControllerListInitialized = false
 
 	controllerInstanceMap1, err := cim.ListControllerInstances(controllerType)
 	assert.Nil(t, err)
 	assert.NotNil(t, controllerInstanceMap1)
-	assert.Equal(t, 2, len(controllerInstanceMap1))
+	assert.Equal(t, 1, len(controllerInstanceMap1))
+	instanceRead, isOK := controllerInstanceMap1[controllerInstance1.Name]
+	assert.True(t, isOK)
+	assert.Equal(t, controllerInstance1.ControllerKey, instanceRead.ControllerKey)
 
 	controllerInstanceMap2, err := cim.ListControllerInstances("foo2")
 	assert.Nil(t, err)
 	assert.NotNil(t, controllerInstanceMap2)
 	assert.Equal(t, 1, len(controllerInstanceMap2))
+	instanceRead, isOK = controllerInstanceMap2[controllerInstance2.Name]
+	assert.True(t, isOK)
+	assert.Equal(t, controllerInstance2.ControllerKey, instanceRead.ControllerKey)
 }

--- a/pkg/cloudfabric-controller/controllerframework/controller_framework_test.go
+++ b/pkg/cloudfabric-controller/controllerframework/controller_framework_test.go
@@ -263,7 +263,7 @@ func TestConsolidateControllerInstances_Sort(t *testing.T) {
 	hashKey1 = int64(3074457345618258603)
 	hashKey2 := int64(6148914691236517205)
 	cim3, _ := CreateTestControllerInstanceManager(stopCh)
-	controllerInstance1_3 := newControllerInstance(cim3,"foo", int64(2000), 100)
+	controllerInstance1_3 := newControllerInstance(cim3, "foo", int64(2000), 100)
 	cim.addControllerInstance(controllerInstance1_3)
 	cim2.addControllerInstance(controllerInstance1_3)
 	cim3.addControllerInstance(controllerInstance1_3)

--- a/pkg/cloudfabric-controller/controllerframework/controller_framework_utils.go
+++ b/pkg/cloudfabric-controller/controllerframework/controller_framework_utils.go
@@ -96,7 +96,7 @@ func CreateTestControllerInstanceManager(stopCh chan struct{}) (*ControllerInsta
 	cim.controllerListerSynced = alwaysReady
 	cim.notifyHandler = mockNotifyHander
 	checkInstanceHandler = mockCheckInstanceHander
-	return GetControllerInstanceManager(), informers
+	return GetInstanceHandler(), informers
 }
 
 func MockCreateControllerInstanceAndResetChs(stopCh chan struct{}) (*bcast.Member, *bcast.Group) {
@@ -104,7 +104,7 @@ func MockCreateControllerInstanceAndResetChs(stopCh chan struct{}) (*bcast.Membe
 	cimUpdateCh := cimUpdateChGrp.Join()
 	informersResetChGrp := bcast.NewGroup()
 
-	cim := GetControllerInstanceManager()
+	cim := GetInstanceHandler()
 	if cim == nil {
 		cim, _ = CreateTestControllerInstanceManager(stopCh)
 		go cim.Run(stopCh)

--- a/pkg/cloudfabric-controller/controllerframework/controllerinstancemanager.go
+++ b/pkg/cloudfabric-controller/controllerframework/controllerinstancemanager.go
@@ -59,8 +59,9 @@ type ControllerInstanceManager struct {
 
 var instance *ControllerInstanceManager
 var checkInstanceHandler = checkInstanceExistence
+var GetInstanceHandler = getControllerInstanceManager
 
-func GetControllerInstanceManager() *ControllerInstanceManager {
+func getControllerInstanceManager() *ControllerInstanceManager {
 	return instance
 }
 
@@ -110,8 +111,13 @@ func NewControllerInstanceManager(coInformer coreinformers.ControllerInstanceInf
 	return instance
 }
 
-func (cim *ControllerInstanceManager) GetInstanceId() types.UID {
-	return cim.instanceId
+func GetInstanceId() types.UID {
+	cim := GetInstanceHandler()
+	if cim != nil {
+		return cim.instanceId
+	} else {
+		return ""
+	}
 }
 
 func (cim *ControllerInstanceManager) addControllerInstance(obj interface{}) {

--- a/pkg/cloudfabric-controller/replicaset/replica_set_test.go
+++ b/pkg/cloudfabric-controller/replicaset/replica_set_test.go
@@ -66,7 +66,7 @@ func testNewReplicaSetControllerFromClient(client clientset.Interface, stopCh ch
 	cimUpdateChGrp := bcast.NewGroup()
 	cimUpdateCh := cimUpdateChGrp.Join()
 
-	cim := controllerframework.GetControllerInstanceManager()
+	cim := controllerframework.GetInstanceHandler()
 	if cim == nil {
 		cim, _ = controllerframework.CreateTestControllerInstanceManager(stopCh)
 		go cim.Run(stopCh)
@@ -481,7 +481,7 @@ func TestWatchControllers(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	cim := controllerframework.GetControllerInstanceManager()
+	cim := controllerframework.GetInstanceHandler()
 	if cim == nil {
 		cim, _ = controllerframework.CreateTestControllerInstanceManager(stopCh)
 		go cim.Run(stopCh)

--- a/test/integration/cloudfabriccontrollers/deployment_util.go
+++ b/test/integration/cloudfabriccontrollers/deployment_util.go
@@ -164,7 +164,7 @@ func dcSetup(t *testing.T) (*httptest.Server, framework.CloseFunc, *replicaset.R
 	informers := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(configs, "deployment-informers")), resyncPeriod)
 
 	// controller instance manager set up
-	cim := controller.GetControllerInstanceManager()
+	cim := controller.GetInstanceHandler()
 	if cim == nil {
 		cimUpdateChGrp := bcast.NewGroup()
 		go cimUpdateChGrp.Broadcast(0)

--- a/test/integration/cloudfabriccontrollers/testutil.go
+++ b/test/integration/cloudfabriccontrollers/testutil.go
@@ -98,7 +98,7 @@ func RmSetupControllerMaster(t *testing.T, s *httptest.Server) (*controller.Cont
 	informers := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(configs, "rs-informers")), resyncPeriod)
 
 	// controller instance manager set up
-	cim := controller.GetControllerInstanceManager()
+	cim := controller.GetInstanceHandler()
 	if cim == nil {
 		cimUpdateChGrp := bcast.NewGroup()
 		go cimUpdateChGrp.Broadcast(0)


### PR DESCRIPTION
Previous controller name use individual generated uuid. Since the controllers watch pods based on owner reference key, the randomized generation logic can cause all controllers watch all pods during perf test.

Force controllers in the same controller managers have similar controller name allows a workload controller manager only watch a small portion of pods.

Example controller names:
NAME                                              CONTROLLERTYPE   UID                                    CONTROLLERKEY         WORKLOADNUM   ISLOCKED
deployment-**0b857ad2-0496-42e6-8a5a-06cec6fabe09**   Deployment       3bcf2c98-dc83-4da4-8af6-53995097c98e   1844674407370955163   0             false
deployment-3de8ea83-4814-4d9f-8f5a-78192baeeb9b   Deployment       89d22ae9-df11-4d10-98a1-88d97952aa77   3689348814741910324   0             false
deployment-51789910-1c24-4849-a1f8-f94c502588c8   Deployment       6e3d620f-b017-4f86-af2c-d818caeeecad   5534023222112865485   0             false
deployment-b2eb19f8-a5cb-4e87-b284-8b4d0525499d   Deployment       2b5d9f7b-0791-405f-859a-9bd75ece44c6   7378697629483820646   0             false
deployment-f1332f7a-6b08-4b43-9252-f20412edf75d   Deployment       ee19e4c0-0bfb-457c-a871-81719a93d01d   9223372036854775807   0             false
replicaset-**0b857ad2-0496-42e6-8a5a-06cec6fabe09**   ReplicaSet       7ab81253-3a07-4049-bef3-6231baecf746   1844674407370955163   0             false
replicaset-3de8ea83-4814-4d9f-8f5a-78192baeeb9b   ReplicaSet       950833b1-a9a9-441c-bb96-97632e04aa12   3689348814741910324   0             false
replicaset-51789910-1c24-4849-a1f8-f94c502588c8   ReplicaSet       8bdf09f2-35be-4162-8b16-830093ad3557   5534023222112865485   0             false
replicaset-b2eb19f8-a5cb-4e87-b284-8b4d0525499d   ReplicaSet       ce3892c1-0a8a-49f6-b20f-ac9faf12abac   7378697629483820646   0             false
replicaset-f1332f7a-6b08-4b43-9252-f20412edf75d   ReplicaSet       39bcdf41-9eb6-40fa-bc07-e94bba91dc47   9223372036854775807   0             false


New watch range for one WCM:
createHashkeyListOptions filterBounds [[{resetCh:0xc00045d8c0 sourceName:ReplicaSet_Controller ownerKind:ReplicaSet bounds:[0 **1844674407370955163**]} {resetCh:0xc00045d9c0 sourceName:ReplicaSet_Controller ownerKind: bounds:[0 **1844674407370955163**]} {resetCh:0xc00023d040 sourceName:Deployment_Controller ownerKind:Deployment bounds:[0 **1844674407370955163**]} {resetCh:0xc00023d080 sourceName:Deployment_Controller ownerKind: bounds:[0 **1844674407370955163**]}]], expectedType *v1.Pod

createHashkeyListOptions filterBounds [[{resetCh:0xc00045d700 sourceName:ReplicaSet_Controller ownerKind: bounds:[0 **1844674407370955163**]} {resetCh:0xc00023cf40 sourceName:Deployment_Controller ownerKind:Deployment bounds:[0 **1844674407370955163**]}]], expectedType *v1.ReplicaSet

createHashkeyListOptions filterBounds [[{resetCh:0xc00023cd80 sourceName:Deployment_Controller ownerKind: bounds:[0 **1844674407370955163**]}]], expectedType *v1.Deployment




