### PR TITLE
E2e perf test

### DIFF
--- a/perf-tests/clusterloader2/pkg/imagepreload/imagepreload.go
+++ b/perf-tests/clusterloader2/pkg/imagepreload/imagepreload.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	informerTimeout = time.Minute
-	manifest        = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/imagepreload/manifests/daemonset.yaml"
+	manifest        = "$GOPATH/src/k8s.io/arktos/perf-tests/clusterloader2/pkg/imagepreload/manifests/daemonset.yaml"
 	namespace       = "preload"
 	daemonsetName   = "preload"
 	pollingInterval = 5 * time.Second

--- a/perf-tests/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/perf-tests/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -35,7 +35,7 @@ import (
 const (
 	probesNamespace = "probes"
 
-	manifestsPathPrefix = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/common/probes/manifests/"
+	manifestsPathPrefix = "$GOPATH/src/k8s.io/arktos/perf-tests/clusterloader2/pkg/measurement/common/probes/manifests/"
 
 	checkProbesReadyInterval = 15 * time.Second
 	checkProbesReadyTimeout  = 5 * time.Minute

--- a/perf-tests/clusterloader2/pkg/prometheus/prometheus.go
+++ b/perf-tests/clusterloader2/pkg/prometheus/prometheus.go
@@ -41,13 +41,13 @@ import (
 
 const (
 	namespace                    = "monitoring"
-	coreManifests                = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/*.yaml"
-	defaultServiceMonitors       = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/default/*.yaml"
-	masterIPServiceMonitors      = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/master-ip/*.yaml"
+	coreManifests                = "$GOPATH/src/k8s.io/arktos/perf-tests/clusterloader2/pkg/prometheus/manifests/*.yaml"
+	defaultServiceMonitors       = "$GOPATH/src/k8s.io/arktos/perf-tests/clusterloader2/pkg/prometheus/manifests/default/*.yaml"
+	masterIPServiceMonitors      = "$GOPATH/src/k8s.io/arktos/perf-tests/clusterloader2/pkg/prometheus/manifests/master-ip/*.yaml"
 	checkPrometheusReadyInterval = 30 * time.Second
 	checkPrometheusReadyTimeout  = 15 * time.Minute
 	numK8sClients                = 1
-	nodeExporterPod              = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml"
+	nodeExporterPod              = "$GOPATH/src/k8s.io/arktos/perf-tests/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml"
 )
 
 // InitFlags initializes prometheus flags.

--- a/staging/src/k8s.io/client-go/deprecated-dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/deprecated-dynamic/client_test.go
@@ -101,7 +101,7 @@ func TestList(t *testing.T) {
 		{
 			name:      "namespaced_list",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
 			resp: getListJSON("vTest", "rTestList",
 				getJSON("vTest", "rTest", "item1"),
 				getJSON("vTest", "rTest", "item2")),
@@ -170,7 +170,7 @@ func TestGet(t *testing.T) {
 			resource:  "rtest",
 			namespace: "nstest",
 			name:      "namespaced_get",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_get",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_get",
 			resp:      getJSON("vTest", "rTest", "namespaced_get"),
 			want:      getObject("vTest", "rTest", "namespaced_get"),
 		},
@@ -185,7 +185,7 @@ func TestGet(t *testing.T) {
 			resource:  "rtest/srtest",
 			namespace: "nstest",
 			name:      "namespaced_subresource_get",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_get/srtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_get/srtest",
 			resp:      getJSON("vTest", "srTest", "namespaced_subresource_get"),
 			want:      getObject("vTest", "srTest", "namespaced_subresource_get"),
 		},
@@ -244,12 +244,12 @@ func TestDelete(t *testing.T) {
 		{
 			namespace: "nstest",
 			name:      "namespaced_delete",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete",
 		},
 		{
 			namespace:     "nstest",
 			name:          "namespaced_delete_with_options",
-			path:          "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete_with_options",
+			path:          "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete_with_options",
 			deleteOptions: &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}, PropagationPolicy: &background},
 		},
 	}
@@ -299,7 +299,7 @@ func TestDeleteCollection(t *testing.T) {
 		{
 			namespace: "nstest",
 			name:      "namespaced_delete_collection",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
 		},
 	}
 	for _, tc := range tcs {
@@ -349,7 +349,7 @@ func TestCreate(t *testing.T) {
 			resource:  "rtest",
 			name:      "namespaced_create",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
 			obj:       getObject("gtest/vTest", "rTest", "namespaced_create"),
 		},
 	}
@@ -411,7 +411,7 @@ func TestUpdate(t *testing.T) {
 			resource:  "rtest",
 			name:      "namespaced_update",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_update",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_update",
 			obj:       getObject("gtest/vTest", "rTest", "namespaced_update"),
 		},
 		{
@@ -424,7 +424,7 @@ func TestUpdate(t *testing.T) {
 			resource:  "rtest/srtest",
 			name:      "namespaced_subresource_update",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_update/srtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_update/srtest",
 			obj:       getObject("gtest/vTest", "srTest", "namespaced_update"),
 		},
 	}
@@ -489,7 +489,7 @@ func TestWatch(t *testing.T) {
 		{
 			name:      "namespaced_watch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
 			query:     "watch=true",
 			events: []watch.Event{
 				{Type: watch.Added, Object: getObject("gtest/vTest", "rTest", "namespaced_watch")},
@@ -559,7 +559,7 @@ func TestPatch(t *testing.T) {
 			resource:  "rtest",
 			name:      "namespaced_patch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_patch",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_patch",
 			patch:     getJSON("gtest/vTest", "rTest", "namespaced_patch"),
 			want:      getObject("gtest/vTest", "rTest", "namespaced_patch"),
 		},
@@ -574,7 +574,7 @@ func TestPatch(t *testing.T) {
 			resource:  "rtest/srtest",
 			name:      "namespaced_subresource_patch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_patch/srtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_patch/srtest",
 			patch:     getJSON("gtest/vTest", "srTest", "namespaced_subresource_patch"),
 			want:      getObject("gtest/vTest", "srTest", "namespaced_subresource_patch"),
 		},

--- a/staging/src/k8s.io/client-go/dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_test.go
@@ -82,7 +82,7 @@ func TestList(t *testing.T) {
 	}{
 		{
 			name: "normal_list",
-			path: "/apis/gtest/vtest/tenants/system/rtest",
+			path: "/apis/gtest/vtest/rtest",
 			resp: getListJSON("vTest", "rTestList",
 				getJSON("vTest", "rTest", "item1"),
 				getJSON("vTest", "rTest", "item2")),
@@ -100,7 +100,7 @@ func TestList(t *testing.T) {
 		{
 			name:      "namespaced_list",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
 			resp: getListJSON("vTest", "rTestList",
 				getJSON("vTest", "rTest", "item1"),
 				getJSON("vTest", "rTest", "item2")),
@@ -161,7 +161,7 @@ func TestGet(t *testing.T) {
 		{
 			resource: "rtest",
 			name:     "normal_get",
-			path:     "/apis/gtest/vtest/tenants/system/rtest/normal_get",
+			path:     "/apis/gtest/vtest/rtest/normal_get",
 			resp:     getJSON("vTest", "rTest", "normal_get"),
 			want:     getObject("vTest", "rTest", "normal_get"),
 		},
@@ -169,7 +169,7 @@ func TestGet(t *testing.T) {
 			resource:  "rtest",
 			namespace: "nstest",
 			name:      "namespaced_get",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_get",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_get",
 			resp:      getJSON("vTest", "rTest", "namespaced_get"),
 			want:      getObject("vTest", "rTest", "namespaced_get"),
 		},
@@ -177,7 +177,7 @@ func TestGet(t *testing.T) {
 			resource:    "rtest",
 			subresource: []string{"srtest"},
 			name:        "normal_subresource_get",
-			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_subresource_get/srtest",
+			path:        "/apis/gtest/vtest/rtest/normal_subresource_get/srtest",
 			resp:        getJSON("vTest", "srTest", "normal_subresource_get"),
 			want:        getObject("vTest", "srTest", "normal_subresource_get"),
 		},
@@ -186,7 +186,7 @@ func TestGet(t *testing.T) {
 			subresource: []string{"srtest"},
 			namespace:   "nstest",
 			name:        "namespaced_subresource_get",
-			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_get/srtest",
+			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_get/srtest",
 			resp:        getJSON("vTest", "srTest", "namespaced_subresource_get"),
 			want:        getObject("vTest", "srTest", "namespaced_subresource_get"),
 		},
@@ -240,28 +240,28 @@ func TestDelete(t *testing.T) {
 	}{
 		{
 			name: "normal_delete",
-			path: "/apis/gtest/vtest/tenants/system/rtest/normal_delete",
+			path: "/apis/gtest/vtest/rtest/normal_delete",
 		},
 		{
 			namespace: "nstest",
 			name:      "namespaced_delete",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete",
 		},
 		{
 			subresource: []string{"srtest"},
 			name:        "normal_delete",
-			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_delete/srtest",
+			path:        "/apis/gtest/vtest/rtest/normal_delete/srtest",
 		},
 		{
 			subresource: []string{"srtest"},
 			namespace:   "nstest",
 			name:        "namespaced_delete",
-			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete/srtest",
+			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete/srtest",
 		},
 		{
 			namespace:     "nstest",
 			name:          "namespaced_delete_with_options",
-			path:          "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_delete_with_options",
+			path:          "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete_with_options",
 			deleteOptions: &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}, PropagationPolicy: &background},
 		},
 	}
@@ -305,12 +305,12 @@ func TestDeleteCollection(t *testing.T) {
 	}{
 		{
 			name: "normal_delete_collection",
-			path: "/apis/gtest/vtest/tenants/system/rtest",
+			path: "/apis/gtest/vtest/rtest",
 		},
 		{
 			namespace: "nstest",
 			name:      "namespaced_delete_collection",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
 		},
 	}
 	for _, tc := range tcs {
@@ -353,21 +353,21 @@ func TestCreate(t *testing.T) {
 		{
 			resource: "rtest",
 			name:     "normal_create",
-			path:     "/apis/gtest/vtest/tenants/system/rtest",
+			path:     "/apis/gtest/vtest/rtest",
 			obj:      getObject("gtest/vTest", "rTest", "normal_create"),
 		},
 		{
 			resource:  "rtest",
 			name:      "namespaced_create",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
 			obj:       getObject("gtest/vTest", "rTest", "namespaced_create"),
 		},
 		{
 			resource:    "rtest",
 			subresource: []string{"srtest"},
 			name:        "normal_subresource_create",
-			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_subresource_create/srtest",
+			path:        "/apis/gtest/vtest/rtest/normal_subresource_create/srtest",
 			obj:         getObject("vTest", "srTest", "normal_subresource_create"),
 		},
 		{
@@ -375,7 +375,7 @@ func TestCreate(t *testing.T) {
 			subresource: []string{"srtest"},
 			name:        "namespaced_subresource_create",
 			namespace:   "nstest",
-			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_create/srtest",
+			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_create/srtest",
 			obj:         getObject("vTest", "srTest", "namespaced_subresource_create"),
 		},
 	}
@@ -430,21 +430,21 @@ func TestUpdate(t *testing.T) {
 		{
 			resource: "rtest",
 			name:     "normal_update",
-			path:     "/apis/gtest/vtest/tenants/system/rtest/normal_update",
+			path:     "/apis/gtest/vtest/rtest/normal_update",
 			obj:      getObject("gtest/vTest", "rTest", "normal_update"),
 		},
 		{
 			resource:  "rtest",
 			name:      "namespaced_update",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_update",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_update",
 			obj:       getObject("gtest/vTest", "rTest", "namespaced_update"),
 		},
 		{
 			resource:    "rtest",
 			subresource: []string{"srtest"},
 			name:        "normal_subresource_update",
-			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_update/srtest",
+			path:        "/apis/gtest/vtest/rtest/normal_update/srtest",
 			obj:         getObject("gtest/vTest", "srTest", "normal_update"),
 		},
 		{
@@ -452,7 +452,7 @@ func TestUpdate(t *testing.T) {
 			subresource: []string{"srtest"},
 			name:        "namespaced_subresource_update",
 			namespace:   "nstest",
-			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_update/srtest",
+			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_update/srtest",
 			obj:         getObject("gtest/vTest", "srTest", "namespaced_update"),
 		},
 	}
@@ -505,7 +505,7 @@ func TestWatch(t *testing.T) {
 	}{
 		{
 			name:  "normal_watch",
-			path:  "/apis/gtest/vtest/tenants/system/rtest",
+			path:  "/apis/gtest/vtest/rtest",
 			query: "watch=true",
 			events: []watch.Event{
 				{Type: watch.Added, Object: getObject("gtest/vTest", "rTest", "normal_watch")},
@@ -516,7 +516,7 @@ func TestWatch(t *testing.T) {
 		{
 			name:      "namespaced_watch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest",
 			query:     "watch=true",
 			events: []watch.Event{
 				{Type: watch.Added, Object: getObject("gtest/vTest", "rTest", "namespaced_watch")},
@@ -578,7 +578,7 @@ func TestPatch(t *testing.T) {
 		{
 			resource: "rtest",
 			name:     "normal_patch",
-			path:     "/apis/gtest/vtest/tenants/system/rtest/normal_patch",
+			path:     "/apis/gtest/vtest/rtest/normal_patch",
 			patch:    getJSON("gtest/vTest", "rTest", "normal_patch"),
 			want:     getObject("gtest/vTest", "rTest", "normal_patch"),
 		},
@@ -586,7 +586,7 @@ func TestPatch(t *testing.T) {
 			resource:  "rtest",
 			name:      "namespaced_patch",
 			namespace: "nstest",
-			path:      "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_patch",
+			path:      "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_patch",
 			patch:     getJSON("gtest/vTest", "rTest", "namespaced_patch"),
 			want:      getObject("gtest/vTest", "rTest", "namespaced_patch"),
 		},
@@ -594,7 +594,7 @@ func TestPatch(t *testing.T) {
 			resource:    "rtest",
 			subresource: []string{"srtest"},
 			name:        "normal_subresource_patch",
-			path:        "/apis/gtest/vtest/tenants/system/rtest/normal_subresource_patch/srtest",
+			path:        "/apis/gtest/vtest/rtest/normal_subresource_patch/srtest",
 			patch:       getJSON("gtest/vTest", "srTest", "normal_subresource_patch"),
 			want:        getObject("gtest/vTest", "srTest", "normal_subresource_patch"),
 		},
@@ -603,7 +603,7 @@ func TestPatch(t *testing.T) {
 			subresource: []string{"srtest"},
 			name:        "namespaced_subresource_patch",
 			namespace:   "nstest",
-			path:        "/apis/gtest/vtest/tenants/system/namespaces/nstest/rtest/namespaced_subresource_patch/srtest",
+			path:        "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_subresource_patch/srtest",
 			patch:       getJSON("gtest/vTest", "srTest", "namespaced_subresource_patch"),
 			want:        getObject("gtest/vTest", "srTest", "namespaced_subresource_patch"),
 		},

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -111,7 +111,8 @@ func (c *dynamicClient) Resource(resource schema.GroupVersionResource) Namespace
 }
 
 func (c *dynamicResourceClient) Namespace(ns string) ResourceInterface {
-	return c.NamespaceWithMultiTenancy(ns, metav1.TenantSystem)
+	// In arktos, short-path resolution will set the tenant per user credential, so we leave it as empty
+	return c.NamespaceWithMultiTenancy(ns, metav1.TenantNone)
 }
 
 func (c *dynamicResourceClient) NamespaceWithMultiTenancy(ns string, tenant string) ResourceInterface {


### PR DESCRIPTION
Enable prometheus e2e-tests after perf-tests are integrated into arktos.

Verification:
run arktos/perf-tests/clusterloader/run-e2e.sh with env var ENABLE_PROMETHEUS_SERVER=true in gce machine and confirmed:
1. the script finished successfully
2. The prometheus perf results are reported.
3. The test results are approximately same as the tests done with the perf-tests before migration.