### PR TITLE
make run-e2e.sh run without softlink

### DIFF
--- a/perf-tests/clusterloader2/run-e2e.sh
+++ b/perf-tests/clusterloader2/run-e2e.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export GO111MODULE=on
 CLUSTERLOADER_ROOT=$(dirname "${BASH_SOURCE}")
 export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
 export KUBEMARK_ROOT_KUBECONFIG="${KUBEMARK_ROOT_KUBECONFIG:-${HOME}/.kube/config}"


### PR DESCRIPTION
**Issue** : perf-tests/clusterloader2/run-e2e.sh is the entry script to run perf-tests in kubernetes. However, our project is named "arktos" yet the code has many dependencies in "k8s.io/kubernetes", running this script in arktos leads to build failures.  Perf test team found a workaround, which creates a kubernetes soft link in parallel to the "arktos" folder and run the script from "kubernetes" folder. This workaround is surely not a clean solution. 


This PR fixes this issue. 

