### PR TITLE
Rewrite multi-tenancy e2e test tool in golang

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -99,6 +99,7 @@ filegroup(
         ":package-srcs",
         "//test/e2e/apimachinery:all-srcs",
         "//test/e2e/apps:all-srcs",
+        "//test/e2e/arktos/multi_tenancy/cmd:all-srcs",
         "//test/e2e/auth:all-srcs",
         "//test/e2e/autoscaling:all-srcs",
         "//test/e2e/chaosmonkey:all-srcs",

--- a/test/e2e/arktos/multi_tenancy/cmd/BUILD
+++ b/test/e2e/arktos/multi_tenancy/cmd/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["testrunner.go"],
+    importpath = "k8s.io/kubernetes/test/e2e/arktos/multi_tenancy/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//test/e2e/arktos/multi_tenancy/cmd/framework:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//test/e2e/arktos/multi_tenancy/cmd/framework:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/BUILD
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "errors.go",
         "testcase.go",
         "testconfig.go",
         "testsuite.go",

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/BUILD
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/BUILD
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "testcase.go",
+        "testconfig.go",
+        "testsuite.go",
+        "util.go",
+    ],
+    importpath = "k8s.io/kubernetes/test/e2e/arktos/multi_tenancy/cmd/framework",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/errors.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/errors.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+type ErrorList struct {
+	errors []error
+}
+
+func NewErrorList(errors ...error) *ErrorList {
+	return &ErrorList{errors: errors}
+}
+
+func (el *ErrorList) IsEmpty() bool {
+	return len(el.errors) == 0
+}
+
+func (el *ErrorList) Add(err error) {
+	if err != nil {
+		el.errors = append(el.errors, err)
+	}
+}
+
+func (el *ErrorList) Concat(errList *ErrorList) {
+	if errList != nil {
+		el.errors = append(el.errors, errList.errors...)
+	}
+}
+
+func (el *ErrorList) String() string {
+	var b bytes.Buffer
+	b.WriteString("[")
+
+	for i := 0; i < len(el.errors); i++ {
+		b.WriteString(el.errors[i].Error())
+		if i != len(el.errors)-1 {
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("]")
+
+	return b.String()
+}
+
+func ErrorIfNegative(name string, valuePtr *int) error {
+	if valuePtr != nil && *valuePtr < 0 {
+		return fmt.Errorf("Invalid %s: %v, cannot be negative", name, *valuePtr)
+	}
+
+	return nil
+}
+
+func ErrorIfEmpty(name string, str string) error {
+	if strings.TrimSpace(str) == "" {
+		return fmt.Errorf("Invalid %s, cannot be empty", name)
+	}
+
+	return nil
+}
+
+func ErrorIfOutOfBounds(name string, valuePtr *int, min int, max int) error {
+	if valuePtr != nil && (*valuePtr < min || *valuePtr > max) {
+		return fmt.Errorf("Invalid %s: %v, should be with [%d, %d]", name, *valuePtr, min, max)
+	}
+
+	return nil
+}

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testcase.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testcase.go
@@ -26,7 +26,7 @@ type TestCase struct {
 	Command string `yaml:"Command,omitempty"`
 	TimeOut *int   `yaml:"TimeOut,omitempty"`
 
-	RunBefore string `yaml:"RunBefore,omitempty"`
+	BeforeTest string `yaml:"BeforeTest,omitempty"`
 
 	RetryCount    *int `yaml:"RetryCount,omitempty"`
 	RetryInterval *int `yaml:"RetryInterval,omitempty"`
@@ -40,117 +40,105 @@ type TestCase struct {
 	OutputShouldNotContain []string `yaml:"OutputShouldNotContain,omitempty"`
 }
 
-func (t *TestCase) Validate(tc *TestConfig) []error {
-	errList := []error{}
+func (t *TestCase) Validate(tc *TestConfig) *ErrorList {
+	errList := NewErrorList()
 
-	if t.Command == "" {
-		errList = append(errList, fmt.Errorf("Test command is empty!"))
-	}
-
-	if t.RetryCount != nil && (*(t.RetryCount) < 0 || *(t.RetryCount) > tc.MaxRetryCount) {
-		errList = append(errList, fmt.Errorf("Invalid RetryCount: %v, should be in the range of [0, %d]", *(t.RetryCount), tc.MaxRetryCount))
-	}
-
-	if t.RetryInterval != nil && (*(t.RetryInterval) < 0 || *(t.RetryInterval) > tc.MaxRetryInterval) {
-		errList = append(errList, fmt.Errorf("Invalid RetryInterval: %v, should be in the range of [0, %d]", *(t.RetryInterval), tc.MaxRetryInterval))
-	}
-
-	if t.TimeOut != nil && (*(t.TimeOut) < 0 || *(t.TimeOut) > tc.MaxTimeOut) {
-		errList = append(errList, fmt.Errorf("Invalid TimeOut: %v, tc.MaxRetryInterval", *(t.TimeOut), tc.MaxTimeOut))
-	}
+	errList.Add(ErrorIfEmpty("Command", t.Command))
+	errList.Add(ErrorIfOutOfBounds("RetryCount", t.RetryCount, 0, tc.MaxRetryCount))
+	errList.Add(ErrorIfOutOfBounds("RetryInterval", t.RetryInterval, 0, tc.MaxRetryInterval))
+	errList.Add(ErrorIfOutOfBounds("TimeOut", t.TimeOut, 0, tc.MaxTimeOut))
 
 	return errList
 }
 
+// Complete() set the settings to the default values, if not specified in the test case definition
 func (t *TestCase) Complete(tc *TestConfig) {
-	if t.RetryCount == nil {
-		t.RetryCount = &tc.DefaultRetryCount
-	}
-
-	if t.RetryInterval == nil {
-		t.RetryInterval = &tc.DefaultRetryInterval
-	}
-
-	if t.TimeOut == nil {
-		t.TimeOut = &tc.DefaultTimeOut
-	}
+	SetDefaultIfNil(&t.RetryCount, &tc.DefaultRetryCount)
+	SetDefaultIfNil(&t.RetryInterval, &tc.DefaultRetryInterval)
+	SetDefaultIfNil(&t.TimeOut, &tc.DefaultTimeOut)
 }
 
-func (t *TestCase) Run(tc *TestConfig) []error {
-	errList := []error{}
-	var testErrList []error
+func (t *TestCase) Run(tc *TestConfig) *ErrorList {
+	var errList *ErrorList
 	var exitCode int
 	var output string
 	var err error
 
 	t.Complete(tc)
 
-	if t.RunBefore != "" {
-		LogWarning("Run pre-test configuration command %q", t.RunBefore)
-		exitCode, output, err = ExecCommandLine(t.RunBefore, 0)
-		if exitCode != 0 {
-			// it is by design that pre-test configuration command is allowed to fail
-			LogWarning("Pre-test command %q returns with error: %v, exit code: %v, command output: %q. Moving on ...", t.RunBefore, exitCode, output)
-		}
-	}
-
 	retries := *t.RetryCount
 	LogNormal("Testing %q...", t.Command)
-	for {
+
+	if t.BeforeTest != "" {
+		LogWarning("\nRun pre-test configuration command %q", t.BeforeTest)
+		exitCode, output, err = ExecCommandLine(t.BeforeTest, 0)
+
+		if exitCode != 0 || err != nil {
+			beforeTestErr := fmt.Sprintf("\nPre-test command %q returns with error: %v, exitcode: %v", t.BeforeTest, err, exitCode)
+			LogError(beforeTestErr)
+			LogNormal("\noutput:\n%v", output)
+			return NewErrorList(fmt.Errorf(beforeTestErr))
+		}
+
+		LogSuccess(" Done\n")
+	}
+
+	retryFunc := func(errs *ErrorList) {
+		if retries > 0 {
+			LogWarning("\nError: %v, retrying after %v seconds ...", errs, *t.RetryInterval)
+			time.Sleep(time.Duration(*t.RetryInterval) * time.Second)
+		}
+		retries--
+	}
+
+	for retries >= 0 {
 		exitCode, output, err = ExecCommandLine(t.Command, *t.TimeOut)
 		if tc.Verbose {
 			LogNormal("\nexit code: %v, output:\n%v", exitCode, output)
 		}
 
-		if err == nil {
-			testErrList = t.CheckTestResult(exitCode, output)
-			if len(testErrList) == 0 {
-				LogSuccess(" PASSED\n")
-				break
-			}
+		if err != nil {
+			errList = NewErrorList(err)
+			retryFunc(errList)
+			continue
 		}
 
-		if retries <= 0 {
-			if err != nil {
-				errList = append(errList, err)
-				LogError("\nFAILED: %v\n", err)
-			} else {
-				errList = append(errList, testErrList...)
-				LogError("\nFAILED: %v \n", testErrList)
-				if !tc.Verbose {
-					LogNormal("exit code: %v, output:\n%v", exitCode, output)
-				}
-			}
-			break
+		errList = t.CheckTestResult(exitCode, output)
+		if !errList.IsEmpty() {
+			retryFunc(errList)
+			continue
 		}
 
-		LogWarning("\nFailed, retrying after %v seconds ...", *t.RetryInterval)
+		LogSuccess(" PASSED\n")
+		return errList
+	}
 
-		retries--
-		time.Sleep(time.Duration(*t.RetryInterval) * time.Second)
+	LogError("\nFAILED: %v \n", errList.String())
+	if !tc.Verbose {
+		LogNormal("exit code: %v, output:\n%v", exitCode, output)
 	}
 
 	return errList
 }
 
-func (t *TestCase) CheckTestResult(exitCode int, output string) []error {
-	errList := []error{}
+func (t *TestCase) CheckTestResult(exitCode int, output string) *ErrorList {
+	errList := NewErrorList()
 	if t.ShouldFail && exitCode == 0 {
-		errList = append(errList, fmt.Errorf("Command succeeded unexpectedly"))
+		errList.Add(fmt.Errorf("Succeeded unexpectedly"))
 	}
 
 	if !t.ShouldFail && exitCode != 0 {
-		errList = append(errList, fmt.Errorf("Command failed unexpectedly"))
+		errList.Add(fmt.Errorf("Command failed"))
 	}
 
 	if t.OutputShouldBe != "" && output != t.OutputShouldBe {
-		errList = append(errList, fmt.Errorf("unexpected output: %q, expected: %q", output, t.OutputShouldBe))
+		errList.Add(fmt.Errorf("unexpected output: %q, expected: %q", output, t.OutputShouldBe))
 	}
 
 	if len(t.OutputShouldContain) > 0 {
 		for _, expectedMatch := range t.OutputShouldContain {
 			if !strings.Contains(output, expectedMatch) {
-				errList = append(errList, fmt.Errorf("Did not find the match in output : %q", expectedMatch))
+				errList.Add(fmt.Errorf("Did not find the match in output : %q", expectedMatch))
 			}
 		}
 	}
@@ -158,7 +146,7 @@ func (t *TestCase) CheckTestResult(exitCode int, output string) []error {
 	if len(t.OutputShouldNotContain) > 0 {
 		for _, expectedNotMatch := range t.OutputShouldNotContain {
 			if strings.Contains(output, expectedNotMatch) {
-				errList = append(errList, fmt.Errorf("Find unexpected match in output : %q", expectedNotMatch))
+				errList.Add(fmt.Errorf("Find unexpected match in output : %q", expectedNotMatch))
 			}
 		}
 	}

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testcase.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testcase.go
@@ -84,7 +84,7 @@ func (t *TestCase) Run(tc *TestConfig) []error {
 	var err error
 
 	t.Complete(tc)
-	
+
 	if t.RunBefore != "" {
 		LogWarning("Run pre-test configuration command %q", t.RunBefore)
 		exitCode, output, err = ExecCommandLine(t.RunBefore, 0)

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testcase.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testcase.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	Command string `yaml:"Command,omitempty"`
+	TimeOut *int   `yaml:"TimeOut,omitempty"`
+
+	RunBefore string `yaml:"RunBefore,omitempty"`
+
+	RetryCount    *int `yaml:"RetryCount,omitempty"`
+	RetryInterval *int `yaml:"RetryInterval,omitempty"`
+
+	TerminateAfter *int `yaml:"TerminateAfter,omitempty"`
+
+	ShouldFail          bool     `yaml:"ShouldFail,omitempty"`
+	OutputShouldBe      string   `yaml:"OutputShouldBe,omitempty"`
+	OutputShouldContain []string `yaml:"OutputShouldContain,omitempty"`
+
+	OutputShouldNotContain []string `yaml:"OutputShouldNotContain,omitempty"`
+}
+
+func (t *TestCase) Validate(tc *TestConfig) []error {
+	errList := []error{}
+
+	if t.Command == "" {
+		errList = append(errList, fmt.Errorf("Test command is empty!"))
+	}
+
+	if t.RetryCount != nil && (*(t.RetryCount) < 0 || *(t.RetryCount) > tc.MaxRetryCount) {
+		errList = append(errList, fmt.Errorf("Invalid RetryCount: %v, should be in the range of [0, %d]", *(t.RetryCount), tc.MaxRetryCount))
+	}
+
+	if t.RetryInterval != nil && (*(t.RetryInterval) < 0 || *(t.RetryInterval) > tc.MaxRetryInterval) {
+		errList = append(errList, fmt.Errorf("Invalid RetryInterval: %v, should be in the range of [0, %d]", *(t.RetryInterval), tc.MaxRetryInterval))
+	}
+
+	if t.TimeOut != nil && (*(t.TimeOut) < 0 || *(t.TimeOut) > tc.MaxTimeOut) {
+		errList = append(errList, fmt.Errorf("Invalid TimeOut: %v, tc.MaxRetryInterval", *(t.TimeOut), tc.MaxTimeOut))
+	}
+
+	return errList
+}
+
+func (t *TestCase) Complete(tc *TestConfig) {
+	if t.RetryCount == nil {
+		t.RetryCount = &tc.DefaultRetryCount
+	}
+
+	if t.RetryInterval == nil {
+		t.RetryInterval = &tc.DefaultRetryInterval
+	}
+
+	if t.TimeOut == nil {
+		t.TimeOut = &tc.DefaultTimeOut
+	}
+}
+
+func (t *TestCase) Run(tc *TestConfig) []error {
+	errList := []error{}
+	var testErrList []error
+	var exitCode int
+	var output string
+	var err error
+
+	t.Complete(tc)
+	
+	if t.RunBefore != "" {
+		LogWarning("Run pre-test configuration command %q", t.RunBefore)
+		exitCode, output, err = ExecCommandLine(t.RunBefore, 0)
+		if exitCode != 0 {
+			// it is by design that pre-test configuration command is allowed to fail
+			LogWarning("Pre-test command %q returns with error: %v, exit code: %v, command output: %q. Moving on ...", t.RunBefore, exitCode, output)
+		}
+	}
+
+	retries := *t.RetryCount
+	LogNormal("Testing %q...", t.Command)
+	for {
+		exitCode, output, err = ExecCommandLine(t.Command, *t.TimeOut)
+		if tc.Verbose {
+			LogNormal("\nexit code: %v, output:\n%v", exitCode, output)
+		}
+
+		if err == nil {
+			testErrList = t.CheckTestResult(exitCode, output)
+			if len(testErrList) == 0 {
+				LogSuccess(" PASSED\n")
+				break
+			}
+		}
+
+		if retries <= 0 {
+			if err != nil {
+				errList = append(errList, err)
+				LogError("\nFAILED: %v\n", err)
+			} else {
+				errList = append(errList, testErrList...)
+				LogError("\nFAILED: %v \n", testErrList)
+				if !tc.Verbose {
+					LogNormal("exit code: %v, output:\n%v", exitCode, output)
+				}
+			}
+			break
+		}
+
+		LogWarning("\nFailed, retrying after %v seconds ...", *t.RetryInterval)
+
+		retries--
+		time.Sleep(time.Duration(*t.RetryInterval) * time.Second)
+	}
+
+	return errList
+}
+
+func (t *TestCase) CheckTestResult(exitCode int, output string) []error {
+	errList := []error{}
+	if t.ShouldFail && exitCode == 0 {
+		errList = append(errList, fmt.Errorf("Command succeeded unexpectedly"))
+	}
+
+	if !t.ShouldFail && exitCode != 0 {
+		errList = append(errList, fmt.Errorf("Command failed unexpectedly"))
+	}
+
+	if t.OutputShouldBe != "" && output != t.OutputShouldBe {
+		errList = append(errList, fmt.Errorf("unexpected output: %q, expected: %q", output, t.OutputShouldBe))
+	}
+
+	if len(t.OutputShouldContain) > 0 {
+		for _, expectedMatch := range t.OutputShouldContain {
+			if !strings.Contains(output, expectedMatch) {
+				errList = append(errList, fmt.Errorf("Did not find the match in output : %q", expectedMatch))
+			}
+		}
+	}
+
+	if len(t.OutputShouldNotContain) > 0 {
+		for _, expectedNotMatch := range t.OutputShouldNotContain {
+			if strings.Contains(output, expectedNotMatch) {
+				errList = append(errList, fmt.Errorf("Find unexpected match in output : %q", expectedNotMatch))
+			}
+		}
+	}
+
+	return errList
+}

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testconfig.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testconfig.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package framework
 
-import (
-	"fmt"
-)
-
 type TestConfig struct {
 	MaxRetryCount        int
 	MaxRetryInterval     int
@@ -31,32 +27,16 @@ type TestConfig struct {
 	CommonVariables      map[string]string
 }
 
-func (tc *TestConfig) Validate() []error {
-	errors := []error{}
+func (tc *TestConfig) Validate() *ErrorList {
+	errors := NewErrorList()
 
-	if tc.MaxRetryCount < 0 {
-		errors = append(errors, fmt.Errorf("MaxRetryCount cannot be negative"))
-	}
+	errors.Add(ErrorIfNegative("MaxRetryCount", &tc.MaxRetryCount))
+	errors.Add(ErrorIfNegative("MaxRetryInterval", &tc.MaxRetryInterval))
+	errors.Add(ErrorIfNegative("MaxTimeOut", &tc.MaxTimeOut))
 
-	if tc.MaxRetryInterval < 0 {
-		errors = append(errors, fmt.Errorf("MaxRetryInterval cannot be negative"))
-	}
-
-	if tc.MaxTimeOut < 0 {
-		errors = append(errors, fmt.Errorf("MaxTimeOut cannot be negative"))
-	}
-
-	if tc.DefaultRetryCount < 0 || tc.DefaultRetryCount > tc.MaxRetryCount {
-		errors = append(errors, fmt.Errorf("Invalid DefaultRetryCount %d, should be in the range of [0, %d]", tc.DefaultRetryCount, tc.MaxRetryCount))
-	}
-
-	if tc.DefaultRetryInterval < 0 || tc.DefaultRetryInterval > tc.MaxRetryInterval {
-		errors = append(errors, fmt.Errorf("Invalid DefaultRetryInterval %d, should be in the range of [0, %d]", tc.DefaultRetryInterval, tc.MaxRetryInterval))
-	}
-
-	if tc.DefaultTimeOut < 0 || tc.DefaultTimeOut > tc.MaxTimeOut {
-		errors = append(errors, fmt.Errorf("Invalid DefaultTimeOut %d, should be in the range of [0, %d]", tc.DefaultTimeOut, tc.MaxTimeOut))
-	}
+	errors.Add(ErrorIfOutOfBounds("DefaultRetryCount", &tc.DefaultRetryCount, 0, tc.MaxRetryCount))
+	errors.Add(ErrorIfOutOfBounds("DefaultRetryInterval", &tc.DefaultRetryInterval, 0, tc.MaxRetryInterval))
+	errors.Add(ErrorIfOutOfBounds("DefaultTimeOut", &tc.DefaultTimeOut, 0, tc.MaxTimeOut))
 
 	return errors
 }

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testconfig.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testconfig.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+)
+
+type TestConfig struct {
+	MaxRetryCount        int
+	MaxRetryInterval     int
+	MaxTimeOut           int
+	DefaultRetryCount    int
+	DefaultRetryInterval int
+	DefaultTimeOut       int
+	Verbose              bool
+	CommonVariables      map[string]string
+}
+
+func (tc *TestConfig) Validate() []error {
+	errors := []error{}
+
+	if tc.MaxRetryCount < 0 {
+		errors = append(errors, fmt.Errorf("MaxRetryCount cannot be negative"))
+	}
+
+	if tc.MaxRetryInterval < 0 {
+		errors = append(errors, fmt.Errorf("MaxRetryInterval cannot be negative"))
+	}
+
+	if tc.MaxTimeOut < 0 {
+		errors = append(errors, fmt.Errorf("MaxTimeOut cannot be negative"))
+	}
+
+	if tc.DefaultRetryCount < 0 || tc.DefaultRetryCount > tc.MaxRetryCount {
+		errors = append(errors, fmt.Errorf("Invalid DefaultRetryCount %d, should be in the range of [0, %d]", tc.DefaultRetryCount, tc.MaxRetryCount))
+	}
+
+	if tc.DefaultRetryInterval < 0 || tc.DefaultRetryInterval > tc.MaxRetryInterval {
+		errors = append(errors, fmt.Errorf("Invalid DefaultRetryInterval %d, should be in the range of [0, %d]", tc.DefaultRetryInterval, tc.MaxRetryInterval))
+	}
+
+	if tc.DefaultTimeOut < 0 || tc.DefaultTimeOut > tc.MaxTimeOut {
+		errors = append(errors, fmt.Errorf("Invalid DefaultTimeOut %d, should be in the range of [0, %d]", tc.DefaultTimeOut, tc.MaxTimeOut))
+	}
+
+	return errors
+}

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testsuite.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testsuite.go
@@ -51,7 +51,7 @@ func (ts *TestSuite) LoadTestSuite(filePath string, tc *TestConfig) error {
 		}
 	}
 
-	allVariables := CombineStringMaps(tc.CommonVariables, ts.Variables)
+	allVariables := MergeStringMaps(tc.CommonVariables, ts.Variables)
 	resolved_output, _ := ioutil.ReadFile(filePath)
 	for key, value := range allVariables {
 		// generate random strings for variables if the value is "random_[string_length]"
@@ -71,7 +71,7 @@ func (ts *TestSuite) LoadTestSuite(filePath string, tc *TestConfig) error {
 	}
 
 	for _, t := range ts.Tests {
-		if errList := t.Validate(tc); len(errList) != 0 {
+		if errList := t.Validate(tc); !errList.IsEmpty() {
 			return fmt.Errorf("error in validating yaml file %v, test case: %v, err: %v ", filePath, t, errList)
 		}
 	}
@@ -85,7 +85,7 @@ func (ts *TestSuite) Run(tc *TestConfig) {
 	for i, t := range ts.Tests {
 		fmt.Println("----------------------------------------------------------------------")
 		errList := t.Run(tc)
-		if len(errList) != 0 {
+		if !errList.IsEmpty() {
 			ts.Failures = append(ts.Failures, fmt.Sprintf("Test Command #%v: %q, Error %v", i+1, t.Command, errList))
 		}
 	}

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testsuite.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testsuite.go
@@ -52,7 +52,7 @@ func (ts *TestSuite) LoadTestSuite(filePath string, tc *TestConfig) error {
 	}
 
 	allVariables := CombineStringMaps(tc.CommonVariables, ts.Variables)
-	resolved_output, _ := ioutil.ReadFile(filePath)	
+	resolved_output, _ := ioutil.ReadFile(filePath)
 	for key, value := range allVariables {
 		// generate random strings for variables if the value is "random_[string_length]"
 		if random_generate, _ := regexp.MatchString("random_[0-9]+", value); random_generate {

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testsuite.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testsuite.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strconv"
+
+	"gopkg.in/yaml.v2"
+)
+
+type TestSuite struct {
+	FilePath  string
+	Variables map[string]string `yaml:"Variables,omitempty"`
+	Tests     []TestCase        `yaml:"Tests,omitempty"`
+	Failures  []string
+}
+
+func (ts *TestSuite) LoadTestSuite(filePath string, tc *TestConfig) error {
+	ts.FilePath = filePath
+	testSuiteFile, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("error in reading file %v, err: %v ", filePath, err)
+	}
+
+	err = yaml.Unmarshal(testSuiteFile, ts)
+	if err != nil {
+		// ignore the yaml.TypeError in the first round of unmarshing as it is most likely due to that
+		// the variable resolution is not done
+		// If there is a real Type error, the second round of unmarshalling, which is done after the
+		// resolution, will catch it
+		if _, type_error := err.(*yaml.TypeError); !type_error {
+			return fmt.Errorf("error in unmarshling original yaml file %v, \n\nerr: %#v ", filePath, err)
+		}
+	}
+
+	allVariables := CombineStringMaps(tc.CommonVariables, ts.Variables)
+	resolved_output, _ := ioutil.ReadFile(filePath)	
+	for key, value := range allVariables {
+		// generate random strings for variables if the value is "random_[string_length]"
+		if random_generate, _ := regexp.MatchString("random_[0-9]+", value); random_generate {
+			length_str := value[len("random_"):]
+			length, err := strconv.Atoi(length_str)
+			if err != nil {
+				return fmt.Errorf("Error in parsing Variable, key: %v, value: %v, err: %v", key, value, err)
+			}
+			value = RandomString(length)
+		}
+		resolved_output = bytes.ReplaceAll(resolved_output, []byte("${"+key+"}"), []byte(value))
+	}
+
+	if err = yaml.Unmarshal(resolved_output, ts); err != nil {
+		return fmt.Errorf("error in unmarshling resolved yaml file %v, err: %v ", filePath, err)
+	}
+
+	for _, t := range ts.Tests {
+		if errList := t.Validate(tc); len(errList) != 0 {
+			return fmt.Errorf("error in validating yaml file %v, test case: %v, err: %v ", filePath, t, errList)
+		}
+	}
+
+	return nil
+}
+
+func (ts *TestSuite) Run(tc *TestConfig) {
+	LogInfo("\nStart Running Test Suite %q\n", ts.FilePath)
+
+	for i, t := range ts.Tests {
+		fmt.Println("----------------------------------------------------------------------")
+		errList := t.Run(tc)
+		if len(errList) != 0 {
+			ts.Failures = append(ts.Failures, fmt.Sprintf("Test Command #%v: %q, Error %v", i+1, t.Command, errList))
+		}
+	}
+
+	fmt.Println("")
+}

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/util.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/util.go
@@ -115,15 +115,22 @@ func FileExists(filename string) bool {
 	return !info.IsDir()
 }
 
-// Combine maps, where the later map overrides the previous if there are conflicts
-func CombineStringMaps(maps ...map[string]string) map[string]string {
-	combined := make(map[string]string)
+// Merge maps, where the later map overrides the previous if there are conflicts
+func MergeStringMaps(maps ...map[string]string) map[string]string {
+	merged := make(map[string]string)
 
 	for _, m := range maps {
 		for k, v := range m {
-			combined[k] = v
+			merged[k] = v
 		}
 	}
 
-	return combined
+	return merged
+}
+
+func SetDefaultIfNil(ptr **int, defaultPtr *int) {
+	if *ptr == nil {
+		defaultValue := *defaultPtr
+		*ptr = &defaultValue
+	}
 }

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/util.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/util.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/klog"
+)
+
+const ShellToUse = "bash"
+
+type FontColor string
+
+const (
+	ResetColor  = FontColor("\033[0m")
+	RedColor    = FontColor("\033[31m")
+	GreenColor  = FontColor("\033[32m")
+	YellowColor = FontColor("\033[33m")
+	BlueColor   = FontColor("\033[34m")
+	PurpleColor = FontColor("\033[35m")
+	CyanColor   = FontColor("\033[36m")
+	GrayColor   = FontColor("\033[37m")
+	WhiteColor  = FontColor("\033[97m")
+)
+
+func ApplyColor(s string, color FontColor) string {
+	return string(color) + s + string(ResetColor)
+}
+
+func RandomString(length int) string {
+	// If we see a crazy length, set it the default length of 8
+	if length <= 0 || length > 128 {
+		length = 8
+	}
+
+	result := fmt.Sprintf("%v", uuid.NewUUID())[0:length]
+
+	return result
+}
+
+func ExecCommandLine(commandline string, timeout int) (int, string, error) {
+	var cmd *exec.Cmd
+	if timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		defer cancel()
+
+		cmd = exec.CommandContext(ctx, ShellToUse, "-c", commandline)
+	} else {
+		cmd = exec.Command(ShellToUse, "-c", commandline)
+	}
+
+	exitCode := 0
+	var output []byte
+	var err error
+
+	if output, err = cmd.CombinedOutput(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		}
+	}
+
+	return exitCode, string(output), nil
+}
+
+func LogError(format string, a ...interface{}) {
+	klog.Infof(format, a...)
+	fmt.Printf(ApplyColor(format, RedColor), a...)
+}
+
+func LogWarning(format string, a ...interface{}) {
+	klog.Warningf(format, a...)
+	fmt.Printf(ApplyColor(format, YellowColor), a...)
+}
+
+func LogInfo(format string, a ...interface{}) {
+	klog.Infof(format, a...)
+	fmt.Printf(ApplyColor(format, CyanColor), a...)
+}
+
+func LogSuccess(format string, a ...interface{}) {
+	klog.Infof(format, a...)
+	fmt.Printf(ApplyColor(format, GreenColor), a...)
+}
+
+func LogNormal(format string, a ...interface{}) {
+	klog.Infof(format, a...)
+	fmt.Printf(format, a...)
+}
+
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// Combine maps, where the later map overrides the previous if there are conflicts
+func CombineStringMaps(maps ...map[string]string) map[string]string {
+	combined := make(map[string]string)
+
+	for _, m := range maps {
+		for k, v := range m {
+			combined[k] = v
+		}
+	}
+
+	return combined
+}

--- a/test/e2e/arktos/multi_tenancy/cmd/testrunner.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/testrunner.go
@@ -61,8 +61,8 @@ func initFlags() {
 }
 
 func validateFlags() {
-	if errs := testConfig.Validate(); len(errs) > 0 {
-		framework.LogError("\nThe test config is invalid: &v \n", errs)
+	if errs := testConfig.Validate(); !errs.IsEmpty() {
+		framework.LogError("\nThe test config is invalid: %v \n", errs)
 		os.Exit(1)
 	}
 
@@ -106,8 +106,8 @@ func verifyLocalClusterUp() {
 	test.Command = "kubectl get nodes"
 
 	errList := test.Run(&testConfig)
-	if len(errList) != 0 {
-		framework.LogError("\nArktos cluster is not up for test. Or you have don't have cluster admin privilege.\n")
+	if !errList.IsEmpty() {
+		framework.LogError("\nArktos cluster is not up for test. Or you don't have cluster admin privilege.\n")
 		os.Exit(1)
 	}
 }
@@ -143,13 +143,14 @@ func printSummary() {
 		if len(ts.Failures) == 0 {
 			framework.LogSuccess("\nTest Suite %v succeeded.\n", ts.FilePath)
 			successNum++
-		} else {
-			framework.LogError("Test Suite %v has %d failures\n", ts.FilePath, len(ts.Failures))
-			for _, failure := range ts.Failures {
-				framework.LogWarning("\t" + failure + "\n")
-			}
-			failNum++
+			continue
 		}
+
+		framework.LogError("Test Suite %v has %d failures\n", ts.FilePath, len(ts.Failures))
+		for _, failure := range ts.Failures {
+			framework.LogWarning("\t" + failure + "\n")
+		}
+		failNum++
 	}
 	framework.LogInfo("\nTotal %v test suite files, %v invalid, %d succeeded, %d contain failures.\n", len(testSuiteFiles), len(invalidTestSuites), successNum, failNum)
 }

--- a/test/e2e/arktos/multi_tenancy/cmd/testrunner.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/testrunner.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"k8s.io/klog"
-	"k8s.io/kubernetes/test/e2e/arktos/multi_tenancy/cmd/framework"	
+	"k8s.io/kubernetes/test/e2e/arktos/multi_tenancy/cmd/framework"
 )
 
 var (

--- a/test/e2e/arktos/multi_tenancy/cmd/testrunner.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/testrunner.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this tsFile except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"k8s.io/klog"
+	"k8s.io/kubernetes/test/e2e/arktos/multi_tenancy/cmd/framework"	
+)
+
+var (
+	startTime          = time.Now()
+	testConfig         framework.TestConfig
+	testSuiteFiles     []string
+	invalidTestSuites  []string
+	validTestSuites    []*framework.TestSuite
+	testSuiteDirFlag   string
+	testSuiteFileFlag  string
+	commonVariableFlag string
+)
+
+func initFlags() {
+	basedir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	defaultTestSuiteDir := filepath.Join(basedir, "test_suites")
+
+	flag.IntVar(&testConfig.MaxRetryCount, "MaxRetryCount", 10, "maximal retry counts of a test command")
+	flag.IntVar(&testConfig.MaxRetryInterval, "MaxRetryInterval", 60, "maximal retry interval in seconds")
+	flag.IntVar(&testConfig.MaxTimeOut, "MaxTimeOut", 300, "maximal timeout in seconds allowed for a test command")
+	flag.IntVar(&testConfig.DefaultRetryCount, "DefaultRetryCount", 0, "default retry counts of a test command")
+	flag.IntVar(&testConfig.DefaultRetryInterval, "DefaultRetryInterval", 5, "default retry interval in seconds")
+	flag.IntVar(&testConfig.DefaultTimeOut, "DefaultTimeOut", 2, "default timeout in seconds allowed for a test command")
+	flag.BoolVar(&testConfig.Verbose, "Verbose", false, "Extra logging if true")
+
+	flag.StringVar(&testSuiteDirFlag, "TestSuiteDir", defaultTestSuiteDir, "The directory of test suite files")
+	flag.StringVar(&testSuiteFileFlag, "TestSuiteFiles", "", "The test suite files")
+	flag.StringVar(&commonVariableFlag, "CommonVar", "", "Common variable definition used across test suites.")
+
+	flag.Parse()
+
+	validateFlags()
+}
+
+func validateFlags() {
+	if errs := testConfig.Validate(); len(errs) > 0 {
+		framework.LogError("\nThe test config is invalid: &v \n", errs)
+		os.Exit(1)
+	}
+
+	if strings.TrimSpace(testSuiteFileFlag) == "" {
+		framework.LogError("\nNo test suite file is specified.  (%v) \n", testSuiteFileFlag)
+		os.Exit(1)
+	}
+
+	for _, file := range strings.Fields(testSuiteFileFlag) {
+		testSuiteFiles = append(testSuiteFiles, filepath.Join(testSuiteDirFlag, strings.TrimSpace(file)))
+	}
+
+	for _, tsf := range testSuiteFiles {
+		if framework.FileExists(tsf) == false {
+			framework.LogError("\nTest suite file %q is missig.\n", tsf)
+			os.Exit(1)
+		}
+	}
+
+	if len(commonVariableFlag) > 0 {
+		testConfig.CommonVariables = make(map[string]string)
+		for _, kv := range strings.Split(commonVariableFlag, ",") {
+			if len(strings.Split(kv, ":")) != 2 {
+				framework.LogError("\n(%q) is not a valid variable definition. Ignored\n", kv)
+				continue
+			}
+
+			parts := strings.Split(kv, ":")
+			if strings.TrimSpace(parts[0]) == "" {
+				framework.LogError("\n(%q) is not a valid variable definition. Ignored\n", kv)
+				continue
+			}
+
+			testConfig.CommonVariables[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+}
+
+func verifyLocalClusterUp() {
+	var test framework.TestCase
+	test.Command = "kubectl get nodes"
+
+	errList := test.Run(&testConfig)
+	if len(errList) != 0 {
+		framework.LogError("\nArktos cluster is not up for test. Or you have don't have cluster admin privilege.\n")
+		os.Exit(1)
+	}
+}
+
+func validateTestSuites() {
+	for _, tsFile := range testSuiteFiles {
+		var ts framework.TestSuite
+		framework.LogInfo("\nValidating Test Suite %q...", tsFile)
+		if err := ts.LoadTestSuite(tsFile, &testConfig); err != nil {
+			framework.LogError("\nWill skip Test Suite %q due to: %v\n", tsFile, err)
+		} else {
+			framework.LogSuccess("Validated")
+			validTestSuites = append(validTestSuites, &ts)
+		}
+	}
+
+	fmt.Println("")
+}
+
+func printSummary() {
+	framework.LogInfo("~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Test Run Summary ~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+	framework.LogInfo("\nStarted %v \nFinished %v\n\n", startTime.Format(time.RFC3339), time.Now().Format(time.RFC3339))
+
+	if len(invalidTestSuites) > 0 {
+		framework.LogError("%d test suite file(s) are invalid\n", len(invalidTestSuites))
+		for _, ts := range invalidTestSuites {
+			framework.LogNormal("\t%v\n", ts)
+		}
+	}
+
+	successNum, failNum := 0, 0
+	for _, ts := range validTestSuites {
+		if len(ts.Failures) == 0 {
+			framework.LogSuccess("\nTest Suite %v succeeded.\n", ts.FilePath)
+			successNum++
+		} else {
+			framework.LogError("Test Suite %v has %d failures\n", ts.FilePath, len(ts.Failures))
+			for _, failure := range ts.Failures {
+				framework.LogWarning("\t" + failure + "\n")
+			}
+			failNum++
+		}
+	}
+	framework.LogInfo("\nTotal %v test suite files, %v invalid, %d succeeded, %d contain failures.\n", len(testSuiteFiles), len(invalidTestSuites), successNum, failNum)
+}
+
+func main() {
+	defer klog.Flush()
+
+	initFlags()
+
+	verifyLocalClusterUp()
+
+	validateTestSuites()
+
+	for _, ts := range validTestSuites {
+		ts.Run(&testConfig)
+	}
+
+	printSummary()
+}

--- a/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
+++ b/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright 2020 Authors of Arktos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export GO111MODULE=on
+script_root=$(dirname "${BASH_SOURCE}")
+repo_root=$(cd $(dirname $0)/../../../.. ; pwd)
+
+#put the test suite file names below, one line one suite. The test suites will be run in the order defined.
+test_suite_files="tenant_init_delete_test.yaml"
+test_suite_file_directory=$(dirname $0)/test_suites/
+
+# The values of timeouts and retry intervals are in the unit of second
+# timeout=0 means that there is not check on whether a command exits within a give time span
+default_timeout=5
+max_timeout=300
+
+default_retry_count=0
+max_retry_count=30
+
+default_retry_interval=5
+max_retry_interval=60
+
+verbose=false
+
+# The following is the common variables which would work across all the test suites.
+# Remember to define here and update the command line flag of "-CommonVar" of "testrunner"
+# By default we use the kubectl binary built in the Arktos repository.
+kubectl=${repo_root}/_output/bin/kubectl
+setup_client_script=${repo_root}/hack/setup-multi-tenancy/setup_client.sh
+test_data_dir=$(dirname $0)/testdata/
+
+cd ${script_root}/ && go build -o /tmp/testrunner './cmd/'
+
+/tmp/testrunner -Verbose=${verbose} \
+				-TestSuiteDir=${test_suite_file_directory} \
+				-TestSuiteFiles="${test_suite_files}" \
+				-DefaultTimeOut=${default_timeout} \
+				-MaxTimeOut=${max_timeout} \
+				-DefaultRetryCount=${default_retry_count} \
+				-MaxRetryCount=${max_retry_count} \
+				-DefaultRetryInterval=${default_retry_interval} \
+				-MaxRetryInterval=${max_retry_interval} \
+				-CommonVar="kubectl:${kubectl},setup_client_script:${setup_client_script},test_data_dir:$test_data_dir}"

--- a/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
+++ b/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
@@ -24,7 +24,7 @@ repo_root=$(cd $(dirname $0)/../../../.. ; pwd)
 
 #put the test suite file names below, one line one suite. The test suites will be run in the order defined.
 test_suite_files="tenant_init_delete_test.yaml"
-test_suite_file_directory=$(dirname $0)/test_suites/
+test_suite_file_directory=${repo_root}/test/e2e/arktos/multi_tenancy/test_suites/
 
 # The values of timeouts and retry intervals are in the unit of second
 # timeout=0 means that there is not check on whether a command exits within a give time span
@@ -44,7 +44,7 @@ verbose=false
 # By default we use the kubectl binary built in the Arktos repository.
 kubectl=${repo_root}/_output/bin/kubectl
 setup_client_script=${repo_root}/hack/setup-multi-tenancy/setup_client.sh
-test_data_dir=$(dirname $0)/testdata/
+test_data_dir=${repo_root}/test/e2e/arktos/multi_tenancy/testdata/
 
 cd ${script_root}/ && go build -o /tmp/testrunner './cmd/'
 
@@ -57,4 +57,4 @@ cd ${script_root}/ && go build -o /tmp/testrunner './cmd/'
 				-MaxRetryCount=${max_retry_count} \
 				-DefaultRetryInterval=${default_retry_interval} \
 				-MaxRetryInterval=${max_retry_interval} \
-				-CommonVar="kubectl:${kubectl},setup_client_script:${setup_client_script},test_data_dir:$test_data_dir}"
+				-CommonVar="kubectl:${kubectl},setup_client_script:${setup_client_script},test_data_dir:${test_data_dir}"

--- a/test/e2e/arktos/multi_tenancy/test_suites/tenant_init_delete_test.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/tenant_init_delete_test.yaml
@@ -1,0 +1,83 @@
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tenant Initialization & Delete Tests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# This test suite verifies that 
+# 1. some resources are automatically created when a tenant is created, including
+# 2. tenant deleter deletes all the resources under the tenant
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################
+# Configure the test variables for this test suite
+######################################################
+Variables:
+  test_ns: random_5
+  test_tenant: random_8
+
+############################################################################################################
+# check the system tenant is created automatically and cannot be deleted
+############################################################################################################
+Tests:
+  - Command: ${kubectl} create tenant system
+    ShouldFail: true
+    OutputShouldContain: 
+    - "Error from server (AlreadyExists): tenants \"system\" already exists"
+    
+  - Command: ${kubectl} get tenants -o json | jq -r '.items[] | [.metadata.name, .status.phase] | @tsv'
+    OutputShouldContain: 
+    - "system\tActive"
+    OutputShouldNotContain: 
+    - ${test_tenant}
+
+  - Command: ${kubectl} delete tenant system
+    ShouldFail: true
+    OutputShouldBe: "Error from server (Forbidden): tenants \"system\" is forbidden: this tenant may not be deleted\n"
+
+###########################################################################################################
+# create the test tenant and configure the context (with test on kubectl config included)
+###########################################################################################################
+  - Command: ${kubectl} create tenant ${test_tenant}
+    OutputShouldContain: 
+    - tenant/${test_tenant} created
+
+  - Command: ${kubectl} get tenants -o json | jq -r '.items[] | [.metadata.name, .status.phase] | @tsv'
+    OutputShouldContain: 
+    - "system\tActive"
+    - "${test_tenant}\tActive"
+
+############################################################################################################
+# check the tenant controller creates the default resources
+############################################################################################################
+  - Command: ${kubectl} get namespaces --tenant ${test_tenant} -o json | jq -r '.items[] | [.metadata.tenant, .metadata.name, .status.phase] | @tsv'
+    OutputShouldContain: 
+    - "${test_tenant}\tdefault\tActive"
+    - "${test_tenant}\tkube-system\tActive"
+    - "${test_tenant}\tkube-public\tActive"
+
+###################################################################################################################
+# namespaces created by tenant controller cannot be deleted
+###################################################################################################################
+  - Command: ${kubectl} delete ns default --tenant ${test_tenant}
+    ShouldFail: true
+    OutputShouldBe: "Error from server (Forbidden): namespaces \"${test_tenant}/default\" is forbidden: this namespace may not be deleted\n"
+
+  - Command: ${kubectl} delete ns kube-system --tenant ${test_tenant}
+    ShouldFail: true
+    OutputShouldBe: "Error from server (Forbidden): namespaces \"${test_tenant}/kube-system\" is forbidden: this namespace may not be deleted\n"
+###################################################################################################################
+# creating a namespace under the tenant
+###################################################################################################################
+  - Command: ${kubectl} create ns ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "namespace/${test_ns} created\n"
+
+######################################################################################################
+# test tenant deleter
+######################################################################################################
+  - Command: ${kubectl} delete tenant ${test_tenant}
+    OutputShouldBe: "tenant \"${test_tenant}\" deleted\n"
+    TimeOut: 60
+
+  - Command: ${kubectl} get tenant ${test_tenant}
+    ShouldFail: true
+    OutputShouldBe: "Error from server (NotFound): tenants \"${test_tenant}\" not found\n"
+
+# all the default namespaces should be gone
+  - Command: ${kubectl} get namespaces --tenant ${test_tenant}
+    OutputShouldBe: "No resources found.\n"


### PR DESCRIPTION
This PR replaces the bash-script based tool with a new one, which is written in golang. This change bring the following benefits:
1. Allowing more complex test command
2. Allowing More incisive test result analysis
3. easier code maintenance & better extensibility

Also included in this PR is a sample test suite file, tenant_init_delete_test.yaml.

### Usage
Run test/e2e/arktos/multi_tenancy/run-e2e-test.sh

This script will build the binary and run the tool with configuration defined in the .sh script

### Verification
The features of this tool is comparable to the previous command-line based tool. Here are some screenshots:

1. The tool will complain if the test Arktos cluster is not ready for test

![image](https://user-images.githubusercontent.com/51831990/90919693-c69f8300-e39b-11ea-8a0c-913ede6f7e93.png)

2. The sample test suite succeeded

![image](https://user-images.githubusercontent.com/51831990/90919772-e767d880-e39b-11ea-89d3-b1080fa0419a.png)

3. break the sample test suite file to showcase the test failure

![image](https://user-images.githubusercontent.com/51831990/90919864-10886900-e39c-11ea-9afc-633aaeea5d38.png)
