### PR TITLE
e2e tests for deployment/replicaset/serviceacount/token/endpoints controllers

### DIFF
--- a/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
+++ b/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
@@ -23,7 +23,10 @@ script_root=$(dirname "${BASH_SOURCE}")
 repo_root=$(cd $(dirname $0)/../../../.. ; pwd)
 
 #put the test suite file names below, one line one suite. The test suites will be run in the order defined.
-test_suite_files="tenant_init_delete_test.yaml"
+test_suite_files="multi_tenancy_controller/test_sa_token_controller.yaml \
+				  multi_tenancy_controller/test_endpoints_controller.yaml \
+				  multi_tenancy_controller/test_deployment_replicaset_controller.yaml \
+				  tenant_init_delete_test.yaml"
 test_suite_file_directory=${repo_root}/test/e2e/arktos/multi_tenancy/test_suites/
 
 # The values of timeouts and retry intervals are in the unit of second

--- a/test/e2e/arktos/multi_tenancy/test_suites/multi_tenancy_controller/test_deployment_replicaset_controller.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/multi_tenancy_controller/test_deployment_replicaset_controller.yaml
@@ -1,0 +1,141 @@
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Deployment & ReplicaSet Controller Tests ~~~~~~~~~~~~~~~~~~~~~~
+# This test suite verifies the multi-tenancy deployment & replicaset controller. 
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################
+# test variables
+######################################################
+Variables:
+  test_ns: random_8
+  test_tenant: random_8
+
+###########################################################################################################
+# test setup
+###########################################################################################################
+Tests:
+  - Command: ${kubectl} create tenant ${test_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${test_tenant} created\n"
+
+  - Command: ${kubectl} create ns ${test_ns} --tenant ${test_tenant} 
+    OutputShouldBe: "namespace/${test_ns} created\n"
+
+########################################################################################
+# Testing deployment controller & replicaset controller
+########################################################################################
+
+# ------------------------------------------------------------
+# replicasets and pods are created when a deployment is created
+# ------------------------------------------------------------
+  - Command: ${kubectl} get deployments --all-namespaces --tenant ${test_tenant} 
+    OutputShouldBe: "No resources found.\n"
+
+  # creating the deployment
+  - Command: ${kubectl} apply -f ${test_data_dir}/sample-deployment.yaml --namespace ${test_ns} --tenant ${test_tenant} 
+    OutputShouldBe: "deployment.apps/sample-nginx-deployment created\n"
+
+  # wait a few secs and allow retry as the controller needs some time to make the deployment running
+  - BeforeTest: sleep 5
+    Command: "${kubectl} get deployment sample-nginx-deployment --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '[.metadata.name, .metadata.namespace, .metadata.tenant, .status.readyReplicas, .status.replicas] | @tsv'"
+    OutputShouldBe: "sample-nginx-deployment	${test_ns}	${test_tenant}	1	1\n"
+    RetryCount: 3
+    RetryInterval: 3
+
+  - Command: "${kubectl} get replicasets --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '.items[] | [.metadata.name[0:24], .metadata.namespace, .metadata.tenant, .status.readyReplicas, .status.replicas] | @tsv'"
+    OutputShouldContain: 
+    - "sample-nginx-deployment-"
+    - "	${test_ns}	${test_tenant}	1	1\n"
+
+  - Command: "${kubectl} get pods --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '.items[] | [.metadata.name[0:24], .metadata.namespace, .metadata.tenant, .status.phase] | @tsv'"
+    OutputShouldContain:
+    - "sample-nginx-deployment-"
+    - "	${test_ns}	${test_tenant}	Running\n"
+
+# ------------------------------------------------------------
+# pods will be recreated if deleted
+# ------------------------------------------------------------
+  - Command: ${kubectl} delete pods --all --namespace ${test_ns} --tenant ${test_tenant}
+    OutputShouldContain:
+    - "pod \"sample-nginx-deployment-"
+    - "deleted\n"
+    TimeOut: 30
+
+  # wait a few secs and allow retry as the controller needs some time to reconcile
+  - BeforeTest: sleep 5
+    Command: "${kubectl} get deployment sample-nginx-deployment --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '[.metadata.name, .metadata.namespace, .metadata.tenant, .status.readyReplicas, .status.replicas] | @tsv'"
+    OutputShouldBe: "sample-nginx-deployment	${test_ns}	${test_tenant}	1	1\n"
+    RetryCount: 3
+    RetryInterval: 3
+
+  - Command: "${kubectl} get replicasets --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '.items[] | [.metadata.name[0:24], .metadata.namespace, .metadata.tenant, .status.readyReplicas, .status.replicas] | @tsv'"
+    OutputShouldContain: 
+    - "sample-nginx-deployment-"
+    - "	${test_ns}	${test_tenant}	1	1\n"
+
+  - Command: "${kubectl} get pods --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '.items[] | [.metadata.name[0:24], .metadata.namespace, .metadata.tenant, .status.phase] | @tsv'"
+    OutputShouldContain:
+    - "sample-nginx-deployment-"
+    - "	${test_ns}	${test_tenant}	Running\n"
+
+# ------------------------------------------------------------
+# replicasets will be recreated if deleted
+# ------------------------------------------------------------
+  - Command: ${kubectl} delete replicasets --all --namespace ${test_ns} --tenant ${test_tenant}
+    OutputShouldContain:
+    - "replicaset.extensions \"sample-nginx-deployment-"
+    - deleted
+    TimeOut: 30
+
+  # wait a few secs and allow retry as the controller needs some time to reconcile
+  - BeforeTest: sleep 5
+    Command: "${kubectl} get deployment sample-nginx-deployment --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '[.metadata.name, .metadata.namespace, .metadata.tenant, .status.readyReplicas, .status.replicas] | @tsv'"
+    OutputShouldBe: "sample-nginx-deployment	${test_ns}	${test_tenant}	1	1\n"
+    RetryCount: 3
+    RetryInterval: 3
+
+  - Command: "${kubectl} get replicasets --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '.items[] | [.metadata.name[0:24], .metadata.namespace, .metadata.tenant, .status.readyReplicas, .status.replicas] | @tsv'"
+    OutputShouldContain: 
+    - "sample-nginx-deployment-"
+    - "	${test_ns}	${test_tenant}	1	1\n"
+
+  - Command: "${kubectl} get pods --namespace ${test_ns} --tenant ${test_tenant} -o json 
+            | jq -r '.items[] | [.metadata.name[0:24], .metadata.namespace, .metadata.tenant, .status.phase] | @tsv'"
+    OutputShouldContain:
+    - "sample-nginx-deployment-"
+    - "	${test_ns}	${test_tenant}	Running\n"
+
+# ------------------------------------------------------------
+# replicasets and pods are deleted when a deployment is deleted
+# ------------------------------------------------------------
+  - Command: ${kubectl} delete -f ${test_data_dir}/sample-deployment.yaml --namespace ${test_ns} --tenant ${test_tenant} 
+    OutputShouldBe: "deployment.apps \"sample-nginx-deployment\" deleted\n"
+
+  - BeforeTest: sleep 5
+    Command: ${kubectl} get deployments sample-nginx-deployment --namespace ${test_ns} --tenant ${test_tenant}
+    ShouldFail: true
+    OutputShouldBe: "Error from server (NotFound): deployments.extensions \"sample-nginx-deployment\" not found\n"
+    RetryCount: 3
+    RetryInterval: 3
+
+  - Command: ${kubectl} get replicasets --namespace ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "No resources found.\n"
+
+  - Command: ${kubectl} get pods --namespace ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "No resources found.\n" 
+    RetryCount: 3
+    RetryInterval: 3
+
+######################################################################################################
+# cleanup
+######################################################################################################
+  - Command: ${kubectl} delete tenant ${test_tenant}
+    OutputShouldBe: "tenant \"${test_tenant}\" deleted\n"
+    TimeOut: 60

--- a/test/e2e/arktos/multi_tenancy/test_suites/multi_tenancy_controller/test_endpoints_controller.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/multi_tenancy_controller/test_endpoints_controller.yaml
@@ -1,0 +1,62 @@
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Endpoints Controller Tests ~~~~~~~~~~~~~~~~~~~~~~
+# This test suite verifies the multi-tenancy endpoints controller. 
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################
+# test variables
+######################################################
+Variables:
+  test_ns: random_8
+  test_tenant: random_8
+
+###########################################################################################################
+# test setup
+###########################################################################################################
+Tests:
+  - Command: ${kubectl} create tenant ${test_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${test_tenant} created\n"
+
+  - Command: ${kubectl} create ns ${test_ns} --tenant ${test_tenant} 
+    OutputShouldBe: "namespace/${test_ns} created\n"
+
+########################################################################################
+# Testing endpoints controller
+########################################################################################
+# ------------------------------------------------------------
+# endpoints will be created when a service is exposed
+# ------------------------------------------------------------
+  - Command: ${kubectl} apply -f ${test_data_dir}/sample-deployment.yaml --namespace ${test_ns} --tenant ${test_tenant} 
+    OutputShouldBe: "deployment.apps/sample-nginx-deployment created\n"
+
+  - Command: ${kubectl} expose deployment sample-nginx-deployment --port=80 --target-port=8080 --namespace ${test_ns}  --tenant ${test_tenant}
+    OutputShouldBe: "service/sample-nginx-deployment exposed\n"
+
+  - Command: "${kubectl} get service sample-nginx-deployment --namespace ${test_ns} --tenant ${test_tenant} -o json 
+              | jq -r '[.metadata.name, .metadata.namespace, .metadata.tenant, .spec.ports[0].port, .spec.ports[0].targetPort] | @tsv'"
+    OutputShouldBe: "sample-nginx-deployment	${test_ns}	${test_tenant}	80	8080\n"
+
+  - Command: "${kubectl} get endpoints sample-nginx-deployment --namespace ${test_ns} --tenant ${test_tenant}  -o json 
+              | jq -r '[.metadata.name, .metadata.namespace, .metadata.tenant] | @tsv'"
+    OutputShouldBe: "sample-nginx-deployment	${test_ns}	${test_tenant}\n"
+
+# ------------------------------------------------------------
+# endpoints will be deleted when the service is deleted
+# ------------------------------------------------------------
+  - Command: ${kubectl} delete service sample-nginx-deployment  --namespace ${test_ns}  --tenant ${test_tenant}
+    OutputShouldBe: "service \"sample-nginx-deployment\" deleted\n"
+
+  - Command: ${kubectl} get service sample-nginx-deployment  --namespace ${test_ns}  --tenant ${test_tenant}
+    ShouldFail: true
+    OutputShouldBe: "Error from server (NotFound): services \"sample-nginx-deployment\" not found\n"
+
+  - Command: ${kubectl} get endpoints sample-nginx-deployment  --namespace ${test_ns}  --tenant ${test_tenant}
+    ShouldFail: true
+    OutputShouldBe: "Error from server (NotFound): endpoints \"sample-nginx-deployment\" not found\n"
+
+######################################################################################################
+# cleanup
+######################################################################################################
+  - Command: ${kubectl} delete tenant ${test_tenant}
+    OutputShouldBe: "tenant \"${test_tenant}\" deleted\n"
+    TimeOut: 60

--- a/test/e2e/arktos/multi_tenancy/test_suites/multi_tenancy_controller/test_sa_token_controller.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/multi_tenancy_controller/test_sa_token_controller.yaml
@@ -1,0 +1,89 @@
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ServiceAccount & Token Controller Tests ~~~~~~~~~~~~~~~~~~~~~~
+# This test suite verifies the multi-tenancy ServiceAccount & Token controller. 
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################
+# test variables
+######################################################
+Variables:
+  test_ns: random_8
+  test_tenant: random_8
+
+###########################################################################################################
+# test setup
+###########################################################################################################
+Tests:
+  - Command: ${kubectl} create tenant ${test_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${test_tenant} created\n"
+
+########################################################################################
+# Testing deployment controller & replicaset controller
+########################################################################################
+# ------------------------------------------------------------
+# default serviceaccount and secret are created when a namespace is created
+# ------------------------------------------------------------
+  - Command: ${kubectl} create ns ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "namespace/${test_ns} created\n"
+
+  - Command: ${kubectl} get serviceaccounts --namespace ${test_ns} --tenant ${test_tenant} -o json | jq -r '.items[] | [.metadata.name, .metadata.namespace, .metadata.tenant] | @tsv'
+    OutputShouldBe: "default	${test_ns}	${test_tenant}\n"
+
+  - Command: ${kubectl} get secrets --namespace ${test_ns} --tenant ${test_tenant} -o json | jq -r '.items[] | [.metadata.name[0:14], .metadata.namespace, .metadata.tenant] | @tsv'
+    OutputShouldBe: "default-token-	${test_ns}	${test_tenant}\n"
+    
+# ------------------------------------------------------------
+# default serviceaccount and secret will be recreated if the serviceaccount deleted
+# ------------------------------------------------------------
+  - Command: ${kubectl} delete serviceaccount default --namespace ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "serviceaccount \"default\" deleted\n"
+
+  - Command: ${kubectl} get serviceaccounts --namespace ${test_ns} --tenant ${test_tenant} -o json | jq -r '.items[] | [.metadata.name, .metadata.namespace, .metadata.tenant] | @tsv'
+    OutputShouldBe: "default	${test_ns}	${test_tenant}\n"
+
+  - Command: ${kubectl} get secrets --namespace ${test_ns} --tenant ${test_tenant} -o json | jq -r '.items[] | [.metadata.name[0:14], .metadata.namespace, .metadata.tenant] | @tsv'
+    OutputShouldBe: "default-token-	${test_ns}	${test_tenant}\n"
+
+# ------------------------------------------------------------
+# default serviceaccount and secret will be recreated if the secret deleted
+# ------------------------------------------------------------
+  - Command: ${kubectl} delete secrets --all --namespace ${test_ns} --tenant ${test_tenant}
+    OutputShouldContain:
+    - "secret \"default-token-"
+    - deleted
+
+  - Command: ${kubectl} get serviceaccounts --namespace ${test_ns} --tenant ${test_tenant} -o json | jq -r '.items[] | [.metadata.name, .metadata.namespace, .metadata.tenant] | @tsv'
+    OutputShouldBe: "default	${test_ns}	${test_tenant}\n"
+
+  - Command: ${kubectl} get secrets --namespace ${test_ns} --tenant ${test_tenant} -o json | jq -r '.items[] | [.metadata.name[0:14], .metadata.namespace, .metadata.tenant] | @tsv'
+    OutputShouldBe: "default-token-	${test_ns}	${test_tenant}\n"
+
+  # ------------------------------------------------------------
+# default serviceaccount and secret are deleted when the namespace is created
+# ------------------------------------------------------------
+
+  - Command: ${kubectl} delete ns ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "namespace \"${test_ns}\" deleted\n"
+    TimeOut: 20
+
+  - Command: ${kubectl} get serviceaccount default --namespace ${test_ns} --tenant ${test_tenant}
+    ShouldFail: true
+    OutputShouldBe: "Error from server (NotFound): namespaces \"${test_ns}\" not found\n"
+
+  - Command: ${kubectl} get serviceaccounts --all-namespaces --all-tenants
+    OutputShouldNotContain: 
+    - ${test_ns}
+
+  - Command: ${kubectl} get secrets --namespace ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "No resources found.\n"
+
+  - Command: ${kubectl} get secrets --all-namespaces --all-tenants
+    OutputShouldNotContain: 
+    - ${test_ns}
+
+######################################################################################################
+# cleanup
+######################################################################################################
+  - Command: ${kubectl} delete tenant ${test_tenant}
+    OutputShouldBe: "tenant \"${test_tenant}\" deleted\n"
+    TimeOut: 60

--- a/test/e2e/arktos/multi_tenancy/testdata/sample-deployment.yaml
+++ b/test/e2e/arktos/multi_tenancy/testdata/sample-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
This PR adds the e2e test suites for the following multi-tenancy controllers:
1. deployment & replicaset controller
2. serviceaccount & token controller
3. endpoints controllers.

The test suites were verified in my dev box. The following are the screenshots:
![image](https://user-images.githubusercontent.com/51831990/91346771-2a5bee80-e796-11ea-99f7-303caafe6407.png)


![image](https://user-images.githubusercontent.com/51831990/91347046-8f174900-e796-11ea-94a5-eca57a7c9a53.png)


Tracking issue: https://github.com/futurewei-cloud/arktos/issues/559