### PR TITLE
improve multi-tenancy e2e test tool

### DIFF
--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testcase.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testcase.go
@@ -26,7 +26,8 @@ type TestCase struct {
 	Command string `yaml:"Command,omitempty"`
 	TimeOut *int   `yaml:"TimeOut,omitempty"`
 
-	BeforeTest string `yaml:"BeforeTest,omitempty"`
+	BeforeTest        string `yaml:"BeforeTest,omitempty"`
+	BeforeTestMessage string `yaml:"BeforeTestMessage,omitempty"`
 
 	RetryCount    *int `yaml:"RetryCount,omitempty"`
 	RetryInterval *int `yaml:"RetryInterval,omitempty"`
@@ -38,6 +39,7 @@ type TestCase struct {
 	OutputShouldContain []string `yaml:"OutputShouldContain,omitempty"`
 
 	OutputShouldNotContain []string `yaml:"OutputShouldNotContain,omitempty"`
+	AfterTestMessage       string   `yaml:"AfterTestMessage,omitempty"`
 }
 
 func (t *TestCase) Validate(tc *TestConfig) *ErrorList {
@@ -59,6 +61,20 @@ func (t *TestCase) Complete(tc *TestConfig) {
 }
 
 func (t *TestCase) Run(tc *TestConfig) *ErrorList {
+	if t.BeforeTestMessage != "" {
+		LogInfo(t.BeforeTestMessage + "\n")
+	}
+
+	errList := t.Test(tc)
+
+	if t.AfterTestMessage != "" {
+		LogInfo(t.AfterTestMessage + "\n")
+	}
+
+	return errList
+}
+
+func (t *TestCase) Test(tc *TestConfig) *ErrorList {
 	var errList *ErrorList
 	var exitCode int
 	var output string
@@ -138,7 +154,7 @@ func (t *TestCase) CheckTestResult(exitCode int, output string) *ErrorList {
 	if len(t.OutputShouldContain) > 0 {
 		for _, expectedMatch := range t.OutputShouldContain {
 			if !strings.Contains(output, expectedMatch) {
-				errList.Add(fmt.Errorf("Did not find the match in output : %q", expectedMatch))
+				errList.Add(fmt.Errorf("Did not find the match in output: %q", expectedMatch))
 			}
 		}
 	}
@@ -146,7 +162,7 @@ func (t *TestCase) CheckTestResult(exitCode int, output string) *ErrorList {
 	if len(t.OutputShouldNotContain) > 0 {
 		for _, expectedNotMatch := range t.OutputShouldNotContain {
 			if strings.Contains(output, expectedNotMatch) {
-				errList.Add(fmt.Errorf("Find unexpected match in output : %q", expectedNotMatch))
+				errList.Add(fmt.Errorf("Find unexpected match in output: %q", expectedNotMatch))
 			}
 		}
 	}

--- a/test/e2e/arktos/multi_tenancy/cmd/framework/testsuite.go
+++ b/test/e2e/arktos/multi_tenancy/cmd/framework/testsuite.go
@@ -40,7 +40,8 @@ func (ts *TestSuite) LoadTestSuite(filePath string, tc *TestConfig) error {
 		return fmt.Errorf("error in reading file %v, err: %v ", filePath, err)
 	}
 
-	err = yaml.Unmarshal(testSuiteFile, ts)
+	var tempTestSuite TestSuite
+	err = yaml.UnmarshalStrict(testSuiteFile, &tempTestSuite)
 	if err != nil {
 		// ignore the yaml.TypeError in the first round of unmarshing as it is most likely due to that
 		// the variable resolution is not done
@@ -51,7 +52,7 @@ func (ts *TestSuite) LoadTestSuite(filePath string, tc *TestConfig) error {
 		}
 	}
 
-	allVariables := MergeStringMaps(tc.CommonVariables, ts.Variables)
+	allVariables := MergeStringMaps(tc.CommonVariables, tempTestSuite.Variables)
 	resolved_output, _ := ioutil.ReadFile(filePath)
 	for key, value := range allVariables {
 		// generate random strings for variables if the value is "random_[string_length]"
@@ -66,7 +67,7 @@ func (ts *TestSuite) LoadTestSuite(filePath string, tc *TestConfig) error {
 		resolved_output = bytes.ReplaceAll(resolved_output, []byte("${"+key+"}"), []byte(value))
 	}
 
-	if err = yaml.Unmarshal(resolved_output, ts); err != nil {
+	if err = yaml.UnmarshalStrict(resolved_output, ts); err != nil {
 		return fmt.Errorf("error in unmarshling resolved yaml file %v, err: %v ", filePath, err)
 	}
 

--- a/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
+++ b/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
@@ -22,10 +22,8 @@ export GO111MODULE=on
 script_root=$(dirname "${BASH_SOURCE}")
 repo_root=$(cd $(dirname $0)/../../../.. ; pwd)
 
-#put the test suite file names below, one line one suite. The test suites will be run in the order defined.
-test_suite_files="multi_tenancy_controller/test_sa_token_controller.yaml \
-				  multi_tenancy_controller/test_endpoints_controller.yaml \
-				  multi_tenancy_controller/test_deployment_replicaset_controller.yaml \
+#put the test suite file patterns below, one line one suite. The test suites will be run in the order defined.
+test_suite_files="multi_tenancy_controller/test_*_controller.yaml \
 				  tenant_init_delete_test.yaml"
 test_suite_file_directory=${repo_root}/test/e2e/arktos/multi_tenancy/test_suites/
 
@@ -61,3 +59,6 @@ cd ${script_root}/ && go build -o /tmp/testrunner './cmd/'
 				-DefaultRetryInterval=${default_retry_interval} \
 				-MaxRetryInterval=${max_retry_interval} \
 				-CommonVar="kubectl:${kubectl},setup_client_script:${setup_client_script},test_data_dir:${test_data_dir}"
+
+returnCode=$?
+exit ${returnCode}

--- a/test/e2e/arktos/multi_tenancy/test_suites/multi_tenancy_controller/test_deployment_replicaset_controller.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/multi_tenancy_controller/test_deployment_replicaset_controller.yaml
@@ -13,12 +13,14 @@ Variables:
 # test setup
 ###########################################################################################################
 Tests:
-  - Command: ${kubectl} create tenant ${test_tenant}
+  - BeforeTestMessage: Test setup ....
+    Command: ${kubectl} create tenant ${test_tenant}
     OutputShouldContain: 
     - "\ntenant/${test_tenant} created\n"
 
   - Command: ${kubectl} create ns ${test_ns} --tenant ${test_tenant} 
     OutputShouldBe: "namespace/${test_ns} created\n"
+    AfterTestMessage: End of test setup.
 
 ########################################################################################
 # Testing deployment controller & replicaset controller
@@ -27,7 +29,8 @@ Tests:
 # ------------------------------------------------------------
 # replicasets and pods are created when a deployment is created
 # ------------------------------------------------------------
-  - Command: ${kubectl} get deployments --all-namespaces --tenant ${test_tenant} 
+  - BeforeTestMessage: Verifying replicasets and pods are created when a deployment is created
+    Command: ${kubectl} get deployments --all-namespaces --tenant ${test_tenant} 
     OutputShouldBe: "No resources found.\n"
 
   # creating the deployment
@@ -57,7 +60,8 @@ Tests:
 # ------------------------------------------------------------
 # pods will be recreated if deleted
 # ------------------------------------------------------------
-  - Command: ${kubectl} delete pods --all --namespace ${test_ns} --tenant ${test_tenant}
+  - BeforeTestMessage: Verifying pods will be recreated if deleted
+    Command: ${kubectl} delete pods --all --namespace ${test_ns} --tenant ${test_tenant}
     OutputShouldContain:
     - "pod \"sample-nginx-deployment-"
     - "deleted\n"
@@ -86,7 +90,8 @@ Tests:
 # ------------------------------------------------------------
 # replicasets will be recreated if deleted
 # ------------------------------------------------------------
-  - Command: ${kubectl} delete replicasets --all --namespace ${test_ns} --tenant ${test_tenant}
+  - BeforeTestMessage: Verifying replicasets will be recreated if deleted
+    Command: ${kubectl} delete replicasets --all --namespace ${test_ns} --tenant ${test_tenant}
     OutputShouldContain:
     - "replicaset.extensions \"sample-nginx-deployment-"
     - deleted
@@ -115,7 +120,8 @@ Tests:
 # ------------------------------------------------------------
 # replicasets and pods are deleted when a deployment is deleted
 # ------------------------------------------------------------
-  - Command: ${kubectl} delete -f ${test_data_dir}/sample-deployment.yaml --namespace ${test_ns} --tenant ${test_tenant} 
+  - BeforeTestMessage: Verifying replicasets and pods are deleted when a deployment is deleted
+    Command: ${kubectl} delete -f ${test_data_dir}/sample-deployment.yaml --namespace ${test_ns} --tenant ${test_tenant} 
     OutputShouldBe: "deployment.apps \"sample-nginx-deployment\" deleted\n"
 
   - BeforeTest: sleep 5
@@ -136,6 +142,7 @@ Tests:
 ######################################################################################################
 # cleanup
 ######################################################################################################
-  - Command: ${kubectl} delete tenant ${test_tenant}
+  - BeforeTestMessage: Clean up...
+    Command: ${kubectl} delete tenant ${test_tenant}
     OutputShouldBe: "tenant \"${test_tenant}\" deleted\n"
     TimeOut: 60


### PR DESCRIPTION
This PR enhances the multi-tenancy e2e test tool per comments from the team members and my own experience. It is part of work for https://github.com/futurewei-cloud/arktos/issues/559

The changes made are:
#### New test case fields, "BeforeTestMessage" and "AfterTestMessage"

The test case author can define them to print some user-friendly message as the test goes on. The following is a screenshot of a test run after I added such definitions (only one test suite file change is included in this PR to have a clear-cut PR. ):

![image](https://user-images.githubusercontent.com/51831990/91507059-a33b7300-e888-11ea-8376-010bf526ace3.png)


#### Stricter check on the test suite yam files.

Test suite file validation will fail if there are undefined fields. The previous behavior is skipping it. This helps catch the typo of test case authors.

#### Allow the use of file name pattern When specifying the test suite files

As a result, I can specify the following in run-e2e-test.sh
```
test_suite_files="multi_tenancy_controller/test_*_controller.yaml"
```

Instead of something like
```
test_suite_files="multi_tenancy_controller/test_sa_token_controller.yaml \
		          multi_tenancy_controller/test_endpoints_controller.yaml \
			  multi_tenancy_controller/test_deployment_replicaset_controller.yaml \
                          "
```

As we are creating more and more test suite files, it keeps the code organized and clean.

#### run-e2e-test.sh exit with code of 1 if there are test failures.

Someday we can run this tool as a periodical job to catch the regression automatically. This change paves the way to it.