### PR TITLE
bump up runtime version

### DIFF
--- a/hack/lib/common-var-init.sh
+++ b/hack/lib/common-var-init.sh
@@ -27,7 +27,7 @@ VIRTLET_LOG_DIR=${VIRTLET_LOG_DIR:-"/var/log/virtlet"}
 VIRTLET_DEPLOYMENT_FILES_DIR=${VIRTLET_DEPLOYMENT_FILES_DIR:-"/tmp"}
 
 # Default to current arktos-vm-runtime release-0.5 branch
-VIRTLET_DEPLOYMENT_FILES_SRC=${VIRTLET_DEPLOYMENT_FILES_SRC:-"https://raw.githubusercontent.com/futurewei-cloud/arktos-vm-runtime/release-0.5/deploy"}
+VIRTLET_DEPLOYMENT_FILES_SRC=${VIRTLET_DEPLOYMENT_FILES_SRC:-"https://raw.githubusercontent.com/futurewei-cloud/arktos-vm-runtime/release-0.6/deploy"}
 OVERWRITE_DEPLOYMENT_FILES=${OVERWRITE_DEPLOYMENT_FILES:-"true"}
 
 APPARMOR_ENABLED=${APPARMOR_ENABLED:-""}

--- a/test/yaml/vm_default.yaml
+++ b/test/yaml/vm_default.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: vmdefault
+  # use host-model or other cpul model that supports numa for memory hotplug/unplug feature in libvirt
+  annotations:
+    VirtletCPUModel: "host-model"
 spec:
   virtualMachine:
     keyPairName: "foobar"

--- a/test/yaml/vm_with_persistedVolumes/vm_aws_static_pv.yaml
+++ b/test/yaml/vm_with_persistedVolumes/vm_aws_static_pv.yaml
@@ -4,6 +4,9 @@ metadata:
   tenant: default
   namespace: default
   name: vmawspv
+  # use host-model or other cpul model that supports numa for memory hotplug/unplug feature in libvirt
+  annotations:
+    VirtletCPUModel: "host-model"
 spec:
   virtualMachine:
     keyPairName: "foobar"

--- a/test/yaml/vm_with_persistedVolumes/vm_datadisk_flexvol.yaml
+++ b/test/yaml/vm_with_persistedVolumes/vm_datadisk_flexvol.yaml
@@ -6,6 +6,8 @@ metadata:
   name: vmflexvol
   annotations:
     VirtletDiskDriver: virtio
+  # use host-model or other cpul model that supports numa for memory hotplug/unplug feature in libvirt
+    VirtletCPUModel: "host-model"
 spec:
   virtualMachine:
     keyPairName: "foobar"

--- a/test/yaml/vm_with_persistedVolumes/vm_datadisk_pv.yaml
+++ b/test/yaml/vm_with_persistedVolumes/vm_datadisk_pv.yaml
@@ -6,6 +6,8 @@ metadata:
   name: vmlocalpv
   annotations:
     VirtletDiskDriver: virtio
+  # use host-model or other cpul model that supports numa for memory hotplug/unplug feature in libvirt
+    VirtletCPUModel: "host-model"
 spec:
   virtualMachine:
     keyPairName: "foobar"

--- a/test/yaml/vm_with_persistedVolumes/vm_rootfs_pv.yaml
+++ b/test/yaml/vm_with_persistedVolumes/vm_rootfs_pv.yaml
@@ -6,6 +6,8 @@ metadata:
   name: vmrootfslocalpv
   annotations:
     VirtletDiskDriver: virtio
+  # use host-model or other cpul model that supports numa for memory hotplug/unplug feature in libvirt
+    VirtletCPUModel: "host-model"
 spec:
   virtualMachine:
     keyPairName: "foobar"


### PR DESCRIPTION
**What type of PR is this?**
bump up runtime version to enable vertical scaling feature for vm

**What this PR does / why we need it**:
arktos 830 release

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None api level. vm pod yaml will need to set the cpu model that supports numa node.

**Testing:
```
root@ip-172-31-10-115:/work/src/github.com/Mirantis/virtlet# kubectl get pods --all-namespaces
NAMESPACE     NAME                        HASHKEY               READY   STATUS    RESTARTS   AGE
kube-system   kube-dns-5d69f5657d-775jw   3992330385106179963   3/3     Running   0          57s
kube-system   virtlet-rzgg8               1061567349605714443   3/3     Running   0          41s

root@ip-172-31-10-115:/work/src/k8s.io/kubernetes/test# kubectl create -f yaml/vm_default.yaml 
pod/vmdefault created

root@ip-172-31-10-115:/work/src/k8s.io/kubernetes/test# kubectl get pods
NAME        HASHKEY               READY   STATUS    RESTARTS   AGE
vmdefault   5724920193123843411   1/1     Running   0          7s
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes/test# 
```

```
sanity tested:
 
Start Arktos
Create VM
Patch to bump up memory
Patch to reduce memory
 
root@ip-172-31-10-115:/# kubectl get pods
NAME        HASHKEY               READY   STATUS    RESTARTS   AGE
vmdefault   1774902635744962552   1/1     Running   0          4s
root@ip-172-31-10-115:/# kubectl get pods -o yaml
………..
  status:
    conditions:
    - lastProbeTime: null
      lastTransitionTime: "2020-09-01T00:03:14Z"
      status: "True"
      type: Ready
    - lastProbeTime: null
      lastTransitionTime: "2020-09-01T00:03:12Z"
      status: "True"
      type: PodScheduled
    hostIP: 172.31.10.115
    phase: Running
    podIP: 10.88.4.27
    qosClass: Guaranteed
    startTime: "2020-09-01T00:03:12Z"
    virtualMachineStatus:
      name: vm
      powerState: running
      ready: true
      resources:
        limits:
          cpu: "2"
          memory: 4Gi
        requests:
          cpu: "2"
          memory: 4Gi
      state: active
      virtualMachineId: d16b6a4d-227b-5e94-46c9-fe82f2d0ede1
 
root@ip-172-31-10-115:/# /patch.sh
pod/vmdefault patched
 
root@ip-172-31-10-115:/# kubectl get pods -o yaml
status:
    conditions:
    - lastProbeTime: null
      lastTransitionTime: "2020-09-01T00:03:14Z"
      status: "True"
      type: Ready
    - lastProbeTime: null
      lastTransitionTime: "2020-09-01T00:03:12Z"
      status: "True"
      type: PodScheduled
    hostIP: 172.31.10.115
    phase: Running
    podIP: 10.88.4.27
    qosClass: Guaranteed
    startTime: "2020-09-01T00:03:12Z"
    virtualMachineStatus:
      name: vm
      powerState: running
      ready: true
      resources:
        limits:
          cpu: "2"
          memory: 4608Mi
        requests:
          cpu: "2"
          memory: 4608Mi
      state: active
      virtualMachineId: d16b6a4d-227b-5e94-46c9-fe82f2d0ede1
 
root@ip-172-31-10-115:/# /patch2.sh
pod/vmdefault patched
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2020-09-01T00:03:14Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2020-09-01T00:03:12Z"
    status: "True"
    type: PodScheduled
  hostIP: 172.31.10.115
  phase: Running
  podIP: 10.88.4.27
  qosClass: Guaranteed
  startTime: "2020-09-01T00:03:12Z"
  virtualMachineStatus:
    name: vm
    powerState: running
    ready: true
    resources:
      limits:
        cpu: "2"
        memory: 4Gi
      requests:
        cpu: "2"
        memory: 4Gi
    state: active
    virtualMachineId: d16b6a4d-227b-5e94-46c9-fe82f2d0ede1
^Croot@ip-172-31-10-115:/# 
 
```
