### PR TITLE
multi-tenancy CRD e2e tests

### DIFF
--- a/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
+++ b/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
@@ -27,6 +27,7 @@ test_suite_files="tenant_init_delete_test.yaml
                   multi_tenancy_controller/test_*_controller.yaml \
                   admission/test_*.yaml \
                   kubectl/test_*.yaml \
+                  crd/test_*.yaml \
                   misc/test_*.yaml"
 test_suite_file_directory=${repo_root}/test/e2e/arktos/multi_tenancy/test_suites/
 

--- a/test/e2e/arktos/multi_tenancy/test_suites/crd/test_per_tenant_crd.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/crd/test_per_tenant_crd.yaml
@@ -93,17 +93,41 @@ Tests:
 
 
 ######################################################################################################
+# Verifying different tenants can create their custom resources independently...
+######################################################################################################
+
+  - BeforeTestMessage: Verifying different tenants can create their custom resources  independently...
+    Command: ${kubectl} apply -f ${test_data_dir}/regular_crd_resource.yaml --context ${first_tenant}-admin-context
+    OutputShouldBe: "neversharingsweetdream.fantasy.wonderland.com/wild-wild-west created\n"
+
+  - Command: ${kubectl} get neversharingsweetdreams --context ${first_tenant}-admin-context -o json | jq -r '.items[] | .metadata.name '
+    OutputShouldBe: "wild-wild-west\n"
+
+  - Command: ${kubectl} get neversharingsweetdreams --context ${second_tenant}-admin-context
+    OutputShouldBe: "No resources found.\n"
+
+  - Command: "cat ${test_data_dir}/regular_crd_resource.yaml | sed 's/wild-wild-west/alice-in-wonderland/g' |
+              ${kubectl} apply --context ${second_tenant}-admin-context -f -"
+    OutputShouldBe: "neversharingsweetdream.fantasy.wonderland.com/alice-in-wonderland created\n"
+
+  - Command: ${kubectl} get neversharingsweetdreams wild-wild-west --context ${first_tenant}-admin-context -o json | jq -r .metadata.name
+    OutputShouldBe: "wild-wild-west\n"
+
+  - Command: ${kubectl} get neversharingsweetdreams alice-in-wonderland --context ${second_tenant}-admin-context -o json | jq -r .metadata.name
+    OutputShouldBe: "alice-in-wonderland\n"
+
+######################################################################################################
 # Verifying different tenants can delete their custom resources independently...
 ######################################################################################################
 
   - BeforeTestMessage: Verifying different tenants can delete their custom resources  independently...
-    Command: ${kubectl} apply -f ${test_data_dir}/regular_crd_resource.yaml --context ${first_tenant}-admin-context
-    OutputShouldBe: "neversharingsweetdream.fantasy.wonderland.com/wild-wild-west created\n"
+    Command: ${kubectl} delete -f ${test_data_dir}/regular_crd_resource.yaml --context ${first_tenant}-admin-context
+    OutputShouldBe: "neversharingsweetdream.fantasy.wonderland.com \"wild-wild-west\" deleted\n"
 
-  - Command: ${kubectl} get neversharingsweetdreams wild-wild-west --context ${first_tenant}-admin-context -o json | jq .metadata.name
-    OutputShouldBe: "\"wild-wild-west\"\n"
+  - Command: ${kubectl} get neversharingsweetdreams --context ${second_tenant}-admin-context -o json | jq -r '.items[] | .metadata.name '
+    OutputShouldBe: "alice-in-wonderland\n"
 
-  - Command: ${kubectl} get neversharingsweetdreams --context ${second_tenant}-admin-context
+  - Command: ${kubectl} get neversharingsweetdreams --context ${first_tenant}-admin-context
     OutputShouldBe: "No resources found.\n"
 
 ######################################################################################################
@@ -124,8 +148,8 @@ Tests:
     OutputShouldContain:
     - "neversharingsweetdreams.fantasy.wonderland.com"
 
-  - Command: ${kubectl} get neversharingsweetdreams --context ${second_tenant}-admin-context
-    OutputShouldBe: "No resources found.\n"
+  - Command: ${kubectl} get neversharingsweetdreams --context ${second_tenant}-admin-context -o json | jq -r '.items[] | .metadata.name'
+    OutputShouldBe: "alice-in-wonderland\n"
 
 ######################################################################################################
 # cleanup
@@ -135,4 +159,7 @@ Tests:
 
   - Command: ${kubectl} delete tenant ${second_tenant} > /dev/null 2>&1 &
 
+  - Command: REMOVE=TRUE ${setup_client_script} ${first_tenant} admin
+
+  - Command: REMOVE=TRUE ${setup_client_script} ${second_tenant} admin
 

--- a/test/e2e/arktos/multi_tenancy/test_suites/crd/test_per_tenant_crd.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/crd/test_per_tenant_crd.yaml
@@ -1,0 +1,138 @@
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Per-Tenant CRD Tests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# This test suite verifies the per-tenant CRD works in Arktos
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################
+# test variables
+######################################################
+Variables:
+  first_tenant: random_8
+  second_tenant: random_8
+
+###########################################################################################################
+# test setup
+###########################################################################################################
+Tests:
+  - BeforeTestMessage: Starting test setup ...
+    Command: ${kubectl} create tenant ${first_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${first_tenant} created\n"
+
+  - Command: ${setup_client_script} ${first_tenant} admin
+
+  - Command: ${kubectl} create tenant ${second_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${second_tenant} created\n"
+
+  - Command: ${setup_client_script} ${second_tenant} admin
+
+############################################
+# Verifying different tenants can create their CRDs independently...
+############################################
+  - BeforeTestMessage: Verifying different tenants can create their CRDs independently...
+    Command: ${kubectl} get crds --context ${first_tenant}-admin-context
+    OutputShouldBe: "No resources found.\n"
+
+  - Command: ${kubectl} apply -f ${test_data_dir}/regular_crd.yaml --context ${first_tenant}-admin-context
+    OutputShouldBe: "customresourcedefinition.apiextensions.k8s.io/neversharingsweetdreams.fantasy.wonderland.com created\n"
+
+  - Command: ${kubectl} get crds --context ${first_tenant}-admin-context
+    OutputShouldContain:
+    - "neversharingsweetdreams.fantasy.wonderland.com"
+
+  - Command: ${kubectl} api-resources --context ${first_tenant}-admin-context
+    OutputShouldContain:
+    - "neversharingsweetdreams"
+    - "NeverSharingSweetDream"
+    - "fantasy.wonderland.com"
+
+  - Command: ${kubectl} api-versions --context ${first_tenant}-admin-context
+    OutputShouldContain:
+    - "fantasy.wonderland.com/v1\n"
+
+  - Command: ${kubectl} get crds --context ${second_tenant}-admin-context
+    OutputShouldBe: "No resources found.\n"
+
+  - Command: ${kubectl} api-resources --context ${second_tenant}-admin-context
+    OutputShouldNotContain:
+    - "neversharingsweetdreams"
+    - "NeverSharingSweetDream"
+    - "fantasy.wonderland.com"
+
+  - Command: ${kubectl} api-versions --context ${second_tenant}-admin-context
+    OutputShouldNotContain:
+    - "fantasy.wonderland.com"
+
+  - Command: "cat ${test_data_dir}/regular_crd.yaml | sed 's/version: v1/version: v1/g' |
+              ${kubectl} apply --context ${second_tenant}-admin-context -f -"
+    OutputShouldBe: "customresourcedefinition.apiextensions.k8s.io/neversharingsweetdreams.fantasy.wonderland.com created\n"
+
+  - Command: ${kubectl} get crds --context ${second_tenant}-admin-context
+    OutputShouldContain:
+    - "neversharingsweetdreams.fantasy.wonderland.com"
+
+  - Command: ${kubectl} api-resources --context ${second_tenant}-admin-context
+    OutputShouldContain:
+    - "neversharingsweetdreams"
+    - "NeverSharingSweetDream"
+    - "fantasy.wonderland.com"
+
+  - Command: ${kubectl} api-versions --context ${second_tenant}-admin-context
+    OutputShouldContain:
+    - "fantasy.wonderland.com/v1\n"
+
+  - Command: ${kubectl} api-versions --context ${first_tenant}-admin-context
+    OutputShouldContain:
+    - "fantasy.wonderland.com/v1\n"
+
+  - Command: "${kubectl} get crds --all-tenants -o json 
+            | jq -r '.items[] | [.metadata.name, .metadata.tenant] | @tsv'"
+    OutputShouldContain:
+    - "neversharingsweetdreams.fantasy.wonderland.com	${first_tenant}\n"
+    - "neversharingsweetdreams.fantasy.wonderland.com	${second_tenant}\n"
+
+
+######################################################################################################
+# Verifying different tenants can delete their custom resources independently...
+######################################################################################################
+
+  - BeforeTestMessage: Verifying different tenants can delete their custom resources  independently...
+    Command: ${kubectl} apply -f ${test_data_dir}/regular_crd_resource.yaml --context ${first_tenant}-admin-context
+    OutputShouldBe: "neversharingsweetdream.fantasy.wonderland.com/wild-wild-west created\n"
+
+  - Command: ${kubectl} get neversharingsweetdreams wild-wild-west --context ${first_tenant}-admin-context -o json | jq .metadata.name
+    OutputShouldBe: "\"wild-wild-west\"\n"
+
+  - Command: ${kubectl} get neversharingsweetdreams --context ${second_tenant}-admin-context
+    OutputShouldBe: "No resources found.\n"
+
+######################################################################################################
+# Verifying different tenants can delete their CRDs independently...
+######################################################################################################
+
+  - BeforeTestMessage: Verifying different tenants can delete their CRDs independently...
+    Command: ${kubectl} delete -f ${test_data_dir}/regular_crd.yaml --context ${first_tenant}-admin-context
+    OutputShouldBe: "customresourcedefinition.apiextensions.k8s.io \"neversharingsweetdreams.fantasy.wonderland.com\" deleted\n"
+    TimeOut: 60
+
+  - Command: ${kubectl} get neversharingsweetdreams --context ${first_tenant}-admin-context
+    ShouldFail: true
+    OutputShouldContain:
+    - "the server could not find the requested resource"
+
+  - Command: ${kubectl} get crds --context ${second_tenant}-admin-context
+    OutputShouldContain:
+    - "neversharingsweetdreams.fantasy.wonderland.com"
+
+  - Command: ${kubectl} get neversharingsweetdreams --context ${second_tenant}-admin-context
+    OutputShouldBe: "No resources found.\n"
+
+######################################################################################################
+# cleanup
+######################################################################################################
+  - BeforeTestMessage: clean up ...
+    Command: ${kubectl} delete tenant ${first_tenant} > /dev/null 2>&1 &
+
+  - Command: ${kubectl} delete tenant ${second_tenant} > /dev/null 2>&1 &
+
+

--- a/test/e2e/arktos/multi_tenancy/test_suites/crd/test_system_share_crd.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/crd/test_system_share_crd.yaml
@@ -1,0 +1,160 @@
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ System Forced Sharing CRD Tests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# This test suite verifies the system forced sharing CRD works in Arktos
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################
+# test variables
+######################################################
+Variables:
+  first_tenant: random_8
+  second_tenant: random_8
+
+###########################################################################################################
+# test setup
+###########################################################################################################
+Tests:
+  - BeforeTestMessage: Starting test setup ...
+    Command: ${kubectl} create tenant ${first_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${first_tenant} created\n"
+
+  - Command: ${setup_client_script} ${first_tenant} admin
+
+  - Command: ${kubectl} create tenant ${second_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${second_tenant} created\n"
+
+  - Command: ${setup_client_script} ${second_tenant} admin
+
+########################################################################################
+# Verifying system-share CRD is visible to all tenants
+########################################################################################
+
+  - BeforeTestMessage: Verifying system-share CRD is visible to all tenants ...
+    Command: ${kubectl} apply -f ${test_data_dir}/forced_share_crd.yaml --tenant system
+    OutputShouldContain:
+    - "customresourcedefinition.apiextensions.k8s.io/mustshareknowledges.learning.wisdom.com"
+
+  - Command: ${kubectl} get crds --context ${first_tenant}-admin-context
+    OutputShouldContain: 
+    - "mustshareknowledges.learning.wisdom.com"
+
+  - Command: ${kubectl} get crds --context ${second_tenant}-admin-context
+    OutputShouldContain:
+    - "mustshareknowledges.learning.wisdom.com"
+
+########################################################################################
+# Verifying system-share CRD cannot be overridden by regular tenants
+########################################################################################
+
+  - BeforeTestMessage: Verifying system-share CRD cannot be overridden by regular tenants ...
+    Command: ${kubectl} apply -f ${test_data_dir}/forced_share_crd.yaml --context ${first_tenant}-admin-context
+    ShouldFail: true
+    OutputShouldContain:
+    - "mustshareknowledges.learning.wisdom.com is a system CRD, you cannot overwrite it"
+
+# the following test is temporarily disabled due to bug #655
+#  - Command: ${kubectl} delete -f ${test_data_dir}/forced_share_crd.yaml --context ${first_tenant}-admin-context
+#    ShouldFail: true
+#    OutputShouldContain:
+#    - "mustshareknowledges.learning.wisdom.com is a system CRD, you cannot delete it"
+
+  - Command: "cat ${test_data_dir}/forced_share_crd.yaml | sed 's|    learning.wisdom.com/crd-sharing-policy: forced||g' |
+              ${kubectl} apply --context ${first_tenant}-admin-context -f -"
+    ShouldFail: true
+    OutputShouldContain:
+    - "mustshareknowledges.learning.wisdom.com is a system CRD, you cannot overwrite it"
+
+# the following test is temporarily disabled due to bug #655
+# - Command: "cat ${test_data_dir}/forced_share_crd.yaml | sed -e 's/    learning.wisdom.com/crd-sharing-policy: forced\n//g' |
+#              ${kubectl} delete --context ${first_tenant}-admin-context -f -"
+#    ShouldFail: true
+#    OutputShouldContain:
+#    - "mustshareknowledges.learning.wisdom.com is a system CRD, you cannot overwrite it"
+
+########################################################################################
+# Verifying regular tenants creating custom resources
+########################################################################################
+
+  - BeforeTestMessage: Verifying regular tenants creating custom resources ...
+    Command: ${kubectl} apply -f ${test_data_dir}/forced_share_crd_resource.yaml --tenant ${first_tenant}
+    OutputShouldBe: "mustshareknowledge.learning.wisdom.com/pythagorean-theorem created\n"
+
+# The following test is temporarily suspended due to bug 525
+#  - Command: ${kubectl} apply -f ${test_data_dir}/forced_share_crd_resource.yaml --context ${first_tenant}-admin-context
+#    OutputShouldBe: "mustshareknowledge.learning.wisdom.com/pythagorean-theorem created\n"
+
+  - Command: ${kubectl} get mustshareknowledges --context ${first_tenant}-admin-context
+    OutputShouldContain:
+    - "pythagorean-theorem"
+
+  - Command: "cat ${test_data_dir}/forced_share_crd_resource.yaml | sed 's|pythagorean-theorem|archimedes-principle|g' |
+              ${kubectl} create --tenant ${second_tenant} -f -"
+    OutputShouldBe: "mustshareknowledge.learning.wisdom.com/archimedes-principle created\n"
+
+# The following test is temporarily suspended due to bug 525
+#  - Command: "cat ${test_data_dir}/forced_share_crd_resource.yaml | sed 's|pythagorean-theorem|archimedes-principle|g' |
+#              ${kubectl} apply --context ${second_tenant}-admin-context -f -"
+#    OutputShouldBe: "mustshareknowledge.learning.wisdom.com/archimedes-principle created\n"
+
+  - Command: ${kubectl} get mustshareknowledges --context ${second_tenant}-admin-context
+    OutputShouldContain:
+    - "archimedes-principle"
+
+  - Command: "${kubectl} get mustshareknowledges --all-namespaces --all-tenants -o json 
+              | jq -r '.items[] | [.metadata.name, .metadata.namespace, .metadata.tenant] | @tsv'" 
+    OutputShouldContain:
+    - "pythagorean-theorem	default	${first_tenant}"
+    - "archimedes-principle	default	${second_tenant}"
+
+########################################################################################
+# Verifying tenant deleter works with system-share CRD
+########################################################################################
+
+  - BeforeTestMessage: Verifying tenant deleter works with system-share CRD ...
+    Command: ${kubectl} delete tenant ${first_tenant} 
+    TimeOut: 60
+    OutputShouldBe: "tenant \"${first_tenant}\" deleted\n"
+
+  - Command: ${kubectl} get tenant ${first_tenant} 
+    ShouldFail: true
+    OutputShouldBe: "Error from server (NotFound): tenants \"${first_tenant}\" not found\n"
+
+  - Command: "${kubectl} get mustshareknowledges --all-namespaces --all-tenants -o json 
+              | jq -r '.items[] | [.metadata.name, .metadata.namespace, .metadata.tenant] | @tsv'" 
+    OutputShouldContain:
+    - "archimedes-principle	default	${second_tenant}"
+    OutputShouldNotContain:
+    - "pythagorean-theorem	default	${first_tenant}"
+
+########################################################################################
+# Verify deleting system-share-CRD in system spaces takes effect in all tenants' spaces
+########################################################################################
+
+  - BeforeTestMessage: Verify deleting system-share-CRD in system spaces takes effect in all tenants' spaces
+    Command: ${kubectl} delete -f ${test_data_dir}/forced_share_crd.yaml --tenant system
+    OutputShouldBe: "customresourcedefinition.apiextensions.k8s.io \"mustshareknowledges.learning.wisdom.com\" deleted\n"
+
+  - Command: ${kubectl} get mustshareknowledges --all-namespaces --all-tenants 
+    ShouldFail: true
+    OutputShouldBe: "Error from server (NotFound): Unable to list \"learning.wisdom.com/v1, Resource=mustshareknowledges\": the server could not find the requested resource (get mustshareknowledges.learning.wisdom.com)\n"
+
+  - Command: ${kubectl} get crds --context ${second_tenant}-admin-context
+    OutputShouldBe: "No resources found.\n"
+
+  - Command: ${kubectl} get mustshareknowledges --context ${second_tenant}-admin-context
+    ShouldFail: true
+    OutputShouldBe: "Error from server (NotFound): Unable to list \"learning.wisdom.com/v1, Resource=mustshareknowledges\": the server could not find the requested resource (get mustshareknowledges.learning.wisdom.com)\n"
+
+########################################################################################
+# TODO: add test about resouce discovery after bug 525 is fixed
+########################################################################################
+
+######################################################################################################
+# cleanup
+######################################################################################################
+
+  - BeforeTestMessage: clean up ...
+    Command: ${kubectl} delete tenant ${second_tenant} > /dev/null 2>&1 &
+
+

--- a/test/e2e/arktos/multi_tenancy/test_suites/crd/test_system_share_crd.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/crd/test_system_share_crd.yaml
@@ -32,8 +32,7 @@ Tests:
 
   - BeforeTestMessage: Verifying system-share CRD is visible to all tenants ...
     Command: ${kubectl} apply -f ${test_data_dir}/forced_share_crd.yaml --tenant system
-    OutputShouldContain:
-    - "customresourcedefinition.apiextensions.k8s.io/mustshareknowledges.learning.wisdom.com"
+    OutputShouldBe: "customresourcedefinition.apiextensions.k8s.io/mustshareknowledges.learning.wisdom.com created\n"
 
   - Command: ${kubectl} get crds --context ${first_tenant}-admin-context
     OutputShouldContain: 
@@ -146,15 +145,16 @@ Tests:
     ShouldFail: true
     OutputShouldBe: "Error from server (NotFound): Unable to list \"learning.wisdom.com/v1, Resource=mustshareknowledges\": the server could not find the requested resource (get mustshareknowledges.learning.wisdom.com)\n"
 
-########################################################################################
-# TODO: add test about resouce discovery after bug 525 is fixed
-########################################################################################
-
 ######################################################################################################
 # cleanup
 ######################################################################################################
 
+# only need to delete ${second_tenant} as ${first_tenant} is already deleted
   - BeforeTestMessage: clean up ...
     Command: ${kubectl} delete tenant ${second_tenant} > /dev/null 2>&1 &
+
+  - Command: REMOVE=TRUE ${setup_client_script} ${first_tenant} admin
+
+  - Command: REMOVE=TRUE ${setup_client_script} ${second_tenant} admin
 
 

--- a/test/e2e/arktos/multi_tenancy/testdata/forced_share_crd.yaml
+++ b/test/e2e/arktos/multi_tenancy/testdata/forced_share_crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mustshareknowledges.learning.wisdom.com
+  labels:
+    arktos.futurewei.com/crd-sharing-policy: forced
+spec:
+  group: learning.wisdom.com
+  version: v1
+  names:
+    kind: MustShareKnowledge
+    plural: mustshareknowledges
+  scope: Namespaced

--- a/test/e2e/arktos/multi_tenancy/testdata/forced_share_crd_resource.yaml
+++ b/test/e2e/arktos/multi_tenancy/testdata/forced_share_crd_resource.yaml
@@ -1,0 +1,4 @@
+apiVersion: learning.wisdom.com/v1
+kind: MustShareKnowledge
+metadata:
+  name: pythagorean-theorem

--- a/test/e2e/arktos/multi_tenancy/testdata/regular_crd.yaml
+++ b/test/e2e/arktos/multi_tenancy/testdata/regular_crd.yaml
@@ -1,0 +1,11 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: neversharingsweetdreams.fantasy.wonderland.com
+spec:
+  group: fantasy.wonderland.com
+  version: v1
+  names:
+    kind: NeverSharingSweetDream
+    plural: neversharingsweetdreams
+  scope: Namespaced

--- a/test/e2e/arktos/multi_tenancy/testdata/regular_crd_resource.yaml
+++ b/test/e2e/arktos/multi_tenancy/testdata/regular_crd_resource.yaml
@@ -1,0 +1,4 @@
+apiVersion: fantasy.wonderland.com/v1
+kind: NeverSharingSweetDream
+metadata:
+  name: wild-wild-west


### PR DESCRIPTION
This PR adds the following e2e test suites for multi-tenancy CRD:
1. test per-tenant CRD
2. test sytem-share CRD

Verification:
All tests passed locally in my dev box.

Tracking work item: https://github.com/futurewei-cloud/arktos/issues/648