### PR TITLE
fix bug 631/641

### DIFF
--- a/pkg/kubectl/cmd/create/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create/create_clusterrole.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -63,6 +64,7 @@ type CreateClusterRoleOptions struct {
 	*CreateRoleOptions
 	NonResourceURLs []string
 	AggregationRule map[string]string
+	Tenant          string
 }
 
 // NewCmdCreateClusterRole initializes and returns new ClusterRoles command
@@ -108,6 +110,12 @@ func (c *CreateClusterRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Comman
 		}
 	}
 	c.NonResourceURLs = nonResourceURLs
+
+	var err error
+	c.Tenant, _, err = f.ToRawKubeConfigLoader().Tenant()
+	if err != nil {
+		return err
+	}
 
 	return c.CreateRoleOptions.Complete(f, cmd, args)
 }
@@ -200,7 +208,7 @@ func (c *CreateClusterRoleOptions) RunCreateRole() error {
 
 	// Create ClusterRole.
 	if !c.DryRun {
-		clusterRole, err = c.Client.ClusterRoles().Create(clusterRole)
+		clusterRole, err = c.Client.ClusterRolesWithMultiTenancy(c.Tenant).Create(clusterRole)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/create/create_cronjob.go
+++ b/pkg/kubectl/cmd/create/create_cronjob.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -61,6 +62,7 @@ type CreateCronJobOptions struct {
 	Restart  string
 
 	Namespace string
+	Tenant    string
 	Client    batchv1beta1client.BatchV1beta1Interface
 	DryRun    bool
 	Builder   *resource.Builder
@@ -130,6 +132,10 @@ func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 	if err != nil {
 		return err
 	}
+	o.Tenant, _, err = f.ToRawKubeConfigLoader().Tenant()
+	if err != nil {
+		return err
+	}
 	o.Builder = f.NewBuilder()
 	o.Cmd = cmd
 
@@ -164,7 +170,7 @@ func (o *CreateCronJobOptions) Run() error {
 
 	if !o.DryRun {
 		var err error
-		cronjob, err = o.Client.CronJobs(o.Namespace).Create(cronjob)
+		cronjob, err = o.Client.CronJobsWithMultiTenancy(o.Namespace, o.Tenant).Create(cronjob)
 		if err != nil {
 			return fmt.Errorf("failed to create cronjob: %v", err)
 		}

--- a/pkg/kubectl/cmd/create/create_role.go
+++ b/pkg/kubectl/cmd/create/create_role.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -124,6 +125,7 @@ type CreateRoleOptions struct {
 	DryRun       bool
 	OutputFormat string
 	Namespace    string
+	Tenant       string
 	Client       clientgorbacv1.RbacV1Interface
 	Mapper       meta.RESTMapper
 	PrintObj     func(obj runtime.Object) error
@@ -250,6 +252,11 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 		return err
 	}
 
+	o.Tenant, _, err = f.ToRawKubeConfigLoader().Tenant()
+	if err != nil {
+		return err
+	}
+
 	clientset, err := f.KubernetesClientSet()
 	if err != nil {
 		return err
@@ -337,7 +344,7 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 
 	// Create role.
 	if !o.DryRun {
-		role, err = o.Client.Roles(o.Namespace).Create(role)
+		role, err = o.Client.RolesWithMultiTenancy(o.Namespace, o.Tenant).Create(role)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -2779,6 +2779,7 @@ func (d *ClusterRoleDescriber) Describe(tenant, namespace, name string, describe
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", role.Name)
+		w.Write(LEVEL_0, "Tenant:\t%s\n", role.Tenant)
 		printLabelsMultiline(w, "Labels", role.Labels)
 		printAnnotationsMultiline(w, "Annotations", role.Annotations)
 
@@ -2857,6 +2858,7 @@ func (d *ClusterRoleBindingDescriber) Describe(tenant, namespace, name string, d
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", binding.Name)
+		w.Write(LEVEL_0, "Tenant:\t%s\n", binding.Tenant)
 		printLabelsMultiline(w, "Labels", binding.Labels)
 		printAnnotationsMultiline(w, "Annotations", binding.Annotations)
 


### PR DESCRIPTION
This PR fixes issues https://github.com/futurewei-cloud/arktos/issues/631 and https://github.com/futurewei-cloud/arktos/issues/641

### Verfication that bug 631 is fixed
"--tenant" option is working with "kubectl create cronjob". The resource created will be under the expected tenant. 

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create cronjob test-cronjob --image=busybox --schedule="*/1 * * * *" --tenant x
cronjob.batch/test-cronjob created
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get cronjob -AT
TENANT   NAMESPACE   NAME           SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
x        default     test-cronjob   */1 * * * *   False     0        <none>          8s
```
"--tenant" option is working with "kubectl create role". The resource created will be under the expected tenant. 
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create role test-role --verb=get --resource=pods --tenant x
role.rbac.authorization.k8s.io/test-role created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get roles -AT
TENANT   NAMESPACE     NAME                                             AGE
...
x        default       test-role                                        27s
```

"--tenant" option is working with "kubectl create clusterrole". The resource created will be under the expected tenant. 

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create clusterrole test-clusterrole --verb=get --resource=pods --tenant x
clusterrole.rbac.authorization.k8s.io/test-clusterrole created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get clusterroles -AT
TENANT   NAME                                                                   AGE
...
x        admin-role                                                             7m12s
x        test-clusterrole                                                       17s

```

### Verfication that bug 641 is fixed
The output of "kubectl describe clusterrole" and "kubectl describe clusterrolebinding" now include the tenant information.
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl describe clusterrole test-clusterrole --tenant x
Name:         test-clusterrole
Tenant:       x
Labels:       <none>
Annotations:  <none>
PolicyRule:
  Resources  Non-Resource URLs  Resource Names  Verbs
  ---------  -----------------  --------------  -----
  pods       []                 []              [get]

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl describe  clusterrolebindings admin-role-binding --tenant x
Name:         admin-role-binding
Tenant:       x
Labels:       <none>
Annotations:  <none>
Role:
  Kind:  ClusterRole
  Name:  admin-role
Subjects:
  Kind  Name   Namespace
  ----  ----   ---------
  User  admin 
```