### PR TITLE
update setup_client.sh for e2e tests

### DIFF
--- a/hack/setup-multi-tenancy/setup_client.sh
+++ b/hack/setup-multi-tenancy/setup_client.sh
@@ -14,51 +14,101 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+print_help() {
+        echo "This is a tool to manage user context in multi-tenancy Arktos cluster. "
+        echo 
+        echo "To set up a context for a person under a given tenant:"
+        echo "  setup_client.sh [tenant] [person] (optional [apiserver ip])"
+        echo 
+        echo "By default, the key and cert files will be saved under /tmp."
+        echo "To save them in a different location:"
+        echo "  OUTPUT_DIR=[desired_path] setup_client.sh [tenant] [person] (optional [apiserver ip])"
+        echo 
+        echo "To remove the context set up for a person under a given tenant:"
+        echo "  REMOVE=TRUE setup_client.sh [tenant] [person]"
+}
 
-set -e
+run_command() {
+        command="$@"
+        $command > /dev/null 2> ${tmpfile}
+        if [[ $? != 0 ]] 
+        then 
+                printf "\033[0;31mFailed: ${command}\n"
+                printf "$(cat ${tmpfile})\033[0m\n"
+                let failures+=1
+        fi
+}
 
-if [ "$#" -lt 2 ]
+setup_client() {
+        echo "setting up context ${context_name} for ${tenant}/${person} in group $group_name at apiserver $ip"
+        echo "generating a client key ${tenant}.key..."
+        run_command openssl genrsa -out ${output_dir}/${tenant_person}.key 2048
+
+        echo "creating a sign request ${tenant}.csr..."
+        run_command openssl req -new -key ${output_dir}/${tenant_person}.key -out ${output_dir}/${tenant}.csr -subj "/CN=${person}/O=tenant:${tenant}/OU=$group_name"
+
+        echo "creating an tenant certificate ${tenant_person}.crt and get it signed by CA"
+        run_command openssl x509 -req -in ${output_dir}/${tenant}.csr -CA /var/run/kubernetes/client-ca.crt -CAkey /var/run/kubernetes/client-ca.key -CAcreateserial -out ${output_dir}/${tenant_person}.crt -days 500
+
+        echo "Setting up tenant context..."
+        run_command kubectl config set-cluster ${cluster_name} --server=https://$ip:6443 --certificate-authority=/var/run/kubernetes/server-ca.crt 
+        run_command kubectl config set-credentials ${tenant_person} --client-certificate=${output_dir}/${tenant_person}.crt --client-key=${output_dir}/${tenant_person}.key
+        run_command kubectl config set-context ${context_name} --cluster=${cluster_name} --namespace=${namespace} --user=${tenant_person} --tenant=${tenant}
+        
+        echo "cleaned up ${tenant}.csr"
+        rm ${output_dir}/${tenant}.csr
+
+        echo "***************************"
+        echo "Context has been setup for tenant ${tenant}/${person} in $CONFIG." 
+        echo
+        echo "Use 'kubectl config use-context ${context_name}' to set it as the default context"
+        echo
+        echo "Here's an example on how to access cluster:"
+        echo
+        set -x
+        kubectl --context=${context_name} get pods
+        { set +x; } 2>/dev/null
+}
+
+unset_client() {
+        echo "removing client key and cert files of ${tenant}/${person} ..."
+        files_to_rm=`kubectl config view -o json | jq -r --arg name "${tenant_person}" '.users[] | select(.name==$name).user | [ .["client-key"], .["client-certificate"]] | @tsv' `
+        rm $files_to_rm > /dev/null 2>&1
+
+        echo "Unsetting the context of ${tenant}/${person} in $CONFIG ..."
+        run_command kubectl config unset contexts.${context_name} 
+        run_command kubectl config unset users.${tenant_person}
+        run_command kubectl config unset clusters.${cluster_name}
+}
+
+if [ "$#" -lt 2 ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]
 then
-        echo "Usage: setup_client.sh [tenant] [person] (optional [host ip])"
+        print_help
         exit 1
 fi
 
 tenant=$1
 person=$2
+ip=${3:-localhost}
+output_dir=${OUTPUT_DIR:-"/tmp/"}
 namespace="default"
 tenant_person="${tenant}-${person}"
 group_name="${tenant}-group"
 context_name="${tenant_person}-context"
-ip=${3:-localhost}
-echo "setting up context $context_name for $tenant/$person in group $group_name at host $ip"
+cluster_name="${tenant_person}-cluster"
+
+failures=0
+tmpfile="/tmp/temp$(date +'%Y%m%d%H%M%s')"
 
 CONFIG=/var/run/kubernetes/admin.kubeconfig
-#if [ -f "$CONFIG" ]; then
-#    echo "making a backup of previous config at $CONFIG.bk"
-#    mv $CONFIG $CONFIG.bk
-#fi
+REMOVE=${REMOVE:-"FALSE"}
 
-echo "generating a client key $tenant.key..."
-openssl genrsa -out $tenant_person.key 2048 > /dev/null 2>&1
+if [ "${REMOVE}" == "TRUE" ]
+then
+        unset_client
+else
+        setup_client
+fi
 
-echo "creating a sign request $tenant.csr..."
-openssl req -new -key $tenant_person.key -out $tenant.csr -subj "/CN=$person/O=tenant:$tenant/OU=$group_name" > /dev/null 2>&1
-
-echo "creating an tenant certificate ${tenant_person}.crt and get it signed by CA"
-openssl x509 -req -in $tenant.csr -CA /var/run/kubernetes/client-ca.crt -CAkey /var/run/kubernetes/client-ca.key -CAcreateserial -out $tenant_person.crt -days 500 > /dev/null 2>&1
-
-echo "Setting up tenant context..."
-kubectl config set-cluster ${tenant_person}-cluster --server=https://$ip:6443 --certificate-authority=/var/run/kubernetes/server-ca.crt > /dev/null 2>&1
-kubectl config set-credentials ${tenant_person} --client-certificate=$tenant_person.crt --client-key=$tenant_person.key > /dev/null 2>&1
-kubectl config set-context $context_name --cluster=${tenant_person}-cluster --namespace=$namespace --user=$tenant_person --tenant=$tenant > /dev/null 2>&1
-echo "cleaned up $tenant.csr"
-rm $tenant.csr
-echo "***************************"
-echo "Context has been setup for tenant $tenant/$person in $CONFIG." 
-echo
-echo "Use 'kubectl use-context $context_name' to set it as the default context"
-echo
-echo "Here's an example on how to access cluster:"
-echo
-set -x
-kubectl --context=${context_name} get pods
+rm ${tmpfile} > /dev/null 2>&1
+exit $failures


### PR DESCRIPTION
This PR is part of work for multi-tenancy e2e tests (https://github.com/futurewei-cloud/arktos/issues/648). It updates the tool of kube config per the requirements of multi-tenancy e2e tests.

### The changes made:
1. Add the ability to remove the context setup. So the contexts created during the e2e tests can be cleaned up.
2. The location of the client key and cert files are moved from pwd to /tmp. This helps keep the repo clean. 
The user is also able to customize the location of the client key and cert files now.
3. Return an non-zero exit code if there are errors. Also, the error messages will be printed.
4. update the help message based on the above changes. 

### Verification
1. The same command line as now to create user context
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl config view
apiVersion: v1
clusters: []
contexts: []
current-context: ""
kind: Config
preferences: {}
users: []

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ hack/setup-multi-tenancy/setup_client.sh aaa admin
setting up context aaa-admin-context for aaa/admin in group aaa-group at apiserver localhost
generating a client key aaa.key...
creating a sign request aaa.csr...
creating an tenant certificate aaa-admin.crt and get it signed by CA
Setting up tenant context...
cleaned up aaa.csr
***************************
Context has been setup for tenant aaa/admin in /var/run/kubernetes/admin.kubeconfig.

Use 'kubectl config use-context aaa-admin-context' to set it as the default context

Here's an example on how to access cluster:

+ kubectl --context=aaa-admin-context get pods
No resources found.
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ echo $?
0
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl config view
apiVersion: v1
clusters:
- cluster:
    certificate-authority: /var/run/kubernetes/server-ca.crt
    server: https://localhost:6443
  name: aaa-admin-cluster
contexts:
- context:
    cluster: aaa-admin-cluster
    namespace: default
    tenant: aaa
    user: aaa-admin
  name: aaa-admin-context
current-context: ""
kind: Config
preferences: {}
users:
- name: aaa-admin
  user:
    client-certificate: /tmp/aaa-admin.crt
    client-key: /tmp/aaa-admin.key
```

2. The script now can remove the contexts if "REMOVE=TRUE" is prepend to to the command line.

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ REMOVE=TRUE hack/setup-multi-tenancy/setup_client.sh aaa admin
removing client key and cert files of aaa/admin ...
Unsetting the context of aaa/admin in /var/run/kubernetes/admin.kubeconfig ...

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ echo $?
0

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ ls /tmp/aaa-admin.*
ls: cannot access '/tmp/aaa-admin.*': No such file or directory

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl config view
apiVersion: v1
clusters: []
contexts: []
current-context: ""
kind: Config
preferences: {}
users: []
```

3. The script also allows the user to customize the key and cerf file location if prepending "OUTPUT_DIR=###"

```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ OUTPUT_DIR=~ hack/setup-multi-tenancy/setup_client.sh aaa admin
setting up context aaa-admin-context for aaa/admin in group aaa-group at apiserver localhost
generating a client key aaa.key...
creating a sign request aaa.csr...
creating an tenant certificate aaa-admin.crt and get it signed by CA
Setting up tenant context...
cleaned up aaa.csr
***************************
Context has been setup for tenant aaa/admin in /var/run/kubernetes/admin.kubeconfig.

Use 'kubectl config use-context aaa-admin-context' to set it as the default context

Here's an example on how to access cluster:

+ kubectl --context=aaa-admin-context get pods
No resources found.
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl config view
apiVersion: v1
clusters:
- cluster:
    certificate-authority: /var/run/kubernetes/server-ca.crt
    server: https://localhost:6443
  name: aaa-admin-cluster
contexts:
- context:
    cluster: aaa-admin-cluster
    namespace: default
    tenant: aaa
    user: aaa-admin
  name: aaa-admin-context
current-context: ""
kind: Config
preferences: {}
users:
- name: aaa-admin
  user:
    client-certificate: /home/qianchen/aaa-admin.crt
    client-key: /home/qianchen/aaa-admin.key
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ hack/setup-multi-tenancy/setup_client.sh aaa admin^C
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ ls /home/qianchen/aaa-admin*
/home/qianchen/aaa-admin.crt  /home/qianchen/aaa-admin.key
```

4. When error occurs, the error message will be printed and the exit code is non-zero.

Intenttionally put a typo in the command to create a break. The following is the screenshot. 

![image](https://user-images.githubusercontent.com/51831990/91939010-e8f1a480-eca9-11ea-9d77-82af5e1d95c6.png)

