### PR TITLE
[Mizar-Network-Controller] - implemented controllers for node, servic…

### DIFF
--- a/cmd/mizar-controller-manager/controllers/arktos_nw_controller.go
+++ b/cmd/mizar-controller-manager/controllers/arktos_nw_controller.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Reference: https://github.com/h-w-chen/arktos.git, arktos/cmd/arktos-network-controller
+*/
+
+package app
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	arktos "k8s.io/arktos-ext/pkg/generated/clientset/versioned"
+	arktoscheme "k8s.io/arktos-ext/pkg/generated/clientset/versioned/scheme"
+	arktosinformer "k8s.io/arktos-ext/pkg/generated/informers/externalversions/arktosextensions/v1"
+	arktosv1 "k8s.io/arktos-ext/pkg/generated/listers/arktosextensions/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+)
+
+type Controller struct {
+	domainName   string
+	cacheSynced  cache.InformerSynced
+	store        arktosv1.NetworkLister
+	queue        workqueue.RateLimitingInterface
+	netClientset *arktos.Clientset
+	svcClientset *kubernetes.Clientset
+	recorder     record.EventRecorder
+}
+
+func NewArktosNetworkController(domainName string, netClientset *arktos.Clientset, svcClientset *kubernetes.Clientset, informer arktosinformer.NetworkInformer) *Controller {
+	utilruntime.Must(arktoscheme.AddToScheme(scheme.Scheme))
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: svcClientset.CoreV1().EventsWithMultiTenancy(metav1.NamespaceAll, metav1.TenantAll)})
+
+	return &Controller{
+		domainName:   domainName,
+		store:        informer.Lister(),
+		queue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		cacheSynced:  informer.Informer().HasSynced,
+		netClientset: netClientset,
+		svcClientset: svcClientset,
+		recorder:     eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "flat-network-controller"}),
+	}
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(object interface{}) {
+			fmt.Println("Arktos Network Added")
+		},
+		UpdateFunc: func(oldObject, newObject interface{}) {
+			fmt.Println("Arktos Network Updated")
+		},
+	})
+	return c, nil
+}
+
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+	klog.Info("starting flat network controller")
+	klog.V(5).Info("waiting for informer caches to sync")
+	if !cache.WaitForCacheSync(stopCh, c.cacheSynced) {
+		klog.Error("failed to wait for cache to sync")
+		return
+	}
+	klog.V(5).Info("staring workers of flat network controller")
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+	klog.V(5).Infof("%d workers started", workers)
+	<-stopCh
+	klog.Info("shutting down flat network controller")
+}
+
+func (c *Controller) runWorker() {
+	for {
+		item, queueIsEmpty := c.queue.Get()
+		if queueIsEmpty {
+			break
+		}
+		c.process(item)
+	}
+}
+
+func (c *Controller) process(item interface{}) {
+	defer c.workqueue.Done(item)
+	c.workqueue.Forget(item)
+}

--- a/cmd/mizar-controller-manager/controllers/node_controller.go
+++ b/cmd/mizar-controller-manager/controllers/node_controller.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+)
+
+type Controller struct {
+	kubeclientset  *kubernetes.Clientset
+	informer       coreinformers.NodeInformer
+	informerSynced cache.InformerSynced
+	lister         corelisters.NodeLister
+	recorder       record.EventRecorder
+	workqueue      workqueue.RateLimitingInterface
+}
+
+func NewNodeController(kubeclientset *kubernetes.Clientset, nodeInformer coreinformers.NodeInformer) (*Controller, error) {
+	informer := nodeInformer
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "mizar-node-controller"})
+	eventBroadcaster.StartLogging(klog.Infof)
+	klog.Infof("Sending events to api server.")
+	eventBroadcaster.StartRecordingToSink(
+		&v1core.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
+	workqueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	c := &Controller{
+		kubeclientset:  kubeclientset,
+		informer:       informer,
+		informerSynced: informer.Informer().HasSynced,
+		lister:         informer.Lister(),
+		recorder:       recorder,
+		workqueue:      workqueue,
+	}
+
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(object interface{}) {
+			fmt.Println("Node Added")
+		},
+		UpdateFunc: func(oldObject, newObject interface{}) {
+			fmt.Println("Node Updated")
+		},
+	})
+	return nc, nil
+}
+
+// Run starts an asynchronous loop that monitors the status of cluster nodes.
+func (nc *Controller) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer nc.workqueue.ShutDown()
+	klog.Infof("Starting node controller")
+	klog.Infoln("Waiting cache to be synced.")
+	if ok := cache.WaitForCacheSync(stopCh, nc.informerSynced); !ok {
+		klog.Fatalln("Timeout expired during waiting for caches to sync.")
+	}
+	klog.Infoln("Starting custom controller.")
+	for i := 0; i < workers; i++ {
+		go wait.Until(nc.runWorker, time.Second, stopCh)
+	}
+	<-stopCh
+	klog.Info("shutting down node controller")
+}
+
+func (nc *Controller) runWorker() {
+	for {
+		item, queueIsEmpty := nc.workqueue.Get()
+		if queueIsEmpty {
+			break
+		}
+		nc.process(item)
+	}
+}
+
+func (nc *Controller) process(item interface{}) {
+	defer nc.workqueue.Done(item)
+	nc.workqueue.Forget(item)
+}

--- a/cmd/mizar-controller-manager/controllers/service_controller.go
+++ b/cmd/mizar-controller-manager/controllers/service_controller.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+)
+
+type Controller struct {
+	kubeclientset  *kubernetes.Clientset
+	informer       coreinformers.ServiceInformer
+	informerSynced cache.InformerSynced
+	lister         corelisters.ServiceLister
+	recorder       record.EventRecorder
+	workqueue      workqueue.RateLimitingInterface
+}
+
+func NewServiceController(kubeclientset *kubernetes.Clientset, serviceInformer coreinformers.ServiceInformer) (*Controller, error) {
+	informer := serviceInformer
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "mizar-service-controller"})
+	eventBroadcaster.StartLogging(klog.Infof)
+	klog.Infof("Sending events to api server.")
+	eventBroadcaster.StartRecordingToSink(
+		&v1core.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
+	workqueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	c := &Controller{
+		kubeclientset:  kubeclientset,
+		informer:       informer,
+		informerSynced: informer.Informer().HasSynced,
+		lister:         informer.Lister(),
+		recorder:       recorder,
+		workqueue:      workqueue,
+	}
+
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(object interface{}) {
+			fmt.Println("Service Added")
+		},
+		UpdateFunc: func(oldObject, newObject interface{}) {
+			fmt.Println("Service Updated")
+		},
+	})
+	return c, nil
+}
+
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.workqueue.ShutDown()
+	klog.Infof("Starting node controller")
+	klog.Infoln("Waiting cache to be synced.")
+	if ok := cache.WaitForCacheSync(stopCh, nc.informerSynced); !ok {
+		klog.Fatalln("Timeout expired during waiting for caches to sync.")
+	}
+	klog.Infoln("Starting custom controller.")
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+	<-stopCh
+	klog.Info("shutting down node controller")
+}
+
+func (c *Controller) runWorker() {
+	for {
+		item, queueIsEmpty := nc.workqueue.Get()
+		if queueIsEmpty {
+			break
+		}
+		c.process(item)
+	}
+}
+
+func (c *Controller) process(item interface{}) {
+	defer c.workqueue.Done(item)
+	c.workqueue.Forget(item)
+}


### PR DESCRIPTION
- This PR presents 2 built-in object controllers  and one crd object controller for integrating Arktos and Mizar systems.
(1) Node: built-in kubernetes object such as a virtual or physical machine of a cluster.
(2) Service: built-in kubernetes service object
(3) Arktos Network: arktos' custom network resource

- Major functions of controllers (currently partially implemented and will be updated soon)
 (1) Controllers detect objects' events such as add, update, delete, and resume.
 (2) Controllers send the events information to Mizar operator using gRPC protocols





