### PR TITLE
Multi tenancy/admission e2e tests

### DIFF
--- a/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
+++ b/test/e2e/arktos/multi_tenancy/run-e2e-test.sh
@@ -23,9 +23,10 @@ script_root=$(dirname "${BASH_SOURCE}")
 repo_root=$(cd $(dirname $0)/../../../.. ; pwd)
 
 #put the test suite file patterns below, one line one suite. The test suites will be run in the order defined.
-test_suite_files="multi_tenancy_controller/test_*_controller.yaml \
-				  tenant_init_delete_test.yaml \
-				  misc/test_*.yaml"
+test_suite_files="tenant_init_delete_test.yaml
+                  multi_tenancy_controller/test_*_controller.yaml \
+                  admission/test_*.yaml \
+                  misc/test_*.yaml"
 test_suite_file_directory=${repo_root}/test/e2e/arktos/multi_tenancy/test_suites/
 
 # The values of timeouts and retry intervals are in the unit of second

--- a/test/e2e/arktos/multi_tenancy/test_suites/admission/test_cross_tenant.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/admission/test_cross_tenant.yaml
@@ -1,0 +1,76 @@
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Cross Tenant Tests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# This test suite verifies that:
+# 1. Regular Tenants can NOT visit cross-tenant resources
+# 2. System Tenant can visit resources of regular tenants
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################
+# test variables
+######################################################
+Variables:
+  first_tenant: random_8
+  second_tenant: random_8
+
+###########################################################################################################
+# test setup
+###########################################################################################################
+Tests:
+  - BeforeTestMessage: Starting test setup ...
+    Command: ${kubectl} create tenant ${first_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${first_tenant} created\n"
+
+  - Command: ${setup_client_script} ${first_tenant} admin
+
+  - Command: ${kubectl} create tenant ${second_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${second_tenant} created\n"
+
+  - Command: ${setup_client_script} system admin
+
+###########################################################################################################
+# Verifying test cross-tenant access is not allowed for reuglar tenants
+###########################################################################################################
+  - BeforeTestMessage: Verifying test cross-tenant access is not allowed for reuglar tenants ...
+    Command: ${kubectl} get ns --tenant ${second_tenant} --context ${first_tenant}-admin-context
+    ShouldFail: true
+    OutputShouldContain: 
+    - "Error from server (Forbidden): namespaces is forbidden"
+    - "cannot list resource \"namespaces\" in API group \"\" in the tenant \"${second_tenant}\"\n"
+
+  - Command: ${kubectl} get ns --tenant system --context ${first_tenant}-admin-context
+    ShouldFail: true
+    OutputShouldContain: 
+    - "Error from server (Forbidden): namespaces is forbidden"
+    - "cannot list resource \"namespaces\" in API group \"\" in the tenant \"system\"\n"
+
+###########################################################################################################
+# Verifying ystem Tenant can visit resources of any tenant
+###########################################################################################################
+  - BeforeTestMessage: Verifying ystem Tenant can visit resources of any tenant ...
+    Command: "${kubectl} get ns --tenant ${second_tenant} --context system-admin-context -o json 
+             | jq -r '.items[] | [.metadata.name] | @tsv'"
+    OutputShouldContain: 
+    - "default\n"
+    - "kube-system\n"
+
+
+  - Command: "${kubectl} get ns --tenant system --context system-admin-context -o json 
+             | jq -r '.items[] | [.metadata.name] | @tsv'"
+    OutputShouldContain: 
+    - "default\n"
+    - "kube-system\n"
+    - "kube-node-lease\n"
+
+######################################################################################################
+# cleanup
+######################################################################################################
+  - Command: ${kubectl} delete tenant ${first_tenant} > /dev/null 2>&1 &
+
+  - Command: ${kubectl} delete tenant ${second_tenant} > /dev/null 2>&1 &
+
+  - Command: REMOVE=TRUE ${setup_client_script} ${first_tenant} admin
+
+  - Command: REMOVE=TRUE ${setup_client_script} system admin
+
+

--- a/test/e2e/arktos/multi_tenancy/test_suites/admission/test_cross_tenant.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/admission/test_cross_tenant.yaml
@@ -38,6 +38,7 @@ Tests:
     - "Error from server (Forbidden): namespaces is forbidden"
     - "cannot list resource \"namespaces\" in API group \"\" in the tenant \"${second_tenant}\"\n"
 
+# This test makes sure bug 393 is fixed
   - Command: ${kubectl} get ns --tenant system --context ${first_tenant}-admin-context
     ShouldFail: true
     OutputShouldContain: 
@@ -45,9 +46,9 @@ Tests:
     - "cannot list resource \"namespaces\" in API group \"\" in the tenant \"system\"\n"
 
 ###########################################################################################################
-# Verifying ystem Tenant can visit resources of any tenant
+# Verifying system Tenant can visit resources of any tenant
 ###########################################################################################################
-  - BeforeTestMessage: Verifying ystem Tenant can visit resources of any tenant ...
+  - BeforeTestMessage: Verifying system Tenant can visit resources of any tenant ...
     Command: "${kubectl} get ns --tenant ${second_tenant} --context system-admin-context -o json 
              | jq -r '.items[] | [.metadata.name] | @tsv'"
     OutputShouldContain: 

--- a/test/e2e/arktos/multi_tenancy/test_suites/admission/test_tenant_exists.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/admission/test_tenant_exists.yaml
@@ -1,0 +1,47 @@
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tenant Admission Controller Tests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# This test suite verifies that resources in a tenant space cannot be created before the tenant is created 
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################
+# Configure the test variables for this test suite
+######################################################
+Variables:
+  test_ns: random_8
+  test_tenant: random_8
+
+############################################################################################################
+# Verifies that resources in a tenant space cannot be created before the tenant is created 
+############################################################################################################
+Tests:
+  - BeforeTestMessage: Verifies that resources in a tenant space cannot be created before the tenant is created
+    Command: ${kubectl} create namespace ${test_ns} --tenant ${test_tenant}
+    ShouldFail: true
+    OutputShouldContain:
+    - "Error from server (NotFound):"
+    - "tenants \"${test_tenant}\" not found\n"
+
+  - Command: ${kubectl} apply -f ${test_data_dir}/sample-pod.yaml -n ${test_ns} --tenant ${test_tenant} 
+    ShouldFail: true
+    OutputShouldContain:
+    - "Error from server (NotFound):"
+    - "tenants \"${test_tenant}\" not found\n"
+    
+############################################################################################################
+# Verifies that resources in a tenant space cab be created after the tenant is created 
+############################################################################################################
+  - BeforeTestMessage: Verifies that resources in a tenant space cab be created after the tenant is created
+    Command: ${kubectl} create tenant ${test_tenant}
+    OutputShouldContain: 
+    - "\ntenant/${test_tenant} created\n"
+
+  - Command: ${kubectl} create namespace ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "namespace/${test_ns} created\n"
+
+  - Command: ${kubectl} apply -f ${test_data_dir}/sample-pod.yaml -n ${test_ns} --tenant ${test_tenant}
+    OutputShouldBe: "pod/sample-nginx-pod created\n"
+
+######################################################################################################
+# cleanup
+######################################################################################################
+  - BeforeTestMessage: clean up ...
+    Command: ${kubectl} delete tenant ${test_tenant} > /dev/null 2>&1 &

--- a/test/e2e/arktos/multi_tenancy/testdata/sample-pod.yaml
+++ b/test/e2e/arktos/multi_tenancy/testdata/sample-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sample-nginx-pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.7.9
+    ports:
+    - containerPort: 80
+


### PR DESCRIPTION
This PR adds the following e2e test suites for multi-tenancy admission controller:
1. test TenantExists admission controller
2. test cross-tenant is banned for regular tenants and works for system tenants

Verification:
All tests passed locally in my dev box.

Tracking work item: https://github.com/futurewei-cloud/arktos/issues/648