### PR TITLE
kubelet starts pod after network is ready and dns service has IP assigned

### DIFF
--- a/pkg/kubelet/network/dns/BUILD
+++ b/pkg/kubelet/network/dns/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//staging/src/k8s.io/arktos-ext/pkg/apis/arktosextensions/v1:go_default_library",
         "//staging/src/k8s.io/arktos-ext/pkg/generated/clientset/versioned/typed/arktosextensions/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2:go_default_library",

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -88,7 +88,7 @@ func NewConfigurer(recorder record.EventRecorder, nodeRef *v1.ObjectReference, n
 func (c *Configurer) getClusterDNS(pod *v1.Pod) ([]net.IP, error) {
 	// todo: consider using exported const of default network name from arktos package
 	const defaultNetwork = "default"
-	networkName, ok := pod.Labels["arktos.futurewei.com/network"]
+	networkName, ok := pod.Labels[arktosv1.NetworkLabel]
 	if !ok {
 		networkName = defaultNetwork
 	}

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -379,7 +379,7 @@ func (c *Configurer) GetPodDNS(pod *v1.Pod) (*runtimeapi.DNSConfig, error) {
 	case podDNSCluster:
 		var clusterDNS []net.IP
 		if clusterDNS, err = c.getClusterDNS(pod); err != nil {
-			return nil, fmt.Errorf("failed to get DNS IP add: %v", err)
+			return nil, fmt.Errorf("failed to get DNS IP address: %v", err)
 		}
 
 		if len(clusterDNS) != 0 {

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -62,7 +62,7 @@ func newTestConfigurer(recorder *record.FakeRecorder, nodeRef *v1.ObjectReferenc
 		},
 		Status: arktosv1.NetworkStatus{
 			DNSServiceIP: dnsVIPOfTestNetwork,
-			Phase: "Ready",
+			Phase:        "Ready",
 		},
 	})
 	return NewConfigurer(recorder, nodeRef, nil, clusterDNS, testClusterDNSDomain, resolverConfig, networkClient.ArktosV1())
@@ -504,15 +504,15 @@ func TestGetPodDNS(t *testing.T) {
 func TestGetPodDNSWithNotReadyNetwork(t *testing.T) {
 	recorder := record.NewFakeRecorder(20)
 	nodeRed := &v1.ObjectReference{
-		Kind:            "Node",
-		Name:            string("testNode"),
-		UID:             types.UID("testNode"),
+		Kind: "Node",
+		Name: string("testNode"),
+		UID:  types.UID("testNode"),
 	}
 	configurer := newTestConfigurerWithNotReadyNetwork(recorder, nodeRed, nil, "test.domain", "")
 
 	pods := newTestPods(1)
 	pods[0].Spec.DNSPolicy = v1.DNSClusterFirst
-	pods[0].Spec.HostNetwork  =false
+	pods[0].Spec.HostNetwork = false
 
 	_, err := configurer.GetPodDNS(pods[0])
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
this PR ensures the pod's associated network is of ready state, and the dns service has IP address assigned.

**Does this PR introduce a user-facing change?**:
NONE