### PR TITLE
hollow-node initializes arktos kube-client

### DIFF
--- a/cmd/kubemark/BUILD
+++ b/cmd/kubemark/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/arktos-ext/pkg/generated/clientset/versioned:go_default_library",
         "//staging/src/k8s.io/client-go/datapartition:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -34,6 +34,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	arktos "k8s.io/arktos-ext/pkg/generated/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -54,7 +55,6 @@ import (
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 	fakeexec "k8s.io/utils/exec/testing"
-	arktos "k8s.io/arktos-ext/pkg/generated/clientset/versioned"
 )
 
 type hollowNodeConfig struct {

--- a/pkg/kubemark/BUILD
+++ b/pkg/kubemark/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/arktos-ext/pkg/generated/clientset/versioned:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -22,7 +22,9 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	arktosCientset "k8s.io/arktos-ext/pkg/generated/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 	kubeletapp "k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	"k8s.io/kubernetes/pkg/kubelet"
@@ -39,8 +41,6 @@ import (
 	"k8s.io/kubernetes/pkg/volume/secret"
 	"k8s.io/kubernetes/pkg/volume/util/subpath"
 	"k8s.io/kubernetes/test/utils"
-
-	"k8s.io/klog"
 )
 
 type HollowKubelet struct {
@@ -53,10 +53,13 @@ func NewHollowKubelet(
 	flags *options.KubeletFlags,
 	config *kubeletconfig.KubeletConfiguration,
 	client *clientset.Clientset,
+	arktosClient arktosCientset.Interface,
 	heartbeatClient *clientset.Clientset,
 	cadvisorInterface cadvisor.Interface,
 	dockerClientConfig *dockershim.ClientConfig,
 	containerManager cm.ContainerManager) *HollowKubelet {
+
+
 	// -----------------
 	// Injected objects
 	// -----------------
@@ -65,6 +68,7 @@ func NewHollowKubelet(
 	volumePlugins = append(volumePlugins, projected.ProbeVolumePlugins()...)
 	d := &kubelet.Dependencies{
 		KubeClient:         client,
+		ArktosExtClient:    arktosClient,
 		HeartbeatClient:    heartbeatClient,
 		DockerClientConfig: dockerClientConfig,
 		CAdvisorInterface:  cadvisorInterface,

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -58,8 +58,6 @@ func NewHollowKubelet(
 	cadvisorInterface cadvisor.Interface,
 	dockerClientConfig *dockershim.ClientConfig,
 	containerManager cm.ContainerManager) *HollowKubelet {
-
-
 	// -----------------
 	// Injected objects
 	// -----------------


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
this PR ensures the arktos kubeclient initialized in hollow-node code path.

Hollow-node starts kubelet in a sort-of simplified way, which would bypass the initialization of arktos clientset object in _regular_ kubelet start code, which leads to nil reference panic in kubemark run. see error log as in next section

**Which issue(s) this PR fixes**:
```
0904 05:19:22.711084       6 file.go:68] Watching path "/tmp/hollow-kubelet.490124287/static-pods068816210"
I0904 05:19:22.711116       6 kubelet.go:315] Watching apiserver
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2fd4662]
 
goroutine 1 [running]:
k8s.io/kubernetes/pkg/kubelet.NewMainKubelet(0xc0005e5a80, 0xc000663e00, 0xc0005e5860, 0x3e80106, 0x6, 0x0, 0x0, 0x7ffedc6c0c30, 0x11, 0x0, ...)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go:500 +0xb52
k8s.io/kubernetes/cmd/kubelet/app.createAndInitKubelet(0xc0005e5a80, 0xc000663e00, 0xc0005e5860, 0x3e80106, 0x6, 0x0, 0x0, 0x7ffedc6c0c30, 0x11, 0x0, ...)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubelet/app/server.go:1177 +0x31a
k8s.io/kubernetes/cmd/kubelet/app.RunKubelet(0xc0005e5800, 0xc000663e00, 0xc000986500, 0xc0009aa380, 0xc0000c9f10)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubelet/app/server.go:1067 +0x67f
k8s.io/kubernetes/pkg/kubemark.(*HollowKubelet).Run(0xc00092b5e0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubemark/hollow_kubelet.go:90 +0xbe
main.run(0xc000510f00)
        _output/dockerized/go/src/k8s.io/kubernetes/cmd/kubemark/hollow-node.go:222 +0x5a4
main.newHollowNodeCommand.func1(0xc000241180, 0xc000570c00, 0x0, 0x6)
        _output/dockerized/go/src/k8s.io/kubernetes/cmd/kubemark/hollow-node.go:156 +0x39
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute(0xc000241180, 0xc0000e4010, 0x6, 0x6, 0xc000241180, 0xc0000e4010)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:760 +0x2ae
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000241180, 0x3ff6aa8, 0x72b9080, 0x2)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:846 +0x2ec
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute(...)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:794
main.main()
        _output/dockerized/go/src/k8s.io/kubernetes/cmd/kubemark/hollow-node.go:139 +0x105
```

**Does this PR introduce a user-facing change?**:
NONE