### PR TITLE
edgegateway gets certificates from cloudgatway

### DIFF
--- a/cmd/edgegateway/app/options/options.go
+++ b/cmd/edgegateway/app/options/options.go
@@ -94,7 +94,6 @@ func NewEdgeGatewayConfig() *v1.EdgeGatewayConfig {
 					Scheme: "https",
 					Host:   net.JoinHostPort(localIP, "10002"),
 				}).String(),
-				RotateCertificates: true,
 			},
 		},
 	}

--- a/pkg/apis/edgegateway/v1/types.go
+++ b/pkg/apis/edgegateway/v1/types.go
@@ -49,9 +49,6 @@ type EdgeHub struct {
 	WebSocket *EdgeHubWebSocket `json:"websocket,omitempty"`
 	// HTTPServer indicates the server for edge to apply for the certificate.
 	HTTPServer string `json:"httpServer,omitempty"`
-	// RotateCertificates indicates whether edge certificate can be rotated
-	// default true
-	RotateCertificates bool `json:"rotateCertificates,omitempty"`
 }
 
 // EdgeHubQUIC indicates the quic client config

--- a/pkg/cloudgateway/cloudhub/servers/httpserver/server.go
+++ b/pkg/cloudgateway/cloudhub/servers/httpserver/server.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2020 The KubeEdge Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package httpserver
 
 import (
@@ -71,38 +55,8 @@ func getCA(w http.ResponseWriter, r *http.Request) {
 	w.Write(caCertDER)
 }
 
-// edgeGatewayClientCert will verify the certificate of EdgeGateway or token then create EdgeGatewayCert and return it
+// edgeGatewayClientCert will create EdgeGatewayCert and return it
 func edgeGatewayClientCert(w http.ResponseWriter, r *http.Request) {
-	if cert := r.TLS.PeerCertificates; len(cert) > 0 {
-		if err := verifyCert(cert[0]); err != nil {
-			klog.Errorf("failed to sign the certificate for edge site: %s, failed to verify the certificate", r.Header.Get(NodeName))
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(err.Error()))
-			return
-		}
-	}
-	signEdgeCert(w, r)
-}
-
-// verifyCert verifies the edge certificate by CA certificate when edge certificates rotate.
-func verifyCert(cert *x509.Certificate) error {
-	roots := x509.NewCertPool()
-	ok := roots.AppendCertsFromPEM(pem.EncodeToMemory(&pem.Block{Type: certificateBlockType, Bytes: hubconfig.Config.Ca}))
-	if !ok {
-		return fmt.Errorf("failed to parse root certificate")
-	}
-	opts := x509.VerifyOptions{
-		Roots:     roots,
-		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	}
-	if _, err := cert.Verify(opts); err != nil {
-		return fmt.Errorf("failed to verify edge certificate: %v", err)
-	}
-	return nil
-}
-
-// signEdgeCert signs the CSR from EdgeGateway
-func signEdgeCert(w http.ResponseWriter, r *http.Request) {
 	csrContent, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		klog.Errorf("fail to read file when signing the cert for edge site:%s! error:%v", r.Header.Get(NodeName), err)

--- a/pkg/cloudgateway/cloudhub/servers/httpserver/signcerts.go
+++ b/pkg/cloudgateway/cloudhub/servers/httpserver/signcerts.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2020 The KubeEdge Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package httpserver
 
 import (

--- a/pkg/edgegateway/common/constants/default.go
+++ b/pkg/edgegateway/common/constants/default.go
@@ -7,6 +7,9 @@ const (
 	DefaultCertFile   = "/etc/edgegateway/certs/server.crt"
 	DefaultKeyFile    = "/etc/edgegateway/certs/server.key"
 
+	DefaultCAURL   = "/ca.crt"
+	DefaultCertURL = "/edge.crt"
+
 	DefaultHostnameOverride = "default-edge-site"
 	LocalIP                 = "127.0.0.1"
 )

--- a/pkg/edgegateway/edgehub/certificate/certmanager.go
+++ b/pkg/edgegateway/edgehub/certificate/certmanager.go
@@ -1,0 +1,163 @@
+package certificate
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io/ioutil"
+
+	"k8s.io/klog"
+	v1 "k8s.io/kubernetes/pkg/apis/edgegateway/v1"
+	"k8s.io/kubernetes/pkg/edgegateway/common/constants"
+	"k8s.io/kubernetes/pkg/edgegateway/edgehub/common/certutil"
+	"k8s.io/kubernetes/pkg/edgegateway/edgehub/common/http"
+)
+
+type CertManager struct {
+	CR       *x509.CertificateRequest
+	// the location to save certificate
+	caFile   string
+	certFile string
+	keyFile  string
+	// the url to get certificate from cloud
+	caURL   string
+	certURL string
+}
+
+func NewCertManager(edgehub v1.EdgeHub) CertManager {
+	certReq := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			Organization: []string{"Arktos"},
+			CommonName:   "arktos.io",
+		},
+	}
+	return CertManager{
+		CR:       certReq,
+		caFile:   edgehub.TLSCAFile,
+		certFile: edgehub.TLSCertFile,
+		keyFile:  edgehub.TLSPrivateKeyFile,
+		caURL:    edgehub.HTTPServer + constants.DefaultCAURL,
+		certURL:  edgehub.HTTPServer + constants.DefaultCertURL,
+	}
+}
+
+// start the CertManager
+func (cm *CertManager) Start() {
+	err := cm.checkCerts()
+	if err != nil {
+		err = cm.getCerts()
+		if err != nil {
+			klog.Fatalf("failed to get edge cert from cloud, err: %v", err)
+		}
+	}
+}
+
+// check if certificates exist
+func (cm *CertManager) checkCerts() error {
+	_, err := ioutil.ReadFile(cm.caFile)
+	if err != nil {
+		return fmt.Errorf("unable to find ca certificate, err: %v", err)
+	}
+	_, err = tls.LoadX509KeyPair(cm.certFile, cm.keyFile)
+	if err != nil {
+		return fmt.Errorf("unable to load certificate data, err: %v", err)
+	}
+	return nil
+}
+
+// get certificate from cloud
+func (cm *CertManager) getCerts() error {
+	// get the ca.crt
+	caCert, err := GetCACert(cm.caURL)
+	if err != nil {
+		return fmt.Errorf("failed to get CA certificate, err: %v", err)
+	}
+	// save the ca.crt to file
+	ca, err := x509.ParseCertificate(caCert)
+	if err != nil {
+		return fmt.Errorf("failed to parse the CA certificate, error: %v", err)
+	}
+	if err = certutil.WriteCert(cm.caFile, ca); err != nil {
+		return fmt.Errorf("failed to save the CA certificate to file: %s, error: %v", cm.caFile, err)
+	}
+
+	// get the edge.crt
+	pk, edgeCert, err := cm.GetEdgeCert(cm.certURL)
+	if err != nil {
+		return fmt.Errorf("failed to get edge certificate from the cloudgateway, error: %v", err)
+	}
+	// save the edge.crt to the file
+	cert, err := x509.ParseCertificate(edgeCert)
+	if err != nil {
+		return fmt.Errorf("failed to parse the edge certificate, error: %v", err)
+	}
+	if err = certutil.WriteKeyAndCert(cm.keyFile, cm.certFile, pk, cert); err != nil {
+		return fmt.Errorf("failed to save the edge key and certificate to file: %s, error: %v", cm.certFile, err)
+	}
+
+	return nil
+}
+
+// GetCACert gets the cloudGateway CA certificate
+func GetCACert(url string) ([]byte, error) {
+	client := http.NewHTTPClient()
+	res, err := http.SendRequest(client, url, nil, "GET")
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	caCert, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return caCert, nil
+}
+
+// GetEdgeCert applies for the certificate from cloudGateway
+func (cm *CertManager) GetEdgeCert(url string) (*ecdsa.PrivateKey, []byte, error) {
+	pk, csr, err := cm.getCSR()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create CSR: %v", err)
+	}
+
+	client := http.NewHTTPClient()
+	if err != nil {
+		return nil, nil, fmt.Errorf("falied to create http client: %v", err)
+	}
+
+	res, err := http.SendRequest(client, url, bytes.NewReader(csr), "GET")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to send http request: %v", err)
+	}
+	defer res.Body.Close()
+
+	content, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	if res.StatusCode != 200 {
+		return nil, nil, fmt.Errorf(string(content))
+	}
+
+	return pk, content, nil
+}
+
+func (cm *CertManager) getCSR() (*ecdsa.PrivateKey, []byte, error) {
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	csr, err := x509.CreateCertificateRequest(rand.Reader, cm.CR, pk)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pk, csr, nil
+}

--- a/pkg/edgegateway/edgehub/common/certutil/certfile.go
+++ b/pkg/edgegateway/edgehub/common/certutil/certfile.go
@@ -1,0 +1,66 @@
+package certutil
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"github.com/pkg/errors"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+)
+
+const (
+	// CertificateBlockType is a possible value for pem.Block.Type.
+	CertificateBlockType = "CERTIFICATE"
+)
+
+func WriteKeyAndCert(keyFile string, certFile string, key crypto.Signer, cert *x509.Certificate) error {
+	err := WriteKey(keyFile, key)
+	if err != nil {
+		return err
+	}
+	err = WriteCert(certFile, cert)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteKey stores the given key at the given location
+func WriteKey(pkiPath string, key crypto.Signer) error {
+	if key == nil {
+		return errors.New("private key cannot be nil when writing to file")
+	}
+
+	encoded, err := keyutil.MarshalPrivateKeyToPEM(key)
+	if err != nil {
+		return errors.Wrapf(err, "unable to marshal private key to PEM")
+	}
+	if err := keyutil.WriteKey(pkiPath, encoded); err != nil {
+		return errors.Wrapf(err, "unable to write private key to file %s", pkiPath)
+	}
+
+	return nil
+}
+
+// WriteCert stores the given certificate at the given location
+func WriteCert(certPath string, cert *x509.Certificate) error {
+	if cert == nil {
+		return errors.New("certificate cannot be nil when writing to file")
+	}
+
+	if err := certutil.WriteCert(certPath, EncodeCertPEM(cert)); err != nil {
+		return errors.Wrapf(err, "unable to write certificate to file %s", certPath)
+	}
+
+	return nil
+}
+
+// EncodeCertPEM returns PEM-endcoded certificate data
+func EncodeCertPEM(cert *x509.Certificate) []byte {
+	block := pem.Block{
+		Type:  CertificateBlockType,
+		Bytes: cert.Raw,
+	}
+	return pem.EncodeToMemory(&block)
+}

--- a/pkg/edgegateway/edgehub/common/http/http.go
+++ b/pkg/edgegateway/edgehub/common/http/http.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"k8s.io/klog"
+)
+
+var (
+	connectTimeout            = 30 * time.Second
+	keepaliveTimeout          = 30 * time.Second
+	responseReadTimeout       = 300 * time.Second
+	maxIdleConnectionsPerHost = 3
+)
+
+// NewHTTPClient create new client
+func NewHTTPClient() *http.Client {
+	transport := &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout:   connectTimeout,
+			KeepAlive: keepaliveTimeout,
+		}).Dial,
+		MaxIdleConnsPerHost:   maxIdleConnectionsPerHost,
+		ResponseHeaderTimeout: responseReadTimeout,
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+	}
+	klog.Infof("tlsConfig InsecureSkipVerify true")
+	return &http.Client{Transport: transport}
+}
+
+// SendRequest create and send a HTTP request, and return the resp info
+func SendRequest(client *http.Client, urlStr string, body io.Reader, method string) (*http.Response, error) {
+	req, err := http.NewRequest(method, urlStr, body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/pkg/edgegateway/edgehub/edgehub.go
+++ b/pkg/edgegateway/edgehub/edgehub.go
@@ -9,12 +9,14 @@ import (
 	"k8s.io/klog"
 	v1 "k8s.io/kubernetes/pkg/apis/edgegateway/v1"
 	"k8s.io/kubernetes/pkg/edgegateway/common/modules"
+	"k8s.io/kubernetes/pkg/edgegateway/edgehub/certificate"
 	"k8s.io/kubernetes/pkg/edgegateway/edgehub/clients"
 	"k8s.io/kubernetes/pkg/edgegateway/edgehub/config"
 )
 
 // EdgeHub defines edgehub object structure
 type EdgeHub struct {
+	certManager   certificate.CertManager
 	chClient      clients.Adapter
 	reconnectChan chan struct{}
 	keeperLock    sync.RWMutex
@@ -51,6 +53,10 @@ func (eh *EdgeHub) Enable() bool {
 
 // Start sets context and starts the controller
 func (eh *EdgeHub) Start() {
+	// manage certificate of edgeGateway
+	eh.certManager = certificate.NewCertManager(config.Config.EdgeHub)
+	eh.certManager.Start()
+
 	for {
 		select {
 		case <-beehiveContext.Done():


### PR DESCRIPTION
**What this PR does / why we need it**:

when edgegateway is started, edgegateway gets certificates from cloudgateway if the certificates don't exist.
then, edgegateway connects to cloudgateway through certificate.