### PR TITLE
Send on closed channel panic fix:

### DIFF
--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -173,7 +173,6 @@ func (c *fakeClient) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfa
 
 	aggWatcher.AddWatchInterface(watcher, nil)
 	c.watch = aggWatcher
-	c.watch.Stop()
 	return c.watch
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/watch/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/github.com/grafov/bcast:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -21,13 +21,11 @@ import (
 	"context"
 	"errors"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"reflect"
 	"sync"
 	"testing"
-	"time"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type testType string
@@ -212,8 +210,7 @@ func TestNewAggregatedWatcherWithReset(t *testing.T) {
 		go func(aggWatcher *AggregatedWatcher, i int) {
 			w := NewFake()
 			aggWatcher.AddWatchInterface(w, nil)
-			time.Sleep(10 * time.Millisecond)
-			aggWatcher.removeWatcherAndError(w)
+			w.Stop()
 			wg.Done()
 		}(aw, i)
 	}
@@ -221,8 +218,120 @@ func TestNewAggregatedWatcherWithReset(t *testing.T) {
 	wg.Wait()
 	assert.True(t, aw.allowWatcherReset)
 	assert.Nil(t, aw.GetErrors())
-	assert.Equal(t, 0, aw.GetWatchersCount())
 	assert.False(t, aw.stopped)
 	aw.Stop()
+	assert.Equal(t, 0, aw.GetWatchersCount())
 	assert.True(t, aw.stopped)
+}
+
+func TestProxyWatcherInAggegatedWatch(t *testing.T) {
+	events := []Event{
+		{Added, testType("foo")},
+		{Modified, testType("qux")},
+		{Modified, testType("bar")},
+		{Deleted, testType("bar")},
+		{Error, testType("error: blah")},
+	}
+
+	ch := make(chan Event, len(events))
+	w := NewProxyWatcher(ch)
+	aw := NewAggregatedWatcherWithOneWatch(w, nil)
+
+	var wg sync.WaitGroup
+	wg.Add(len(events))
+	go func() {
+		for _, e := range events {
+			ch <- e
+		}
+	}()
+
+	go func() {
+		for _, e := range events {
+			g := <-aw.ResultChan()
+			if !reflect.DeepEqual(e, g) {
+				t.Errorf("Expected %#v, got %#v", e, g)
+				continue
+			}
+			wg.Done()
+		}
+	}()
+
+	wg.Wait()
+	aw.Stop()
+	assert.True(t, aw.stopped)
+	assert.True(t, w.stopped)
+
+	// Test double close
+	aw.Stop()
+}
+
+// This is for the aggregated watch panic on timeout issue
+// 3 watch channels - two send events consistently, one send error after some events
+func TestAggregatedWatchOnError(t *testing.T) {
+	for m := 0; m < 100; m++ {
+		agg := NewAggregatedWatcher()
+
+		ch1 := make(chan Event)
+		ch2 := make(chan Event)
+		ch3 := make(chan Event)
+		w1 := NewProxyWatcher(ch1)
+		w2 := NewProxyWatcher(ch2)
+		w3 := NewProxyWatcher(ch3)
+
+		agg.AddWatchInterface(w1, nil)
+		agg.AddWatchInterface(w2, nil)
+		agg.AddWatchInterface(w3, nil)
+
+		var received bool
+		received = false
+		go func(rev *bool) {
+			for range agg.ResultChan() {
+				*rev = true
+			}
+		}(&received)
+
+		var wg sync.WaitGroup
+		var ch1Sent int
+		var ch2Sent int
+		var ch3Sent int
+		ch1Sent = 0
+		ch2Sent = 0
+		ch3Sent = 0
+		go func(sent *int) {
+			for i := 0; i < 1000; i++ {
+				ch1 <- Event{Added, testType("foo")}
+				*sent = *sent + 1
+			}
+		}(&ch1Sent)
+
+		go func(sent *int) {
+			for i := 0; i < 1000; i++ {
+				ch2 <- Event{Modified, testType("bar")}
+				*sent = *sent + 1
+			}
+		}(&ch2Sent)
+
+		wg.Add(1)
+		go func(sent *int) {
+			for i := 0; i < 10; i++ {
+				ch3 <- Event{Deleted, testType("qux")}
+				*sent = *sent + 1
+			}
+			wg.Done()
+		}(&ch3Sent)
+
+		wg.Wait()
+		agg.Stop()
+		t.Logf("Channel 1 scheduled to sent 1000 but sent %d", ch1Sent)
+		t.Logf("Channel 2 scheduled to sent 1000 but sent %d", ch2Sent)
+		assert.True(t, 1000 > ch1Sent)
+		assert.True(t, 1000 > ch2Sent)
+		assert.Equal(t, 10, ch3Sent)
+
+		assert.True(t, received)
+		assert.True(t, agg.stopped)
+		assert.True(t, w1.stopped)
+		assert.True(t, w2.stopped)
+		assert.True(t, w3.stopped)
+	}
 }

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -157,9 +157,11 @@ func (ag *Config) WatchUpdate() *bcast.Member {
 
 func (ag *Config) ToString() string {
 	text := ""
+	ag.mux.RLock()
 	for _, kubeConfig := range ag.config {
 		text += fmt.Sprintf("%#v", kubeConfig)
 	}
+	ag.mux.RUnlock()
 	return text
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -95,8 +95,8 @@ type Reflector struct {
 	// filterBounds are a list of list/watch filtering bounds
 	filterBounds []filterBound
 
-	// aggChan is the aggregate channel of reset channels
-	aggChan chan interface{}
+	// aggResetCh is the aggregate channel of reset channels
+	aggResetCh chan interface{}
 
 	// clientSetUpdateChan is the channel to get client set updates
 	clientSetUpdateChan *bcast.Member
@@ -159,7 +159,7 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 		resyncPeriod:            resyncPeriod,
 		clock:                   &clock.RealClock{},
 		filterBounds:            make([]filterBound, 0),
-		aggChan:                 make(chan interface{}),
+		aggResetCh:              make(chan interface{}),
 		clientSetUpdateChan:     apiserverupdate.WatchClientSetUpdate(),
 		listFromResourceVersion: "0",
 		allowPartialWatch:       allowPartialWatch,
@@ -195,7 +195,7 @@ func (r *Reflector) Run(stopCh <-chan struct{}) {
 								klog.V(4).Infof("Got reset channel message. expectedType %v, new bound [%+v]", r.expectedType, signal)
 							}
 
-							r.aggChan <- signal
+							r.aggResetCh <- signal
 						}
 					}
 				}(i, fb)
@@ -414,6 +414,8 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			if urlError, ok := err.(*url.Error); ok {
 				if opError, ok := urlError.Err.(*net.OpError); ok {
 					if errno, ok := opError.Err.(syscall.Errno); ok && errno == syscall.ECONNREFUSED {
+						klog.Infof("Retry on connection refused error [%v]", err)
+						aggregatedWatcher.Stop()
 						time.Sleep(time.Second)
 						continue
 					}
@@ -481,7 +483,7 @@ loop:
 				return errorClientSetResetRequested
 			case <-stopCh:
 				return errorStopRequested
-			case signal, ok := <-r.aggChan:
+			case signal, ok := <-r.aggResetCh:
 				if !ok {
 					klog.Error("resetCh channel closed")
 					return errors.New("Reset channel closed")
@@ -636,7 +638,7 @@ func (r *Reflector) hasInitBounds() bool {
 func (r *Reflector) waitForBoundInit(stopCh <-chan struct{}) bool {
 	for {
 		select {
-		case msg, ok := <-r.aggChan:
+		case msg, ok := <-r.aggResetCh:
 			if !ok {
 				klog.Errorf("Cannot read from closed channel. expectedType %v", r.expectedType)
 				return false


### PR DESCRIPTION
   . Use wait group for closing aggregated channel
   . Do not used bcast in stop channel broadcast as there is deadlock
   . Add UT for massive open/close multiple channels
   . Fix the name of reset channel
   . Close aggregated watcher when connection was refused for some watchers.

