### PR TITLE
create per-tenant-network kubernetes service

### DIFF
--- a/cmd/arktos-network-controller/app/BUILD
+++ b/cmd/arktos-network-controller/app/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "controller.go",
         "dns_deployment.go",
+        "wellknown_service.go",
     ],
     importpath = "k8s.io/kubernetes/cmd/arktos-network-controller/app",
     visibility = ["//visibility:public"],
@@ -14,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
@@ -46,6 +48,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/arktos-ext/pkg/apis/arktosextensions/v1:go_default_library",
         "//staging/src/k8s.io/arktos-ext/pkg/generated/clientset/versioned/fake:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",

--- a/cmd/arktos-network-controller/app/wellknown_service.go
+++ b/cmd/arktos-network-controller/app/wellknown_service.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The external network controller is responsible for running controller loops for the flat network providers.
+// Most of canonical CNI plugins can be used on so-called flat networks.
+
+package app
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	v1 "k8s.io/arktos-ext/pkg/apis/arktosextensions/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func createOrGetKubernetesService(net *v1.Network, svcClient kubernetes.Interface) (*corev1.Service, error) {
+	nsK8s := metav1.NamespaceDefault
+	nameKubernetes := types.KubernetesServiceName + "-" + net.Name
+	kubernetesService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nameKubernetes,
+			Tenant:    net.Tenant,
+			Namespace: nsK8s,
+			Labels: map[string]string{
+				v1.NetworkLabel:      net.Name,
+				clusterAddonLabelKey: nameKubernetes,
+				"provider":           "kubernetes",
+				"component":          "apiserver",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "https",
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(6443),
+				},
+			},
+			Selector: map[string]string{
+				clusterAddonLabelKey: nameKubernetes,
+			},
+			SessionAffinity: corev1.ServiceAffinityNone,
+			Type:            corev1.ServiceTypeClusterIP,
+		},
+	}
+	return createOrGetwellKnownService(svcClient, &kubernetesService)
+}
+
+func createOrGetDNSService(net *v1.Network, svcClient kubernetes.Interface) (*corev1.Service, error) {
+	nsDNS := metav1.NamespaceSystem
+	nameDNS := dnsServiceDefaultName + "-" + net.Name
+	dnsService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nameDNS,
+			Tenant:    net.Tenant,
+			Namespace: nsDNS,
+			Labels: map[string]string{
+				v1.NetworkLabel:      net.Name,
+				clusterAddonLabelKey: nameDNS,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "dns",
+					Protocol:   "UDP",
+					Port:       53,
+					TargetPort: intstr.FromInt(53),
+				},
+				{
+					Name:       "dns-tcp",
+					Protocol:   "TCP",
+					Port:       53,
+					TargetPort: intstr.FromInt(53),
+				},
+				{
+					Name:       "metrics",
+					Protocol:   "TCP",
+					Port:       9153,
+					TargetPort: intstr.FromInt(9153),
+				},
+			},
+			Selector: map[string]string{
+				clusterAddonLabelKey: nameDNS,
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+	return createOrGetwellKnownService(svcClient, &dnsService)
+}
+
+func createOrGetwellKnownService(svcClient kubernetes.Interface, svc *corev1.Service) (*corev1.Service, error) {
+	result, err := svcClient.CoreV1().ServicesWithMultiTenancy(svc.Namespace, svc.Tenant).Create(svc)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			// todo: consider differing temporary errors from permanent errors
+			// todo: to fail the network provision in case of permanent errors
+			return nil, err
+		} else {
+			result, err = svcClient.CoreV1().ServicesWithMultiTenancy(svc.Namespace, svc.Tenant).Get(svc.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
This PR creates the well-known kubernetes for a network object.

Verification:
1. start the test cluster by running arktos-up.sh.
2. Create the network CRD, by running
```
kubectl create -f pkg/controller/artifacts/crd-network.yaml
```
3. create tenant x
```
kubectl create tenant x
```
4. Start the arktos network controller
```
./_output/bin/arktos-network-controller --kubeconfig=/home/qianchen/.kube/config
```
Where the config is:
```
qianchen@qianchen-VirtualBox:~$ kubectl config view
apiVersion: v1
clusters:
- cluster:
    server: http://127.0.0.1:8080
  name: local
contexts:
- context:
    cluster: local
    user: ""
  name: local-ctx
current-context: local-ctx
kind: Config
preferences: {}
users: []
```
5.  create a flat-type network object and see the kubernetes service is created:
```
qianchen@qianchen-VirtualBox:~$ cat ~/ksvc/net.yaml
apiVersion: "arktos.futurewei.com/v1"
kind: Network
metadata:
  name: test2
spec:
  type: flat


qianchen@qianchen-VirtualBox:~$ kubectl apply -f ~/ksvc/net.yaml --tenant x
network.arktos.futurewei.com/test2 created

qianchen@qianchen-VirtualBox:~$ kubectl get svc --all-namespaces  --tenant x
NAMESPACE     NAME               TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE
default       kubernetes-test2   ClusterIP   10.0.0.196   <none>        443/TCP                  26s
kube-system   kube-dns-test2     ClusterIP   10.0.0.121   <none>        53/UDP,53/TCP,9153/TCP   26s

qianchen@qianchen-VirtualBox:~$ kubectl get svc kubernetes-test2   --tenant x -o json
{
    "apiVersion": "v1",
    "kind": "Service",
    "metadata": {
        "creationTimestamp": "2020-09-10T05:30:14Z",
        "hashKey": 5189151623754939875,
        "labels": {
            "arktos.futurewei.com/network": "test2",
            "component": "apiserver",
            "k8s-app": "kubernetes-test2",
            "provider": "kubernetes"
        },
        "name": "kubernetes-test2",
        "namespace": "default",
        "resourceVersion": "838711804820455425",
        "selfLink": "/api/v1/tenants/x/namespaces/default/services/kubernetes-test2",
        "tenant": "x",
        "uid": "a62ddc07-9fd6-414e-aecb-75e08ede92a1"
    },
    "spec": {
        "clusterIP": "10.0.0.196",
        "ports": [
            {
                "name": "https",
                "port": 443,
                "protocol": "TCP",
                "targetPort": 6443
            }
        ],
        "selector": {
            "k8s-app": "kubernetes-test2"
        },
        "sessionAffinity": "None",
        "type": "ClusterIP"
    },
    "status": {
        "loadBalancer": {}
    }
}
```
6. create a non-flat-type network object and see the kubernetes service is created:
```
qianchen@qianchen-VirtualBox:~$ cat ~/ksvc/net2.yaml
apiVersion: "arktos.futurewei.com/v1"
kind: Network
metadata:
  name: vpc1
spec:
  type: vpc

qianchen@qianchen-VirtualBox:~$ kubectl apply -f ~/ksvc/net2.yaml --tenant x
network.arktos.futurewei.com/vpc1 created

qianchen@qianchen-VirtualBox:~$ kubectl get svc --all-namespaces  --tenant x
NAMESPACE     NAME               TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE
default       kubernetes-test2   ClusterIP   10.0.0.196   <none>        443/TCP                  98s
default       kubernetes-vpc1    ClusterIP   10.0.0.24    <none>        443/TCP                  16s
kube-system   kube-dns-test2     ClusterIP   10.0.0.121   <none>        53/UDP,53/TCP,9153/TCP   98s
kube-system   kube-dns-vpc1      ClusterIP   10.0.0.216   <none>        53/UDP,53/TCP,9153/TCP   16s

qianchen@qianchen-VirtualBox:~$ kubectl get svc kubernetes-vpc1   --tenant x -o json
{
    "apiVersion": "v1",
    "kind": "Service",
    "metadata": {
        "creationTimestamp": "2020-09-10T05:31:36Z",
        "hashKey": 3804243492592420109,
        "labels": {
            "arktos.futurewei.com/network": "vpc1",
            "component": "apiserver",
            "k8s-app": "kubernetes-vpc1",
            "provider": "kubernetes"
        },
        "name": "kubernetes-vpc1",
        "namespace": "default",
        "resourceVersion": "838711847938949121",
        "selfLink": "/api/v1/tenants/x/namespaces/default/services/kubernetes-vpc1",
        "tenant": "x",
        "uid": "547fc4eb-d3fa-4ce1-9e95-4f82ee6e2650"
    },
    "spec": {
        "clusterIP": "10.0.0.24",
        "ports": [
            {
                "name": "https",
                "port": 443,
                "protocol": "TCP",
                "targetPort": 6443
            }
        ],
        "selector": {
            "k8s-app": "kubernetes-vpc1"
        },
        "sessionAffinity": "None",
        "type": "ClusterIP"
    },
    "status": {
        "loadBalancer": {}
    }
}

```

7. Verify that the kubernetes service DNS is resolved:
```
qianchen@qianchen-VirtualBox:/etc$ kubectl get pods ---tenant x -o wide
TENANT   NAMESPACE     NAME                             HASHKEY               READY   STATUS    RESTARTS   AGE     IP            NODE                  NOMINATED NODE   READINESS GATES
x        kube-system   coredns-test2-6dbf58b74b-fgkqk   9043349710197372281   1/1     Running   0          11s     10.88.16.80   qianchen-virtualbox   <none>           <none>

qianchen@qianchen-VirtualBox:/etc$ dig @10.88.16.80 kube-dns-test2.kube-system.svc.cluster.local +short
10.0.0.74
qianchen@qianchen-VirtualBox:/etc$ dig @10.88.16.80 kubernetes.default.svc.cluster.local +short
10.0.0.90
qianchen@qianchen-VirtualBox:/etc$ dig @10.88.16.80 kubernetes-test2.default.svc.cluster.local +short
10.0.0.90
qianchen@qianchen-VirtualBox:/etc$ dig @10.88.16.80 kube-dns.kube-system.svc.cluster.local +short
10.0.0.74

```
```