### PR TITLE
Fix issue that no hostIP sent to grpc server

### DIFF
--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -103,7 +103,7 @@ func (c *MizarPodController) Run(workers int, stopCh <-chan struct{}) {
 
 func (c *MizarPodController) createObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
-	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create})
+	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create, EventTime: time.Now().Format(time.RFC3339Nano)})
 }
 
 // When an object is updated.
@@ -121,13 +121,13 @@ func (c *MizarPodController) updateObj(old, cur interface{}) {
 	}
 
 	key, _ := controller.KeyFunc(curObj)
-	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update})
+	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, EventTime: time.Now().Format(time.RFC3339Nano)})
 }
 
 func (c *MizarPodController) deleteObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	klog.Infof("%v deleted. key %s.", controllerForMizarPod, key)
-	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete})
+	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete, EventTime: time.Now().Format(time.RFC3339Nano)})
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -103,7 +103,7 @@ func (c *MizarPodController) Run(workers int, stopCh <-chan struct{}) {
 
 func (c *MizarPodController) createObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
-	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create, ResourceVersion: getResourceVersion(obj)})
+	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create})
 }
 
 // When an object is updated.
@@ -127,12 +127,7 @@ func (c *MizarPodController) updateObj(old, cur interface{}) {
 func (c *MizarPodController) deleteObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	klog.Infof("%v deleted. key %s.", controllerForMizarPod, key)
-	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete, ResourceVersion: getResourceVersion(obj)})
-}
-
-func getResourceVersion(obj interface{}) string {
-	pod := obj.(*v1.Pod)
-	return pod.ResourceVersion
+	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete})
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
@@ -205,9 +200,9 @@ func processGrpcReturnCode(c *MizarPodController, returnCode *ReturnCode, keyWit
 	key := keyWithEventType.Key
 	switch returnCode.Code {
 	case CodeType_OK:
-		klog.Infof("Mizar handled request successfully for %v. key %s, eventType %s", controllerForMizarPod, key, keyWithEventType.EventType)
+		klog.Infof("Mizar handled request successfully for %v. key %s, eventType %v", controllerForMizarPod, key, keyWithEventType.EventType)
 	case CodeType_TEMP_ERROR:
-		klog.Infof("Mizar hit temporary error for %v. key %s. %s, eventType %s", controllerForMizarPod, key, returnCode.Message, keyWithEventType.EventType)
+		klog.Infof("Mizar hit temporary error for %v. key %s. %s, eventType %v", controllerForMizarPod, key, returnCode.Message, keyWithEventType.EventType)
 		c.queue.AddRateLimited(keyWithEventType)
 	}
 }

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -103,7 +103,7 @@ func (c *MizarPodController) Run(workers int, stopCh <-chan struct{}) {
 
 func (c *MizarPodController) createObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
-	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create, EventTime: time.Now().Format(time.RFC3339Nano)})
+	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create, ResourceVersion: getResourceVersion(obj)})
 }
 
 // When an object is updated.
@@ -121,13 +121,18 @@ func (c *MizarPodController) updateObj(old, cur interface{}) {
 	}
 
 	key, _ := controller.KeyFunc(curObj)
-	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, EventTime: time.Now().Format(time.RFC3339Nano)})
+	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, ResourceVersion: curObj.ResourceVersion})
 }
 
 func (c *MizarPodController) deleteObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	klog.Infof("%v deleted. key %s.", controllerForMizarPod, key)
-	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete, EventTime: time.Now().Format(time.RFC3339Nano)})
+	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete, ResourceVersion: getResourceVersion(obj)})
+}
+
+func getResourceVersion(obj interface{}) string {
+	pod := obj.(*v1.Pod)
+	return pod.ResourceVersion
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.

--- a/pkg/controller/mizar/util.go
+++ b/pkg/controller/mizar/util.go
@@ -26,6 +26,7 @@ const (
 type KeyWithEventType struct {
 	EventType EventType
 	Key       string
+	EventTime string
 }
 
 type StartHandler func(interface{}, string)

--- a/pkg/controller/mizar/util.go
+++ b/pkg/controller/mizar/util.go
@@ -15,12 +15,12 @@ package mizar
 
 import v1 "k8s.io/api/core/v1"
 
-type EventType int
+type EventType string
 
 const (
-	EventType_Create EventType = 0
-	EventType_Update EventType = 1
-	EventType_Delete EventType = 2
+	EventType_Create EventType = "Create"
+	EventType_Update EventType = "Update"
+	EventType_Delete EventType = "Delete"
 )
 
 type KeyWithEventType struct {

--- a/pkg/controller/mizar/util.go
+++ b/pkg/controller/mizar/util.go
@@ -24,9 +24,9 @@ const (
 )
 
 type KeyWithEventType struct {
-	EventType EventType
-	Key       string
-	EventTime string
+	EventType       EventType
+	Key             string
+	ResourceVersion string
 }
 
 type StartHandler func(interface{}, string)


### PR DESCRIPTION
Currently there is no hostIP sent to grpc server for newly created pod.
When a pod got created, there will be 1 create event triggered and 5 update events triggered. At the time the create event and first update event happens, there is no hostIP yet. And at this time mizar pod controller is sending the data to grpc server without hostIP data. The followed 4 update events have hostIP data, but in the event queue, the update event is being handled and existing in the queue, then the 4 followed update events are dedup'd by queue, which means the 4 followed update events cannot enqueue. Hence when first update event handle completed, there is no more event to be handled in the queue, so eventually there is no hostIP data sent to grpc server.
The solution is to add an EventTime field in the queue data which can distinguish all the different update events. In this way all the update events will be handled and sent to grpc server. Even the first event has no hostIP data, the following events have hostIP data and grpc server will get hostIP. 

What type of PR is this?
/kind bug

What this PR does / why we need it:

Which issue(s) this PR fixes:
For newly created pod, there is empty HostIP sent to grpc server