### PR TITLE
enable network_template_path in starting kube-controller-manager in a…

### DIFF
--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -107,6 +107,16 @@ else
   sudo systemctl stop apparmor
 fi
 
+ARKTOS_NETWORK_TEMPLATE=${ARKTOS_NETWORK_TEMPLATE:-}
+DEFAULT_NETWORK_TEMPLATE=${KUBE_ROOT}/hack/runtime/default_flat_network.json
+if [ "${ARKTOS_NETWORK_TEMPLATE}" == "default" ]; then 
+  ARKTOS_NETWORK_TEMPLATE=${DEFAULT_NETWORK_TEMPLATE}
+fi
+if [ -n "${ARKTOS_NETWORK_TEMPLATE}" ] && [ ! -f "${ARKTOS_NETWORK_TEMPLATE}" ]; then 
+  printf "\033[1;33m\nWarning: could not find newtork template file ${ARKTOS_NETWORK_TEMPLATE}. Setting ARKTOS_NETWORK_TEMPLATE to empty.\n\033[0m"
+  ARKTOS_NETWORK_TEMPLATE=""
+fi
+
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
 function kube::common::detect_binary {
@@ -478,6 +488,7 @@ function kube::common::start_controller_manager {
       --controllers="${KUBE_CONTROLLERS}" \
       --leader-elect=false \
       --cert-dir="${CERT_DIR}" \
+      --default-network-template-path="${ARKTOS_NETWORK_TEMPLATE}" \
       --master="https://${API_HOST}:${API_SECURE_PORT}" >"${CTLRMGR_LOG}" 2>&1 &
     CTLRMGR_PID=$!
 }

--- a/hack/runtime/default_flat_network.json
+++ b/hack/runtime/default_flat_network.json
@@ -1,0 +1,9 @@
+{
+    "metadata": {
+        "name": "default",
+        "finalizers": ["arktos.futurewei.com/network"]
+    },
+    "spec": {
+        "type": "flat"
+    }
+}


### PR DESCRIPTION
This PR creates the default network template file, hack/runtime/default_flat_network.json.

This PR allows user to set the env var ARKTOS_NETWORK_TEMPLATE to configure the commandline option in default_network_template_path when starting kube-controlle-manager in arktos-up.sh. 
1. if  env var ARKTOS_NETWORK_TEMPLATE is empty or unset, command line option default_network_template_path will be empty.
2. if  env var ARKTOS_NETWORK_TEMPLATE is "default", command line option default_network_template_path will use the default template file, hack/runtime/default_flat_network.json, which is created in this PR.
3. if  env var ARKTOS_NETWORK_TEMPLATE is a path to an existing file, command line option default_network_template_path will use that file.
4. if  env var ARKTOS_NETWORK_TEMPLATE is a path to a non-existing file, the command line option default_network_template_path will be empty.

### Verification
#### 1. When env var ARKTOS_NETWORK_TEMPLATE is not set or is empty.
Start arktos-up.sh, check the the commandline parameter of kube-controller-manager process, and see the following 

--default-network-template-path=

When the cluster is up, a tenant object is NOT created for the system tenant.
When a new tenant is created, a network object will NOT be created for it.

##### 2.  When env var ARKTOS_NETWORK_TEMPLATE is set to  "default".
Start arktos-up.sh, check the the commandline parameter of kube-controller-manager process, and see the following 

--default-network-template-path=[repo_path]/hack/runtime/default_flat_network.json

When the cluster is up, a tenant object is created for the system tenant.
When a new tenant is created, a network object will be created for it.



#### 3.  When env var ARKTOS_NETWORK_TEMPLATE is set to [Local_json_file] .
Start arktos-up.sh, check the the commandline parameter of kube-controller-manager process, and see the following 

--default-network-template-path=[Local_json_file]

When the cluster is up, a tenant object is created for the system tenant based on the given template file.
When a new tenant is created, a network object will  be created for it on the given template file.

#### 4.  When env var ARKTOS_NETWORK_TEMPLATE is set to [invalid_file_path] .
Start arktos-up.sh, check the the commandline parameter of kube-controller-manager process, and see the following 

--default-network-template-path=

When the cluster is up, a tenant object is NOT created for the system tenant.
When a new tenant is created, a network object will NOT be created for it.