### PR TITLE
arktos-up: install network crd before waiting for node ready

### DIFF
--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -522,6 +522,8 @@ if [[ "${DEFAULT_STORAGE_CLASS}" = "true" ]]; then
   create_storage_class
 fi
 
+${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
+
 echo "*******************************************"
 echo "Setup Arktos components ..."
 echo ""
@@ -537,8 +539,6 @@ ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" create -f ${VIRTLET_DEPLO
 ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" get ds --namespace kube-system
 
 ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/rbac/kubelet-network-reader/kubelet-network-reader.yaml"
-
-${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
 
 echo ""
 echo "Arktos Setup done."


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Arktos-up.sh installs network CRD before entering the loop of waiting for node be ready

**Does this PR introduce a user-facing change?**:
NONE
