### PR TITLE
fix kubectl-get-net error

### DIFF
--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -523,7 +523,8 @@ if [[ "${DEFAULT_STORAGE_CLASS}" = "true" ]]; then
 fi
 
 ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
-
+# refresh the resource discovery cache after the CRD is created
+${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" api-resources &>/dev/null
 echo "*******************************************"
 echo "Setup Arktos components ..."
 echo ""


### PR DESCRIPTION
This PR fixes the issue that "kubectl get net" return error complaining the "net" is not a valid resource type, though CRD networks.arktos.futurewei.com has already been installed in the arktos-up.sh.

Analysis & Solution:
The bug is due to that resource discovery cache is not updated after the new CRD type is created. So this script adds a line of "kubectl api-resources" to force a cache refresh.

Verification:
In the local dev box, right after the Arktos cluster is up by arktos-up.up, run the following command:
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get net
No resources found.
```

The error message before this change was gone.