### PR TITLE
arktos-up: installs the common cni binary package for the external cni plugin that will be installed later

### DIFF
--- a/hack/arktos-cni.rc
+++ b/hack/arktos-cni.rc
@@ -40,12 +40,7 @@ setup_cni_conf() {
     echo "copied ${conf_source_file} to ${conf_target_file}"
 }
 
-
-install_cni_bridge() {
-    echo "Ensuring firewall to allow traffic forward by default"
-    sudo iptables -S FORWARD | grep '\-P' | grep DROP && sudo iptables -P FORWARD ACCEPT
-    sudo iptables -S FORWARD | grep '\-P'
-
+ensure_cni_binaries() {
     echo "Ensuring minimum cni plugin installation..."
 
     if (test -x ${cni_bin_dir}/bridge && test -x ${cni_bin_dir}/host-local && test -x ${cni_bin_dir}/loopback); then
@@ -56,6 +51,14 @@ install_cni_bridge() {
         sudo mkdir -p ${cni_bin_dir}
         wget -nv -O - ${cniplugin_release_url} | sudo tar -C ${cni_bin_dir} -xzv
     fi
+}
+
+install_cni_bridge() {
+    echo "Ensuring firewall to allow traffic forward by default"
+    sudo iptables -S FORWARD | grep '\-P' | grep DROP && sudo iptables -P FORWARD ACCEPT
+    sudo iptables -S FORWARD | grep '\-P'
+
+    ensure_cni_binaries
 
     local cni_conf_source=$(dirname "$BASH_SOURCE[0]}")/testdata/cni-conf/bridge.conf
     setup_cni_conf  "${cni_conf_dir}/bridge.conf" ${cni_conf_source}
@@ -160,8 +163,11 @@ CNIPLUGIN=${CNIPLUGIN:-"bridge"}
 cni_conf_dir=${CNI_CONF_DIR:-"/etc/cni/net.d"}
 cni_bin_dir=${CNI_BIN_DIR:-"/opt/cni/bin"}
 
-
-if [ "${CNIPLUGIN}" == "bridge" ]; then
+if [[ -n "${ARKTOS_NO_CNI_PREINSTALLED}" ]]; then
+    echo "CNI plugin will be installed after cluster is started"
+    echo "Right now the minimum common cni binary package is being installed only"
+    ensure_cni_binaries
+elif [ "${CNIPLUGIN}" == "bridge" ]; then
     echo "cni plugin is bridge; arktos will use bridge to provision pod network"
     install_cni_bridge
 elif [ "${CNIPLUGIN}" == "alktron" ]; then
@@ -177,4 +183,3 @@ else
     echo "if you really want to use this plugin, you need to config cni plugin by yourself."
     exit 1
 fi
-

--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -63,9 +63,7 @@ fi
 # Install simple cni plugin based on env var CNIPLUGIN (bridge, alktron) before cluster is up.
 # If more advanced cni like Flannel is desired, it should be installed AFTER the clsuter is up;
 # in that case, please set ARKTOS-NO-CNI_PREINSTALLED to any no-empty value
-if [[ -z "${ARKTOS_NO_CNI_PREINSTALLED}" ]]; then
-  source ${KUBE_ROOT}/hack/arktos-cni.rc
-fi
+source ${KUBE_ROOT}/hack/arktos-cni.rc
 
 source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/common.sh"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This change in arktos-up bootstrap process is to ensure the common cni binaries is installed. 

This installation is necessary, as some external cni plugins (like new versions of flannel) does not install the binaries by themselves, bu trely on the binaries(e.g. loopback, flannel, bridge, host-local 7 portmap - required by flannel) exist on the system instead.

**Does this PR introduce a user-facing change?**:
NONE