### PR TITLE
coredns pod connects to kube-apiserver directly

### DIFF
--- a/cmd/arktos-network-controller/app/controller.go
+++ b/cmd/arktos-network-controller/app/controller.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,32 +51,34 @@ const (
 
 // Controller represents the flat network controller
 type Controller struct {
-	domainName      string
-	kubeAPIServerIP string
-	cacheSynced     cache.InformerSynced
-	store           arktosv1.NetworkLister
-	queue           workqueue.RateLimitingInterface
-	netClientset    *arktos.Clientset
-	svcClientset    *kubernetes.Clientset
-	recorder        record.EventRecorder
+	domainName        string
+	kubeAPIServerIP   string
+	kubeAPIServerPort string
+	cacheSynced       cache.InformerSynced
+	store             arktosv1.NetworkLister
+	queue             workqueue.RateLimitingInterface
+	netClientset      *arktos.Clientset
+	svcClientset      *kubernetes.Clientset
+	recorder          record.EventRecorder
 }
 
 // New creates the controller object
-func New(domainName, kubeAPIServerIP string, netClientset *arktos.Clientset, svcClientset *kubernetes.Clientset, informer arktosinformer.NetworkInformer) *Controller {
+func New(domainName, kubeAPIServerIP string, kubeAPIServerPort int, netClientset *arktos.Clientset, svcClientset *kubernetes.Clientset, informer arktosinformer.NetworkInformer) *Controller {
 	utilruntime.Must(arktoscheme.AddToScheme(scheme.Scheme))
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: svcClientset.CoreV1().EventsWithMultiTenancy(metav1.NamespaceAll, metav1.TenantAll)})
 
 	return &Controller{
-		domainName:      domainName,
-		kubeAPIServerIP: kubeAPIServerIP,
-		store:           informer.Lister(),
-		queue:           workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		cacheSynced:     informer.Informer().HasSynced,
-		netClientset:    netClientset,
-		svcClientset:    svcClientset,
-		recorder:        eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "flat-network-controller"}),
+		domainName:        domainName,
+		kubeAPIServerIP:   kubeAPIServerIP,
+		kubeAPIServerPort: strconv.Itoa(kubeAPIServerPort),
+		store:             informer.Lister(),
+		queue:             workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		cacheSynced:       informer.Informer().HasSynced,
+		netClientset:      netClientset,
+		svcClientset:      svcClientset,
+		recorder:          eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "flat-network-controller"}),
 	}
 }
 
@@ -140,9 +143,9 @@ func (c *Controller) process(item interface{}) {
 	klog.V(5).Infof("processing network %s/%s", net.Tenant, net.Name)
 
 	if net.Spec.Type == flatNetworkType {
-		err = manageFlatNetwork(net, c.netClientset, c.svcClientset, true, c.domainName, c.kubeAPIServerIP)
+		err = manageFlatNetwork(net, c.netClientset, c.svcClientset, true, c.domainName, c.kubeAPIServerIP, c.kubeAPIServerPort)
 	} else {
-		err = manageNonFlatNetwork(net, c.netClientset, c.svcClientset, true, c.domainName, c.kubeAPIServerIP)
+		err = manageNonFlatNetwork(net, c.netClientset, c.svcClientset, true, c.domainName, c.kubeAPIServerIP, c.kubeAPIServerPort)
 	}
 
 	if err != nil {
@@ -156,7 +159,7 @@ func (c *Controller) process(item interface{}) {
 }
 
 // manageNonFlatNetwork is the core logic to manage a non-flat typed network object
-func manageNonFlatNetwork(net *v1.Network, netClient arktos.Interface, svcClient kubernetes.Interface, toDeployDNS bool, domainName, kubeAPIServerIP string) error {
+func manageNonFlatNetwork(net *v1.Network, netClient arktos.Interface, svcClient kubernetes.Interface, toDeployDNS bool, domainName, kubeAPIServerIP, kubeAPIServerPort string) error {
 	if net.DeletionTimestamp != nil {
 		return ensureTerminatingPhase(net, netClient)
 	}
@@ -170,7 +173,7 @@ func manageNonFlatNetwork(net *v1.Network, netClient arktos.Interface, svcClient
 	}
 
 	if toDeployDNS {
-		if err = deployDNSForNetwork(net, svcClient, domainName, kubeAPIServerIP); err != nil {
+		if err = deployDNSForNetwork(net, svcClient, domainName, kubeAPIServerIP, kubeAPIServerPort); err != nil {
 			return fmt.Errorf("failed to deploy per-network DNS: %v", err)
 		}
 	}
@@ -224,7 +227,7 @@ func ensureTerminatingPhase(net *v1.Network, netClient arktos.Interface) error {
 }
 
 // manageFlatNetwork is the core logic to manage a flat typed network object
-func manageFlatNetwork(net *v1.Network, netClient arktos.Interface, svcClient kubernetes.Interface, toDeployDNS bool, domainName, kubeAPIServerIP string) error {
+func manageFlatNetwork(net *v1.Network, netClient arktos.Interface, svcClient kubernetes.Interface, toDeployDNS bool, domainName, kubeAPIServerIP, kubeAPIServerPort string) error {
 	if net.DeletionTimestamp != nil {
 		return ensureTerminatingPhase(net, netClient)
 	}
@@ -240,7 +243,7 @@ func manageFlatNetwork(net *v1.Network, netClient arktos.Interface, svcClient ku
 	}
 
 	if toDeployDNS {
-		if err = deployDNSForNetwork(net, svcClient, domainName, kubeAPIServerIP); err != nil {
+		if err = deployDNSForNetwork(net, svcClient, domainName, kubeAPIServerIP, kubeAPIServerPort); err != nil {
 			return fmt.Errorf("failed to deploy per-network DNS: %v", err)
 		}
 	}

--- a/cmd/arktos-network-controller/app/controller_test.go
+++ b/cmd/arktos-network-controller/app/controller_test.go
@@ -162,7 +162,7 @@ func TestManageFlatNetwork(t *testing.T) {
 				return true, svc, nil
 			})
 
-			err := manageFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local")
+			err := manageFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3")
 
 			if !tc.expectingError && err != nil {
 				t.Errorf("got unexpected error: %v", err)
@@ -309,7 +309,7 @@ func TestManageNonFlatNetwork(t *testing.T) {
 				return true, svc, nil
 			})
 
-			err := manageNonFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local")
+			err := manageNonFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3")
 
 			if !tc.expectingError && err != nil {
 				t.Errorf("got unexpected error: %v", err)
@@ -416,7 +416,7 @@ func TestNetworkPhaseShift(t *testing.T) {
 			})
 			kubeClient := fake.NewSimpleClientset()
 
-			err := manageNonFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local")
+			err := manageNonFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/cmd/arktos-network-controller/app/controller_test.go
+++ b/cmd/arktos-network-controller/app/controller_test.go
@@ -162,7 +162,7 @@ func TestManageFlatNetwork(t *testing.T) {
 				return true, svc, nil
 			})
 
-			err := manageFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3")
+			err := manageFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3", "6443")
 
 			if !tc.expectingError && err != nil {
 				t.Errorf("got unexpected error: %v", err)
@@ -309,7 +309,7 @@ func TestManageNonFlatNetwork(t *testing.T) {
 				return true, svc, nil
 			})
 
-			err := manageNonFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3")
+			err := manageNonFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3", "6443")
 
 			if !tc.expectingError && err != nil {
 				t.Errorf("got unexpected error: %v", err)
@@ -416,7 +416,7 @@ func TestNetworkPhaseShift(t *testing.T) {
 			})
 			kubeClient := fake.NewSimpleClientset()
 
-			err := manageNonFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3")
+			err := manageNonFlatNetwork(tc.input, netClient, kubeClient, false, "cluster.local", "192.168.0.3", "6443")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/cmd/arktos-network-controller/app/dns_deployment.go
+++ b/cmd/arktos-network-controller/app/dns_deployment.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func deployDNSForNetwork(net *v1.Network, client kubernetes.Interface, domainName, kubeAPIServerIP string) error {
+func deployDNSForNetwork(net *v1.Network, client kubernetes.Interface, domainName, kubeAPIServerIP, kubeAPIServerPort string) error {
 	if err := ensureToCreateServiceAccount(net, client); err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func deployDNSForNetwork(net *v1.Network, client kubernetes.Interface, domainNam
 		return err
 	}
 
-	if err := ensureToCreateDeployment(net, client, kubeAPIServerIP); err != nil {
+	if err := ensureToCreateDeployment(net, client, kubeAPIServerIP, kubeAPIServerPort); err != nil {
 		return err
 	}
 
@@ -174,7 +174,7 @@ func ensureToCreateConfigMap(net *v1.Network, client kubernetes.Interface, domai
 	return nil
 }
 
-func ensureToCreateDeployment(net *v1.Network, client kubernetes.Interface, kubeAPIServerIP string) error {
+func ensureToCreateDeployment(net *v1.Network, client kubernetes.Interface, kubeAPIServerIP, kubeAPIServerPort string) error {
 	name := dnsBaseName + "-" + net.Name
 	label := dnsServiceDefaultName + "-" + net.Name
 	configmap := dnsBaseName + "-" + net.Name
@@ -267,7 +267,7 @@ func ensureToCreateDeployment(net *v1.Network, client kubernetes.Interface, kube
 								},
 								Env: []corev1.EnvVar{
 									{Name: "KUBERNETES_SERVICE_HOST", Value: kubeAPIServerIP},
-									{Name: "KUBERNETES_SERVICE_PORT", Value: "6443"},
+									{Name: "KUBERNETES_SERVICE_PORT", Value: kubeAPIServerPort},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{

--- a/cmd/arktos-network-controller/app/dns_deployment.go
+++ b/cmd/arktos-network-controller/app/dns_deployment.go
@@ -267,7 +267,7 @@ func ensureToCreateDeployment(net *v1.Network, client kubernetes.Interface, kube
 								},
 								Env: []corev1.EnvVar{
 									{Name: "KUBERNETES_SERVICE_HOST", Value: kubeAPIServerIP},
-									{Name: "KUBERNETES_SERVICE_PORT", Value:"6443"},
+									{Name: "KUBERNETES_SERVICE_PORT", Value: "6443"},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{

--- a/cmd/arktos-network-controller/app/dns_deployment.go
+++ b/cmd/arktos-network-controller/app/dns_deployment.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func deployDNSForNetwork(net *v1.Network, client kubernetes.Interface, domainName string) error {
+func deployDNSForNetwork(net *v1.Network, client kubernetes.Interface, domainName, kubeAPIServerIP string) error {
 	if err := ensureToCreateServiceAccount(net, client); err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func deployDNSForNetwork(net *v1.Network, client kubernetes.Interface, domainNam
 		return err
 	}
 
-	if err := ensureToCreateDeployment(net, client); err != nil {
+	if err := ensureToCreateDeployment(net, client, kubeAPIServerIP); err != nil {
 		return err
 	}
 
@@ -174,7 +174,7 @@ func ensureToCreateConfigMap(net *v1.Network, client kubernetes.Interface, domai
 	return nil
 }
 
-func ensureToCreateDeployment(net *v1.Network, client kubernetes.Interface) error {
+func ensureToCreateDeployment(net *v1.Network, client kubernetes.Interface, kubeAPIServerIP string) error {
 	name := dnsBaseName + "-" + net.Name
 	label := dnsServiceDefaultName + "-" + net.Name
 	configmap := dnsBaseName + "-" + net.Name
@@ -264,6 +264,10 @@ func ensureToCreateDeployment(net *v1.Network, client kubernetes.Interface) erro
 								Args: []string{
 									"-conf",
 									"/etc/coredns/Corefile",
+								},
+								Env: []corev1.EnvVar{
+									{Name: "KUBERNETES_SERVICE_HOST", Value: kubeAPIServerIP},
+									{Name: "KUBERNETES_SERVICE_PORT", Value:"6443"},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{

--- a/cmd/arktos-network-controller/app/dns_deployment_test.go
+++ b/cmd/arktos-network-controller/app/dns_deployment_test.go
@@ -95,7 +95,7 @@ func TestDeployDNSForNetwork(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			namePerNetwork := "coredns-" + tc.input.Name
 			kubeClient := fake.NewSimpleClientset(tc.objects...)
-			err := deployDNSForNetwork(tc.input, kubeClient, "cluster.local")
+			err := deployDNSForNetwork(tc.input, kubeClient, "cluster.local", "192.168.0.3")
 
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/cmd/arktos-network-controller/app/dns_deployment_test.go
+++ b/cmd/arktos-network-controller/app/dns_deployment_test.go
@@ -95,7 +95,7 @@ func TestDeployDNSForNetwork(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			namePerNetwork := "coredns-" + tc.input.Name
 			kubeClient := fake.NewSimpleClientset(tc.objects...)
-			err := deployDNSForNetwork(tc.input, kubeClient, "cluster.local", "192.168.0.3")
+			err := deployDNSForNetwork(tc.input, kubeClient, "cluster.local", "192.168.0.3", "6443")
 
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/cmd/arktos-network-controller/network-controller.go
+++ b/cmd/arktos-network-controller/network-controller.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	if len(kubeAPIServerIP) == 0 {
-		klog.Fatalf("--kube-apiserver arg must be specified in this version.")
+		klog.Fatalf("--kube-apiserver-ip arg must be specified in this version.")
 	}
 
 	defer klog.Flush()

--- a/docs/setup-guide/arktos-enforces-netowrk-feature.md
+++ b/docs/setup-guide/arktos-enforces-netowrk-feature.md
@@ -43,7 +43,7 @@ default   flat
 
 The current version has a limitation which requires cluster admin to specify the IP address of kube-apiserver that this controller connects to. We are working on the improvement that gets rid of this inconvenience. At this monent, please provide the ip address of the master node. Below is assuming 172.31.41.177:
 ```bash
-./_output/local/bin/linux/amd64/arktos-network-controller --kubeconfig ~/.kube/config --kube-apiserver-ip=172.31.41.177
+./_output/local/bin/linux/amd64/arktos-network-controller --kubeconfig=~/.kube/config --kube-apiserver-ip=172.31.41.177
 ```
 The config file has below content
 ```yaml

--- a/docs/setup-guide/arktos-enforces-netowrk-feature.md
+++ b/docs/setup-guide/arktos-enforces-netowrk-feature.md
@@ -40,8 +40,10 @@ default   flat
 ```
 
 4. Start the arktos-network-controller
+
+The current version has a limitation which requires cluster admin to specify the IP address of kube-apiserver that this controller connects to. We are working on the improvement that gets rid of this inconvenience. At this monent, please provide the ip address of the master node. Below is assuming 172.31.41.177:
 ```bash
-./_output/local/bin/linux/amd64/arktos-network-controller --kubeconfig ~/.kube/config
+./_output/local/bin/linux/amd64/arktos-network-controller --kubeconfig ~/.kube/config --kube-apiserver-ip=172.31.41.177
 ```
 The config file has below content
 ```yaml


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR makes coredns pods of per-network DNS deployment connecting to the specified kube-apiserver.

When a network resource is created, arktos network controller creates its per-network DNS deployment; however, at this moment, the controller might not have any idea of the per-network kubernetes service IP (for external IPAM networks) - actually it uses 10.0.0.1 by default,  leading to coredns unable to get hold of the api server, thus cannot start properly.

Making the DNS deployment to define its pod template so that coredns pod connects to kube-apiserver directly solve this kubernetes service ip not yet assigned issue.

In the long run, the controller may need to wait for per-network kubernetes service IP assigned, before it creates per-network DNS deployment.

**Which issue(s) this PR fixes**:
Fixes #742

**Does this PR introduce a user-facing change?**:
YES
```release-note
when arktos_network_controller is started, it requires --kube-apiserver-ip argument
```
