### PR TITLE
fix the bug in setup_client.sh when the context to remove is current …

### DIFF
--- a/hack/setup-multi-tenancy/setup_client.sh
+++ b/hack/setup-multi-tenancy/setup_client.sh
@@ -71,6 +71,11 @@ setup_client() {
 }
 
 unset_client() {
+        if [ "$(kubectl config current-context)" == "${context_name}" ]
+        then
+                run_command kubectl config unset current-context
+        fi
+
         echo "removing client key and cert files of ${tenant}/${person} ..."
         files_to_rm=`kubectl config view -o json | jq -r --arg name "${tenant_person}" '.users[] | select(.name==$name).user | [ .["client-key"], .["client-certificate"]] | @tsv' `
         rm $files_to_rm > /dev/null 2>&1


### PR DESCRIPTION
### Issue
This PR addresses the following issue in setup_client.sh:

If the context to unset is the current-context, the script will remove key files and the config  of relevant user/context/cluster, but did not unset the currrent-context. As a result the current-context is no longer valid, which will result in the failure to run almost all the kubectl commands, also arktos facilities like arktos-up.sh.

### Fix
If the context to unset is the current-context, the script will also unset the current-context.

### Verificiation

The kubeconfig before :  
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl config view
apiVersion: v1
clusters:
- cluster:
    certificate-authority: /var/run/kubernetes/server-ca.crt
    server: https://localhost:6443
  name: x-admin-cluster
contexts:
- context:
    cluster: x-admin-cluster
    namespace: default
    tenant: x
    user: x-admin
  name: x-admin-context
current-context: x-admin-context
kind: Config
preferences: {}
users:
- name: x-admin
  user:
    client-certificate: /tmp/x-admin.crt
    client-key: /tmp/x-admin.key
```


Running the script to unset:
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ REMOVE=TRUE hack/setup-multi-tenancy/setup_client.sh x admin
removing client key and cert files of x/admin ...
Unsetting the context of x/admin in /var/run/kubernetes/admin.kubeconfig ...
```

The Kubeconfig after, the current-context is empty now:
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl config view
apiVersion: v1
clusters: []
contexts: []
current-context: ""
kind: Config
preferences: {}
users: []
```