### PR TITLE
Update storageclass scope

### DIFF
--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -48,7 +48,7 @@ const (
 
 // ValidateStorageClass validates a StorageClass.
 func ValidateStorageClass(storageClass *storage.StorageClass) field.ErrorList {
-	allErrs := apivalidation.ValidateObjectMeta(&storageClass.ObjectMeta, false, false, apivalidation.ValidateClassName, field.NewPath("metadata"))
+	allErrs := apivalidation.ValidateObjectMeta(&storageClass.ObjectMeta, true, false, apivalidation.ValidateClassName, field.NewPath("metadata"))
 	allErrs = append(allErrs, validateProvisioner(storageClass.Provisioner, field.NewPath("provisioner"))...)
 	allErrs = append(allErrs, validateParameters(storageClass.Parameters, field.NewPath("parameters"))...)
 	allErrs = append(allErrs, validateReclaimPolicy(storageClass.ReclaimPolicy, field.NewPath("reclaimPolicy"))...)

--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -56,7 +56,7 @@ func TestValidateStorageClass(t *testing.T) {
 	successCases := []storage.StorageClass{
 		{
 			// empty parameters
-			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner:       "kubernetes.io/foo-provisioner",
 			Parameters:        map[string]string{},
 			ReclaimPolicy:     &deleteReclaimPolicy,
@@ -64,14 +64,14 @@ func TestValidateStorageClass(t *testing.T) {
 		},
 		{
 			// nil parameters
-			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner:       "kubernetes.io/foo-provisioner",
 			ReclaimPolicy:     &deleteReclaimPolicy,
 			VolumeBindingMode: &immediateMode1,
 		},
 		{
 			// some parameters
-			ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:  metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner: "kubernetes.io/foo-provisioner",
 			Parameters: map[string]string{
 				"kubernetes.io/foo-parameter": "free/form/string",
@@ -83,7 +83,7 @@ func TestValidateStorageClass(t *testing.T) {
 		},
 		{
 			// retain reclaimPolicy
-			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner:       "kubernetes.io/foo-provisioner",
 			ReclaimPolicy:     &retainReclaimPolicy,
 			VolumeBindingMode: &immediateMode1,
@@ -108,23 +108,23 @@ func TestValidateStorageClass(t *testing.T) {
 	}
 
 	errorCases := map[string]storage.StorageClass{
-		"tenant is present": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo", Tenant: "bar"},
+		"tenant is missing": {
+			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
 			Provisioner:   "kubernetes.io/foo-provisioner",
 			ReclaimPolicy: &deleteReclaimPolicy,
 		},
 		"namespace is present": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			ObjectMeta:    metav1.ObjectMeta{Name: "foo", Namespace: "bar", Tenant: testTenant},
 			Provisioner:   "kubernetes.io/foo-provisioner",
 			ReclaimPolicy: &deleteReclaimPolicy,
 		},
 		"invalid provisioner": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:    metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner:   "kubernetes.io/invalid/provisioner",
 			ReclaimPolicy: &deleteReclaimPolicy,
 		},
 		"invalid empty parameter name": {
-			ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:  metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner: "kubernetes.io/foo",
 			Parameters: map[string]string{
 				"": "value",
@@ -132,18 +132,18 @@ func TestValidateStorageClass(t *testing.T) {
 			ReclaimPolicy: &deleteReclaimPolicy,
 		},
 		"provisioner: Required value": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:    metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner:   "",
 			ReclaimPolicy: &deleteReclaimPolicy,
 		},
 		"too long parameters": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:    metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner:   "kubernetes.io/foo",
 			Parameters:    longParameters,
 			ReclaimPolicy: &deleteReclaimPolicy,
 		},
 		"invalid reclaimpolicy": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
+			ObjectMeta:    metav1.ObjectMeta{Name: "foo", Tenant: testTenant},
 			Provisioner:   "kubernetes.io/foo",
 			ReclaimPolicy: &recycleReclaimPolicy,
 		},
@@ -637,7 +637,7 @@ func TestVolumeAttachmentValidationV1(t *testing.T) {
 
 func makeClass(mode *storage.VolumeBindingMode, topologies []api.TopologySelectorTerm) *storage.StorageClass {
 	return &storage.StorageClass{
-		ObjectMeta:        metav1.ObjectMeta{Name: "foo", ResourceVersion: "foo"},
+		ObjectMeta:        metav1.ObjectMeta{Name: "foo", Tenant: testTenant, ResourceVersion: "foo"},
 		Provisioner:       "kubernetes.io/foo-provisioner",
 		ReclaimPolicy:     &deleteReclaimPolicy,
 		VolumeBindingMode: mode,

--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -3764,7 +3764,7 @@ type StorageClassDescriber struct {
 }
 
 func (s *StorageClassDescriber) Describe(tenant, namespace, name string, describerSettings describe.DescriberSettings) (string, error) {
-	sc, err := s.StorageV1().StorageClasses().Get(name, metav1.GetOptions{})
+	sc, err := s.StorageV1().StorageClassesWithMultiTenancy(tenant).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubectl/describe/versioned/describe_test.go
+++ b/pkg/kubectl/describe/versioned/describe_test.go
@@ -1546,6 +1546,7 @@ func TestDescribeStorageClass(t *testing.T) {
 	f := fake.NewSimpleClientset(&storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
+			Tenant:          metav1.TenantSystem,
 			ResourceVersion: "4",
 			Annotations: map[string]string{
 				"name": "foo",
@@ -2521,7 +2522,8 @@ func TestDescribeEvents(t *testing.T) {
 		"StorageClass": &StorageClassDescriber{
 			fake.NewSimpleClientset(&storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "bar",
+					Name:   "bar",
+					Tenant: metav1.TenantSystem,
 				},
 			}, events),
 		},

--- a/pkg/kubectl/describe/versioned/multi_tenancy_describe_test.go
+++ b/pkg/kubectl/describe/versioned/multi_tenancy_describe_test.go
@@ -43,6 +43,10 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 )
 
+var (
+	testTenant = "test-te"
+)
+
 type describeClientWithMultiTenancy struct {
 	T         *testing.T
 	Tenant    string
@@ -60,7 +64,7 @@ func TestDescribePodWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:                       "bar",
 			Namespace:                  "foo",
-			Tenant:                     "test-te",
+			Tenant:                     testTenant,
 			DeletionTimestamp:          &deletionTimestamp,
 			DeletionGracePeriodSeconds: &gracePeriod,
 		},
@@ -83,9 +87,9 @@ func TestDescribePodWithMultiTenancy(t *testing.T) {
 			},
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := PodDescriber{c}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -102,7 +106,7 @@ func TestDescribePodNodeWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Spec: corev1.PodSpec{
 			NodeName: "all-in-one",
@@ -112,9 +116,9 @@ func TestDescribePodNodeWithMultiTenancy(t *testing.T) {
 			NominatedNodeName: "nodeA",
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := PodDescriber{c}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -131,7 +135,7 @@ func TestDescribePodTolerationsWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Spec: corev1.PodSpec{
 			Tolerations: []corev1.Toleration{
@@ -143,9 +147,9 @@ func TestDescribePodTolerationsWithMultiTenancy(t *testing.T) {
 			},
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := PodDescriber{c}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -164,16 +168,16 @@ func TestDescribeSecretWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Data: map[string][]byte{
 			"username": []byte("YWRtaW4="),
 			"password": []byte("MWYyZDFlMmU2N2Rm"),
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := SecretDescriber{c}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -189,12 +193,12 @@ func TestDescribeNamespaceWithMultiTenancy(t *testing.T) {
 	fake := fake.NewSimpleClientset(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "myns",
-			Tenant: "test-te",
+			Tenant: testTenant,
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "", Interface: fake}
 	d := NamespaceDescriber{c}
-	out, err := d.Describe("test-te", "", "myns", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "", "myns", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -208,16 +212,16 @@ func TestDescribePodPriorityWithMultiTenancy(t *testing.T) {
 	fake := fake.NewSimpleClientset(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "bar",
-			Tenant: "test-te",
+			Tenant: testTenant,
 		},
 		Spec: corev1.PodSpec{
 			PriorityClassName: "high-priority",
 			Priority:          &priority,
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "", Interface: fake}
 	d := PodDescriber{c}
-	out, err := d.Describe("test-te", "", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "", "bar", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -231,16 +235,16 @@ func TestDescribeConfigMapWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycm",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Data: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := ConfigMapDescriber{c}
-	out, err := d.Describe("test-te", "foo", "mycm", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "mycm", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -254,7 +258,7 @@ func TestDescribeLimitRangeWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mylr",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Spec: corev1.LimitRangeSpec{
 			Limits: []corev1.LimitRangeItem{
@@ -280,9 +284,9 @@ func TestDescribeLimitRangeWithMultiTenancy(t *testing.T) {
 			},
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := LimitRangeDescriber{c}
-	out, err := d.Describe("test-te", "foo", "mylr", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "mylr", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -307,7 +311,7 @@ func TestDescribeServiceWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 				Spec: corev1.ServiceSpec{
 					Type: corev1.ServiceTypeLoadBalancer,
@@ -346,7 +350,7 @@ func TestDescribeServiceWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 				Spec: corev1.ServiceSpec{
 					Type: corev1.ServiceTypeLoadBalancer,
@@ -383,9 +387,9 @@ func TestDescribeServiceWithMultiTenancy(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			fake := fake.NewSimpleClientset(testCase.service)
-			c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+			c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 			d := ServiceDescriber{c}
-			out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+			out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -432,13 +436,13 @@ func TestPodDescribeResultsSortedWithMultiTenancy(t *testing.T) {
 				},
 			},
 		},
-		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"}},
 	)
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := PodDescriber{c}
 
 	// Act
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 
 	// Assert
 	if err != nil {
@@ -917,7 +921,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test0",
 			plugin: "hostpath",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{Type: new(corev1.HostPathType)},
@@ -930,7 +934,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test1",
 			plugin: "gce",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						GCEPersistentDisk: &corev1.GCEPersistentDiskVolumeSource{},
@@ -944,7 +948,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test2",
 			plugin: "ebs",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						AWSElasticBlockStore: &corev1.AWSElasticBlockStoreVolumeSource{},
@@ -957,7 +961,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test3",
 			plugin: "nfs",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						NFS: &corev1.NFSVolumeSource{},
@@ -970,7 +974,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test4",
 			plugin: "iscsi",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						ISCSI: &corev1.ISCSIPersistentVolumeSource{},
@@ -984,7 +988,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test5",
 			plugin: "gluster",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Glusterfs: &corev1.GlusterfsPersistentVolumeSource{},
@@ -997,7 +1001,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test6",
 			plugin: "rbd",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						RBD: &corev1.RBDPersistentVolumeSource{},
@@ -1010,7 +1014,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test7",
 			plugin: "quobyte",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Quobyte: &corev1.QuobyteVolumeSource{},
@@ -1023,7 +1027,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test8",
 			plugin: "cinder",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Cinder: &corev1.CinderPersistentVolumeSource{},
@@ -1036,7 +1040,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test9",
 			plugin: "fc",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						FC: &corev1.FCVolumeSource{},
@@ -1050,7 +1054,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test10",
 			plugin: "local",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Local: &corev1.LocalVolumeSource{},
@@ -1064,7 +1068,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test11",
 			plugin: "local",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Local: &corev1.LocalVolumeSource{},
@@ -1079,7 +1083,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test12",
 			plugin: "local",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Local: &corev1.LocalVolumeSource{},
@@ -1096,7 +1100,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test13",
 			plugin: "local",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Local: &corev1.LocalVolumeSource{},
@@ -1121,7 +1125,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			name:   "test14",
 			plugin: "local",
 			pv: &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Name: "bar"},
 				Spec: corev1.PersistentVolumeSpec{
 					PersistentVolumeSource: corev1.PersistentVolumeSource{
 						Local: &corev1.LocalVolumeSource{},
@@ -1157,7 +1161,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			pv: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "bar",
-					Tenant:            "test-te",
+					Tenant:            testTenant,
 					DeletionTimestamp: &deletionTimestamp,
 				},
 				Spec: corev1.PersistentVolumeSpec{
@@ -1174,7 +1178,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			pv: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:                       "bar",
-					Tenant:                     "test-te",
+					Tenant:                     testTenant,
 					GenerateName:               "test-GenerateName",
 					UID:                        "test-UID",
 					CreationTimestamp:          metav1.Time{Time: time.Now()},
@@ -1218,7 +1222,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 			pv: &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:                       "bar",
-					Tenant:                     "test-te",
+					Tenant:                     testTenant,
 					GenerateName:               "test-GenerateName",
 					UID:                        "test-UID",
 					CreationTimestamp:          metav1.Time{Time: time.Now()},
@@ -1250,7 +1254,7 @@ func TestPersistentVolumeDescriberWithMultiTenancy(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fake := fake.NewSimpleClientset(test.pv)
 			c := PersistentVolumeDescriber{fake}
-			str, err := c.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+			str, err := c.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 			if err != nil {
 				t.Errorf("Unexpected error for test %s: %v", test.plugin, err)
 			}
@@ -1286,7 +1290,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "default",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume1",
 					StorageClassName: &goldClassName,
@@ -1300,7 +1304,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "filesystem",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume2",
 					StorageClassName: &goldClassName,
@@ -1315,7 +1319,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "block",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume3",
 					StorageClassName: &goldClassName,
@@ -1331,7 +1335,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "condition-type",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume4",
 					StorageClassName: &goldClassName,
@@ -1347,7 +1351,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "condition-status",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume5",
 					StorageClassName: &goldClassName,
@@ -1363,7 +1367,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "condition-last-probe-time",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume6",
 					StorageClassName: &goldClassName,
@@ -1379,7 +1383,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "condition-last-transition-time",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume7",
 					StorageClassName: &goldClassName,
@@ -1395,7 +1399,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "condition-reason",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume8",
 					StorageClassName: &goldClassName,
@@ -1411,7 +1415,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		{
 			name: "condition-message",
 			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Tenant: "test-te", Namespace: "foo", Name: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Tenant: testTenant, Namespace: "foo", Name: "bar"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName:       "volume9",
 					StorageClassName: &goldClassName,
@@ -1428,7 +1432,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 			name: "deletion-timestamp",
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Tenant:            "test-te",
+					Tenant:            testTenant,
 					Namespace:         "foo",
 					Name:              "bar",
 					DeletionTimestamp: &deletionTimestamp,
@@ -1447,7 +1451,7 @@ func TestPersistentVolumeClaimDescriberWithMultiTenancy(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fake := fake.NewSimpleClientset(test.pvc)
 			c := PersistentVolumeClaimDescriber{fake}
-			str, err := c.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+			str, err := c.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 			if err != nil {
 				t.Errorf("Unexpected error for test %s: %v", test.name, err)
 			}
@@ -1473,7 +1477,7 @@ func TestDescribeDeploymentWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: utilpointer.Int32Ptr(1),
@@ -1488,7 +1492,7 @@ func TestDescribeDeploymentWithMultiTenancy(t *testing.T) {
 		},
 	})
 	d := DeploymentDescriber{fakeClient}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1503,6 +1507,7 @@ func TestDescribeStorageClassWithMultiTenancy(t *testing.T) {
 	f := fake.NewSimpleClientset(&storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
+			Tenant:          testTenant,
 			ResourceVersion: "4",
 			Annotations: map[string]string{
 				"name": "foo",
@@ -1543,7 +1548,7 @@ func TestDescribeStorageClassWithMultiTenancy(t *testing.T) {
 		},
 	})
 	s := StorageClassDescriber{f}
-	out, err := s.Describe("test-te", "", "foo", describe.DescriberSettings{ShowEvents: true})
+	out, err := s.Describe(testTenant, "", "foo", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1569,7 +1574,7 @@ func TestDescribePodDisruptionBudgetWithMultiTenancy(t *testing.T) {
 	minAvailable := intstr.FromInt(22)
 	f := fake.NewSimpleClientset(&policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
-			Tenant:            "test-te",
+			Tenant:            testTenant,
 			Namespace:         "ns1",
 			Name:              "pdb1",
 			CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
@@ -1582,7 +1587,7 @@ func TestDescribePodDisruptionBudgetWithMultiTenancy(t *testing.T) {
 		},
 	})
 	s := PodDisruptionBudgetDescriber{f}
-	out, err := s.Describe("test-te", "ns1", "pdb1", describe.DescriberSettings{ShowEvents: true})
+	out, err := s.Describe(testTenant, "ns1", "pdb1", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2249,11 +2254,11 @@ func TestDescribeHorizontalPodAutoscalerWithMultiTenancy(t *testing.T) {
 			test.hpa.ObjectMeta = metav1.ObjectMeta{
 				Name:      "bar",
 				Namespace: "foo",
-				Tenant:    "test-te",
+				Tenant:    testTenant,
 			}
 			fake := fake.NewSimpleClientset(&test.hpa)
 			desc := HorizontalPodAutoscalerDescriber{fake}
-			str, err := desc.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+			str, err := desc.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 			if err != nil {
 				t.Errorf("Unexpected error for test %s: %v", test.name, err)
 			}
@@ -2345,11 +2350,11 @@ func TestDescribeHorizontalPodAutoscalerWithMultiTenancy(t *testing.T) {
 			test.hpa.ObjectMeta = metav1.ObjectMeta{
 				Name:      "bar",
 				Namespace: "foo",
-				Tenant:    "test-te",
+				Tenant:    testTenant,
 			}
 			fake := fake.NewSimpleClientset(&test.hpa)
 			desc := HorizontalPodAutoscalerDescriber{fake}
-			str, err := desc.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+			str, err := desc.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 			if err != nil {
 				t.Errorf("Unexpected error for test %s: %v", test.name, err)
 			}
@@ -2368,7 +2373,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 				Source:         corev1.EventSource{Component: "kubelet"},
 				Message:        "Item 1",
@@ -2386,7 +2391,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 			}, events),
 		},
@@ -2395,7 +2400,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: utilpointer.Int32Ptr(1),
@@ -2408,7 +2413,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 			}, events),
 		},
@@ -2427,7 +2432,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 			fake.NewSimpleClientset(&corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:     "bar",
-					Tenant:   "test-te",
+					Tenant:   testTenant,
 					SelfLink: "url/url/url/url",
 				},
 			}, events),
@@ -2437,7 +2442,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 					SelfLink:  "url/url/url/url",
 				},
 			}, events),
@@ -2447,7 +2452,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 				Spec: appsv1.ReplicaSetSpec{
 					Replicas: utilpointer.Int32Ptr(1),
@@ -2459,7 +2464,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 				Spec: corev1.ReplicationControllerSpec{
 					Replicas: utilpointer.Int32Ptr(1),
@@ -2471,14 +2476,15 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 			}, events),
 		},
 		"StorageClass": &StorageClassDescriber{
 			fake.NewSimpleClientset(&storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "bar",
+					Name:   "bar",
+					Tenant: testTenant,
 				},
 			}, events),
 		},
@@ -2487,7 +2493,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 			}, events),
 		},
@@ -2496,7 +2502,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",
-					Tenant:    "test-te",
+					Tenant:    testTenant,
 				},
 			}, events),
 		},
@@ -2504,7 +2510,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 
 	for name, d := range m {
 		t.Run(name, func(t *testing.T) {
-			out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+			out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 			if err != nil {
 				t.Errorf("unexpected error for %q: %v", name, err)
 			}
@@ -2515,7 +2521,7 @@ func TestDescribeEventsWithMultiTenancy(t *testing.T) {
 				t.Errorf("events not found for %q when ShowEvents=true: %s", name, out)
 			}
 
-			out, err = d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: false})
+			out, err = d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: false})
 			if err != nil {
 				t.Errorf("unexpected error for %q: %s", name, err)
 			}
@@ -2694,7 +2700,7 @@ func TestDescribePodSecurityPolicyWithMultiTenancy(t *testing.T) {
 	fake := fake.NewSimpleClientset(&policyv1beta1.PodSecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "mypsp",
-			Tenant: "test-te",
+			Tenant: testTenant,
 		},
 		Spec: policyv1beta1.PodSecurityPolicySpec{
 			AllowedUnsafeSysctls: []string{"kernel.*", "net.ipv4.ip_local_port_range"},
@@ -2714,9 +2720,9 @@ func TestDescribePodSecurityPolicyWithMultiTenancy(t *testing.T) {
 		},
 	})
 
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "", Interface: fake}
 	d := PodSecurityPolicyDescriber{c}
-	out, err := d.Describe("test-te", "", "mypsp", describe.DescriberSettings{})
+	out, err := d.Describe(testTenant, "", "mypsp", describe.DescriberSettings{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2733,7 +2739,7 @@ func TestDescribeResourceQuotaWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Status: corev1.ResourceQuotaStatus{
 			Hard: corev1.ResourceList{
@@ -2754,9 +2760,9 @@ func TestDescribeResourceQuotaWithMultiTenancy(t *testing.T) {
 			},
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := ResourceQuotaDescriber{c}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2830,7 +2836,7 @@ Spec:
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "network-policy-1",
 			Namespace:         "default",
-			Tenant:            "test-te",
+			Tenant:            testTenant,
 			CreationTimestamp: metav1.NewTime(expectedTime),
 		},
 		Spec: networkingv1.NetworkPolicySpec{
@@ -2964,7 +2970,7 @@ Spec:
 		},
 	})
 	d := NetworkPolicyDescriber{versionedFake}
-	out, err := d.Describe("test-te", "", "network-policy-1", describe.DescriberSettings{})
+	out, err := d.Describe(testTenant, "", "network-policy-1", describe.DescriberSettings{})
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -2978,7 +2984,7 @@ func TestDescribeServiceAccountWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Secrets: []corev1.ObjectReference{
 			{
@@ -2991,9 +2997,9 @@ func TestDescribeServiceAccountWithMultiTenancy(t *testing.T) {
 			},
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := ServiceAccountDescriber{c}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3017,15 +3023,15 @@ func TestDescribeNodeWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Spec: corev1.NodeSpec{
 			Unschedulable: true,
 		},
 	})
-	c := &describeClientWithMultiTenancy{T: t, Tenant: "test-te", Namespace: "foo", Interface: fake}
+	c := &describeClientWithMultiTenancy{T: t, Tenant: testTenant, Namespace: "foo", Interface: fake}
 	d := NodeDescriber{c}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3046,7 +3052,7 @@ func TestDescribeStatefulSetWithMultiTenancy(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "foo",
-			Tenant:    "test-te",
+			Tenant:    testTenant,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,
@@ -3067,7 +3073,7 @@ func TestDescribeStatefulSetWithMultiTenancy(t *testing.T) {
 		},
 	})
 	d := StatefulSetDescriber{fake}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: true})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3089,7 +3095,7 @@ func TestControllerRefWithMultiTenancy(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bar",
 				Namespace: "foo",
-				Tenant:    "test-te",
+				Tenant:    testTenant,
 				UID:       "123456",
 			},
 			TypeMeta: metav1.TypeMeta{
@@ -3111,7 +3117,7 @@ func TestControllerRefWithMultiTenancy(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "barpod",
 				Namespace:       "foo",
-				Tenant:          "test-te",
+				Tenant:          testTenant,
 				Labels:          map[string]string{"abc": "xyz"},
 				OwnerReferences: []metav1.OwnerReference{{Name: "bar", UID: "123456", Controller: utilpointer.BoolPtr(true)}},
 			},
@@ -3131,7 +3137,7 @@ func TestControllerRefWithMultiTenancy(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "orphan",
 				Namespace: "foo",
-				Tenant:    "test-te",
+				Tenant:    testTenant,
 				Labels:    map[string]string{"abc": "xyz"},
 			},
 			TypeMeta: metav1.TypeMeta{
@@ -3150,7 +3156,7 @@ func TestControllerRefWithMultiTenancy(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "buzpod",
 				Namespace:       "foo",
-				Tenant:          "test-te",
+				Tenant:          testTenant,
 				Labels:          map[string]string{"abc": "xyz"},
 				OwnerReferences: []metav1.OwnerReference{{Name: "buz", UID: "654321", Controller: utilpointer.BoolPtr(true)}},
 			},
@@ -3167,7 +3173,7 @@ func TestControllerRefWithMultiTenancy(t *testing.T) {
 			},
 		})
 	d := ReplicationControllerDescriber{f}
-	out, err := d.Describe("test-te", "foo", "bar", describe.DescriberSettings{ShowEvents: false})
+	out, err := d.Describe(testTenant, "foo", "bar", describe.DescriberSettings{ShowEvents: false})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/registry/storage/storageclass/strategy.go
+++ b/pkg/registry/storage/storageclass/strategy.go
@@ -45,7 +45,7 @@ func (storageClassStrategy) NamespaceScoped() bool {
 
 //TenantScoped is false as it is cluster-scoped
 func (storageClassStrategy) TenantScoped() bool {
-	return false
+	return true
 }
 
 // ResetBeforeCreate clears the Status field which is not allowed to be set by end users on creation.

--- a/pkg/registry/storage/storageclass/strategy_test.go
+++ b/pkg/registry/storage/storageclass/strategy_test.go
@@ -26,13 +26,17 @@ import (
 	"k8s.io/kubernetes/pkg/apis/storage"
 )
 
+const (
+	testTenant = "test-tenant"
+)
+
 func TestStorageClassStrategy(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	if Strategy.NamespaceScoped() {
 		t.Errorf("StorageClass must not be namespace scoped")
 	}
-	if Strategy.TenantScoped() {
-		t.Errorf("StorageClass must not be tenant scoped")
+	if !Strategy.TenantScoped() {
+		t.Errorf("StorageClass must be tenant scoped")
 	}
 	if Strategy.AllowCreateOnUpdate() {
 		t.Errorf("StorageClass should not allow create on update")
@@ -42,7 +46,8 @@ func TestStorageClassStrategy(t *testing.T) {
 	bindingMode := storage.VolumeBindingWaitForFirstConsumer
 	storageClass := &storage.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "valid-class",
+			Name:   "valid-class",
+			Tenant: testTenant,
 		},
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters: map[string]string{
@@ -62,6 +67,7 @@ func TestStorageClassStrategy(t *testing.T) {
 	newStorageClass := &storage.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "valid-class-2",
+			Tenant:          testTenant,
 			ResourceVersion: "4",
 		},
 		Provisioner: "kubernetes.io/aws-ebs",

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -24,7 +24,6 @@ import (
 
 // +genclient
 // +genclient:nonNamespaced
-// +genclient:nonTenanted
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StorageClass describes the parameters for a class of storage for

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -24,7 +24,6 @@ import (
 
 // +genclient
 // +genclient:nonNamespaced
-// +genclient:nonTenanted
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StorageClass describes the parameters for a class of storage for

--- a/staging/src/k8s.io/client-go/informers/storage/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/interface.go
@@ -50,7 +50,7 @@ func NewWithMultiTenancy(f internalinterfaces.SharedInformerFactory, namespace s
 
 // StorageClasses returns a StorageClassInformer.
 func (v *version) StorageClasses() StorageClassInformer {
-	return &storageClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &storageClassInformer{factory: v.factory, tenant: v.tenant, tweakListOptions: v.tweakListOptions}
 }
 
 // VolumeAttachments returns a VolumeAttachmentInformer.

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/interface.go
@@ -64,7 +64,7 @@ func (v *version) CSINodes() CSINodeInformer {
 
 // StorageClasses returns a StorageClassInformer.
 func (v *version) StorageClasses() StorageClassInformer {
-	return &storageClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &storageClassInformer{factory: v.factory, tenant: v.tenant, tweakListOptions: v.tweakListOptions}
 }
 
 // VolumeAttachments returns a VolumeAttachmentInformer.

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
@@ -42,6 +42,7 @@ type StorageClassInformer interface {
 type storageClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	tenant           string
 }
 
 // NewStorageClassInformer constructs a new informer for StorageClass type.
@@ -51,23 +52,31 @@ func NewStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 	return NewFilteredStorageClassInformer(client, resyncPeriod, indexers, nil)
 }
 
+func NewStorageClassInformerWithMultiTenancy(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tenant string) cache.SharedIndexInformer {
+	return NewFilteredStorageClassInformerWithMultiTenancy(client, resyncPeriod, indexers, nil, tenant)
+}
+
 // NewFilteredStorageClassInformer constructs a new informer for StorageClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+	return NewFilteredStorageClassInformerWithMultiTenancy(client, resyncPeriod, indexers, tweakListOptions, "system")
+}
+
+func NewFilteredStorageClassInformerWithMultiTenancy(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc, tenant string) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().StorageClasses().List(options)
+				return client.StorageV1beta1().StorageClassesWithMultiTenancy(tenant).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.StorageV1beta1().StorageClasses().Watch(options)
+				return client.StorageV1beta1().StorageClassesWithMultiTenancy(tenant).Watch(options)
 			},
 		},
 		&storagev1beta1.StorageClass{},
@@ -77,7 +86,7 @@ func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod t
 }
 
 func (f *storageClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredStorageClassInformer(client, resyncPeriod, cache.Indexers{}, f.tweakListOptions)
+	return NewFilteredStorageClassInformerWithMultiTenancy(client, resyncPeriod, cache.Indexers{cache.TenantIndex: cache.MetaTenantIndexFunc}, f.tweakListOptions, f.tenant)
 }
 
 func (f *storageClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storage_client.go
@@ -30,8 +30,11 @@ type FakeStorageV1 struct {
 }
 
 func (c *FakeStorageV1) StorageClasses() v1.StorageClassInterface {
+	return &FakeStorageClasses{c, "system"}
+}
 
-	return &FakeStorageClasses{c}
+func (c *FakeStorageV1) StorageClassesWithMultiTenancy(tenant string) v1.StorageClassInterface {
+	return &FakeStorageClasses{c, tenant}
 }
 
 func (c *FakeStorageV1) VolumeAttachments() v1.VolumeAttachmentInterface {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
@@ -32,6 +32,7 @@ import (
 // FakeStorageClasses implements StorageClassInterface
 type FakeStorageClasses struct {
 	Fake *FakeStorageV1
+	te   string
 }
 
 var storageclassesResource = schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"}
@@ -41,7 +42,8 @@ var storageclassesKind = schema.GroupVersionKind{Group: "storage.k8s.io", Versio
 // Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
 func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *storagev1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(storageclassesResource, name), &storagev1.StorageClass{})
+		Invokes(testing.NewTenantGetAction(storageclassesResource, name, c.te), &storagev1.StorageClass{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -52,7 +54,8 @@ func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *st
 // List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
 func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *storagev1.StorageClassList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(storageclassesResource, storageclassesKind, opts), &storagev1.StorageClassList{})
+		Invokes(testing.NewTenantListAction(storageclassesResource, storageclassesKind, opts, c.te), &storagev1.StorageClassList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -74,7 +77,8 @@ func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *storagev1.Storag
 func (c *FakeStorageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	aggWatch := watch.NewAggregatedWatcher()
 	watcher, err := c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
+		InvokesWatch(testing.NewTenantWatchAction(storageclassesResource, opts, c.te))
+
 	aggWatch.AddWatchInterface(watcher, err)
 	return aggWatch
 }
@@ -82,7 +86,8 @@ func (c *FakeStorageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInt
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *FakeStorageClasses) Create(storageClass *storagev1.StorageClass) (result *storagev1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &storagev1.StorageClass{})
+		Invokes(testing.NewTenantCreateAction(storageclassesResource, storageClass, c.te), &storagev1.StorageClass{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -93,7 +98,8 @@ func (c *FakeStorageClasses) Create(storageClass *storagev1.StorageClass) (resul
 // Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *FakeStorageClasses) Update(storageClass *storagev1.StorageClass) (result *storagev1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &storagev1.StorageClass{})
+		Invokes(testing.NewTenantUpdateAction(storageclassesResource, storageClass, c.te), &storagev1.StorageClass{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +110,16 @@ func (c *FakeStorageClasses) Update(storageClass *storagev1.StorageClass) (resul
 // Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
 func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &storagev1.StorageClass{})
+		Invokes(testing.NewTenantDeleteAction(storageclassesResource, name, c.te), &storagev1.StorageClass{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 
-	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
+	action := testing.NewTenantDeleteCollectionAction(storageclassesResource, listOptions, c.te)
+
 	_, err := c.Fake.Invokes(action, &storagev1.StorageClassList{})
 	return err
 }
@@ -119,7 +127,8 @@ func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOpt
 // Patch applies the patch and returns the patched storageClass.
 func (c *FakeStorageClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *storagev1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(storageclassesResource, name, pt, data, subresources...), &storagev1.StorageClass{})
+		Invokes(testing.NewTenantPatchSubresourceAction(storageclassesResource, c.te, name, pt, data, subresources...), &storagev1.StorageClass{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -46,7 +46,11 @@ type StorageV1Client struct {
 }
 
 func (c *StorageV1Client) StorageClasses() StorageClassInterface {
-	return newStorageClasses(c)
+	return newStorageClassesWithMultiTenancy(c, "system")
+}
+
+func (c *StorageV1Client) StorageClassesWithMultiTenancy(tenant string) StorageClassInterface {
+	return newStorageClassesWithMultiTenancy(c, tenant)
 }
 
 func (c *StorageV1Client) VolumeAttachments() VolumeAttachmentInterface {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storage_client.go
@@ -40,8 +40,11 @@ func (c *FakeStorageV1beta1) CSINodes() v1beta1.CSINodeInterface {
 }
 
 func (c *FakeStorageV1beta1) StorageClasses() v1beta1.StorageClassInterface {
+	return &FakeStorageClasses{c, "system"}
+}
 
-	return &FakeStorageClasses{c}
+func (c *FakeStorageV1beta1) StorageClassesWithMultiTenancy(tenant string) v1beta1.StorageClassInterface {
+	return &FakeStorageClasses{c, tenant}
 }
 
 func (c *FakeStorageV1beta1) VolumeAttachments() v1beta1.VolumeAttachmentInterface {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
@@ -32,6 +32,7 @@ import (
 // FakeStorageClasses implements StorageClassInterface
 type FakeStorageClasses struct {
 	Fake *FakeStorageV1beta1
+	te   string
 }
 
 var storageclassesResource = schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "storageclasses"}
@@ -41,7 +42,8 @@ var storageclassesKind = schema.GroupVersionKind{Group: "storage.k8s.io", Versio
 // Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
 func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *v1beta1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(storageclassesResource, name), &v1beta1.StorageClass{})
+		Invokes(testing.NewTenantGetAction(storageclassesResource, name, c.te), &v1beta1.StorageClass{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -52,7 +54,8 @@ func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *v1
 // List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
 func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClassList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(storageclassesResource, storageclassesKind, opts), &v1beta1.StorageClassList{})
+		Invokes(testing.NewTenantListAction(storageclassesResource, storageclassesKind, opts, c.te), &v1beta1.StorageClassList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -74,7 +77,8 @@ func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageC
 func (c *FakeStorageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	aggWatch := watch.NewAggregatedWatcher()
 	watcher, err := c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
+		InvokesWatch(testing.NewTenantWatchAction(storageclassesResource, opts, c.te))
+
 	aggWatch.AddWatchInterface(watcher, err)
 	return aggWatch
 }
@@ -82,7 +86,8 @@ func (c *FakeStorageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInt
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *FakeStorageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
+		Invokes(testing.NewTenantCreateAction(storageclassesResource, storageClass, c.te), &v1beta1.StorageClass{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -93,7 +98,8 @@ func (c *FakeStorageClasses) Create(storageClass *v1beta1.StorageClass) (result 
 // Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *FakeStorageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
+		Invokes(testing.NewTenantUpdateAction(storageclassesResource, storageClass, c.te), &v1beta1.StorageClass{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +110,16 @@ func (c *FakeStorageClasses) Update(storageClass *v1beta1.StorageClass) (result 
 // Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
 func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &v1beta1.StorageClass{})
+		Invokes(testing.NewTenantDeleteAction(storageclassesResource, name, c.te), &v1beta1.StorageClass{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 
-	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
+	action := testing.NewTenantDeleteCollectionAction(storageclassesResource, listOptions, c.te)
+
 	_, err := c.Fake.Invokes(action, &v1beta1.StorageClassList{})
 	return err
 }
@@ -119,7 +127,8 @@ func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOpt
 // Patch applies the patch and returns the patched storageClass.
 func (c *FakeStorageClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(storageclassesResource, name, pt, data, subresources...), &v1beta1.StorageClass{})
+		Invokes(testing.NewTenantPatchSubresourceAction(storageclassesResource, c.te, name, pt, data, subresources...), &v1beta1.StorageClass{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -56,7 +56,11 @@ func (c *StorageV1beta1Client) CSINodes() CSINodeInterface {
 }
 
 func (c *StorageV1beta1Client) StorageClasses() StorageClassInterface {
-	return newStorageClasses(c)
+	return newStorageClassesWithMultiTenancy(c, "system")
+}
+
+func (c *StorageV1beta1Client) StorageClassesWithMultiTenancy(tenant string) StorageClassInterface {
+	return newStorageClassesWithMultiTenancy(c, tenant)
 }
 
 func (c *StorageV1beta1Client) VolumeAttachments() VolumeAttachmentInterface {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -40,6 +40,7 @@ import (
 // A group's client should implement this interface.
 type StorageClassesGetter interface {
 	StorageClasses() StorageClassInterface
+	StorageClassesWithMultiTenancy(tenant string) StorageClassInterface
 }
 
 // StorageClassInterface has methods to work with StorageClass resources.
@@ -59,13 +60,19 @@ type StorageClassInterface interface {
 type storageClasses struct {
 	client  rest.Interface
 	clients []rest.Interface
+	te      string
 }
 
 // newStorageClasses returns a StorageClasses
 func newStorageClasses(c *StorageV1beta1Client) *storageClasses {
+	return newStorageClassesWithMultiTenancy(c, "system")
+}
+
+func newStorageClassesWithMultiTenancy(c *StorageV1beta1Client, tenant string) *storageClasses {
 	return &storageClasses{
 		client:  c.RESTClient(),
 		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }
 
@@ -73,6 +80,7 @@ func newStorageClasses(c *StorageV1beta1Client) *storageClasses {
 func (c *storageClasses) Get(name string, options v1.GetOptions) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
 	err = c.client.Get().
+		Tenant(c.te).
 		Resource("storageclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -108,6 +116,7 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 			go func(c *storageClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.StorageClassList, errMap map[int]error) {
 				r := &v1beta1.StorageClassList{}
 				err := ci.Get().
+					Tenant(c.te).
 					Resource("storageclasses").
 					VersionedParams(&opts, scheme.ParameterCodec).
 					Timeout(timeout).
@@ -169,6 +178,7 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
 	err = c.client.Get().
+		Tenant(c.te).
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -189,6 +199,7 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 		}
 
 		err = client.Get().
+			Tenant(c.te).
 			Resource("storageclasses").
 			VersionedParams(&opts, scheme.ParameterCodec).
 			Timeout(timeout).
@@ -220,6 +231,7 @@ func (c *storageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
 		watcher, err := client.Get().
+			Tenant(c.te).
 			Resource("storageclasses").
 			VersionedParams(&opts, scheme.ParameterCodec).
 			Timeout(timeout).
@@ -238,7 +250,13 @@ func (c *storageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 func (c *storageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
 
+	objectTenant := storageClass.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Post().
+		Tenant(objectTenant).
 		Resource("storageclasses").
 		Body(storageClass).
 		Do().
@@ -251,7 +269,13 @@ func (c *storageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1b
 func (c *storageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
 
+	objectTenant := storageClass.ObjectMeta.Tenant
+	if objectTenant == "" {
+		objectTenant = c.te
+	}
+
 	err = c.client.Put().
+		Tenant(objectTenant).
 		Resource("storageclasses").
 		Name(storageClass.Name).
 		Body(storageClass).
@@ -264,6 +288,7 @@ func (c *storageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1b
 // Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
 func (c *storageClasses) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
+		Tenant(c.te).
 		Resource("storageclasses").
 		Name(name).
 		Body(options).
@@ -278,6 +303,7 @@ func (c *storageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		Tenant(c.te).
 		Resource("storageclasses").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -290,6 +316,7 @@ func (c *storageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 func (c *storageClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
 	err = c.client.Patch(pt).
+		Tenant(c.te).
 		Resource("storageclasses").
 		SubResource(subresources...).
 		Name(name).

--- a/staging/src/k8s.io/client-go/listers/storage/v1/expansion_generated.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/expansion_generated.go
@@ -23,6 +23,10 @@ package v1
 // StorageClassLister.
 type StorageClassListerExpansion interface{}
 
+// StorageClassTenantListerExpansion allows custom methods to be added to
+// StorageClassTenantLister.
+type StorageClassTenantListerExpansion interface{}
+
 // VolumeAttachmentListerExpansion allows custom methods to be added to
 // VolumeAttachmentLister.
 type VolumeAttachmentListerExpansion interface{}

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/expansion_generated.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/expansion_generated.go
@@ -31,6 +31,10 @@ type CSINodeListerExpansion interface{}
 // StorageClassLister.
 type StorageClassListerExpansion interface{}
 
+// StorageClassTenantListerExpansion allows custom methods to be added to
+// StorageClassTenantLister.
+type StorageClassTenantListerExpansion interface{}
+
 // VolumeAttachmentListerExpansion allows custom methods to be added to
 // VolumeAttachmentLister.
 type VolumeAttachmentListerExpansion interface{}

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
@@ -1,5 +1,6 @@
 /*
 Copyright The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +30,9 @@ import (
 type StorageClassLister interface {
 	// List lists all StorageClasses in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.StorageClass, err error)
+	// StorageClasses returns an object that can list and get StorageClasses.
+	StorageClasses() StorageClassTenantLister
+	StorageClassesWithMultiTenancy(tenant string) StorageClassTenantLister
 	// Get retrieves the StorageClass from the index for a given name.
 	Get(name string) (*v1beta1.StorageClass, error)
 	StorageClassListerExpansion
@@ -55,6 +59,55 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*v1beta1.Stor
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1beta1.StorageClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(v1beta1.Resource("storageclass"), name)
+	}
+	return obj.(*v1beta1.StorageClass), nil
+}
+
+// StorageClasses returns an object that can list and get StorageClasses.
+func (s *storageClassLister) StorageClasses() StorageClassTenantLister {
+	return storageClassTenantLister{indexer: s.indexer, tenant: "system"}
+}
+
+func (s *storageClassLister) StorageClassesWithMultiTenancy(tenant string) StorageClassTenantLister {
+	return storageClassTenantLister{indexer: s.indexer, tenant: tenant}
+}
+
+// StorageClassTenantLister helps list and get StorageClasses.
+type StorageClassTenantLister interface {
+	// List lists all StorageClasses in the indexer for a given tenant/tenant.
+	List(selector labels.Selector) (ret []*v1beta1.StorageClass, err error)
+	// Get retrieves the StorageClass from the indexer for a given tenant/tenant and name.
+	Get(name string) (*v1beta1.StorageClass, error)
+	StorageClassTenantListerExpansion
+}
+
+// storageClassTenantLister implements the StorageClassTenantLister
+// interface.
+type storageClassTenantLister struct {
+	indexer cache.Indexer
+	tenant  string
+}
+
+// List lists all StorageClasses in the indexer for a given tenant.
+func (s storageClassTenantLister) List(selector labels.Selector) (ret []*v1beta1.StorageClass, err error) {
+	err = cache.ListAllByTenant(s.indexer, s.tenant, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.StorageClass))
+	})
+	return ret, err
+}
+
+// Get retrieves the StorageClass from the indexer for a given tenant and name.
+func (s storageClassTenantLister) Get(name string) (*v1beta1.StorageClass, error) {
+	key := s.tenant + "/" + name
+	if s.tenant == "system" {
+		key = name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/etcd/multi_tenancy_data.go
+++ b/test/integration/etcd/multi_tenancy_data.go
@@ -353,7 +353,7 @@ func GetEtcdStorageDataForNamespaceWithMultiTenancy(tenant, namespace string) ma
 		// k8s.io/kubernetes/pkg/apis/storage/v1beta1
 		gvr("storage.k8s.io", "v1beta1", "storageclasses"): {
 			Stub:             `{"metadata": {"name": "sc1"}, "provisioner": "aws"}`,
-			ExpectedEtcdPath: "/registry/storageclasses/sc1",
+			ExpectedEtcdPath: "/registry/storageclasses/" + tenant + "/sc1",
 			ExpectedGVK:      gvkP("storage.k8s.io", "v1", "StorageClass"),
 		},
 		// --
@@ -361,7 +361,7 @@ func GetEtcdStorageDataForNamespaceWithMultiTenancy(tenant, namespace string) ma
 		// k8s.io/kubernetes/pkg/apis/storage/v1
 		gvr("storage.k8s.io", "v1", "storageclasses"): {
 			Stub:             `{"metadata": {"name": "sc2"}, "provisioner": "aws"}`,
-			ExpectedEtcdPath: "/registry/storageclasses/sc2",
+			ExpectedEtcdPath: "/registry/storageclasses/" + tenant + "/sc2",
 		},
 		// --
 


### PR DESCRIPTION
This PR fixes issue https://github.com/futurewei-cloud/arktos/issues/758. 

This PR changes the scope of resource StorageClass to tenant-scope. As StoragClass is conceptually a dynamic PersistentVolume, it should have the same resource scope. 

MultiTenancy APIs for storageclass, including StorageClassesWithMultiTenancy, are generated. 

### Verification:
As shown, different tenants can create storageclass objects in its own space.
```
qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create tenant x
setting storage cluster to 0
tenant/x created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get storageclass -AT
TENANT   NAME                 PROVISIONER               AGE
system   standard (default)   kubernetes.io/host-path   107s

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create  -f ./test/e2e/testing-manifests/storage-csi/mock/csi-storageclass.yaml
storageclass.storage.k8s.io/csi-mock-sc created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl create  -f ./test/e2e/testing-manifests/storage-csi/mock/csi-storageclass.yaml --tenant x
storageclass.storage.k8s.io/csi-mock-sc created

qianchen@qianchen-VirtualBox:~/gopath/qianc/arktos$ kubectl get storageclass -AT
TENANT   NAME                 PROVISIONER               AGE
system   csi-mock-sc          csi-mock                  11s
system   standard (default)   kubernetes.io/host-path   2m59s
x        csi-mock-sc          csi-mock                  4s
```
