### PR TITLE
update doc per feedback from the Mizar team

### DIFF
--- a/docs/design-proposals/multi-tenancy/multi-tenancy-network.md
+++ b/docs/design-proposals/multi-tenancy/multi-tenancy-network.md
@@ -257,7 +257,7 @@ Network object specifies service IPAM as *external*:
     metadata:
       name: default
     spec:
-      type: flat
+      type: mizar
       service:
         ipam: External
 

--- a/docs/design-proposals/multi-tenancy/multi-tenancy-network.md
+++ b/docs/design-proposals/multi-tenancy/multi-tenancy-network.md
@@ -259,7 +259,7 @@ Network object specifies service IPAM as *external*:
     spec:
       type: flat
       service:
-        ipam: external
+        ipam: External
 
 (**TBD: consider support for user can provide hints about service IP address**)
 

--- a/docs/setup-guide/arktos-enforces-netowrk-feature.md
+++ b/docs/setup-guide/arktos-enforces-netowrk-feature.md
@@ -65,8 +65,8 @@ default   flat
 
 The output will be as follows if you set ARKTOS_NETWORK_TEMPLATE=mizar.
 ```bash
-NAME      TYPE   VPC                      PHASE   DNS
-default   vpc    system-default-network           
+NAME      TYPE    VPC                      PHASE   DNS
+default   mizar   system-default-network    
 ```
 
 6. Start the arktos-network-controller

--- a/docs/setup-guide/arktos-enforces-netowrk-feature.md
+++ b/docs/setup-guide/arktos-enforces-netowrk-feature.md
@@ -21,25 +21,55 @@ If this machine will be used as the master of a multi-node cluster, please set a
 
 If mizar cni plugin is to be used, please replace containerd following the instruction of [multi-tansnt aware containerd](https://github.com/futurewei-cloud/containerd/releases/tag/tenant-cni-args).
 
-2. Enable network related feature and change cni installation setting by (assuming flat typed networks here)
+2. Clean up some left-over network plugin and binaries.
+Delete all the files under the following directories:
+```
+/opt/cni/bin/
+/etc/cni/net.d/
+```
+You can skip this step if it is a newly-provisioned lab machine, yet it is recommeneded to check before moving on. 
+
+
+3. Enable network related feature and change cni installation setting by
 ```bash
 export FEATURE_GATES="AllAlpha=false,MandatoryArktosNetwork=true"
 export ARKTOS_NO_CNI_PREINSTALLED=y
-export ARKTOS_NETWORK_TEMPLATE=default
 ```
 
-3. Start Arktos cluster
+4. Set the default network template based on the the default network type you desire:
+If you want the default network to be of "flat" type:
+```bash
+export ARKTOS_NETWORK_TEMPLATE=flat
+```
+
+Or, If you want the default network to be of "mizar" type:
+```bash
+export ARKTOS_NETWORK_TEMPLATE=mizar
+```
+
+Or, set the env var to a file path of your desire network object template file.
+
+4. Start Arktos cluster
 ```bash
 ./hack/arktos-up.sh
 ```
-After the cluster is started, there will be the first network, "default", in system tenant. Its state is empty at this moment.
+
+Note: arktos-up.sh should be stuck in "Waiting for node ready at api server" messages. Don't worry, the apiserver is already up at this point, just the master node status is not "Ready" as we have not installed the network plugin yet. 
+
+5. Leave the "arktos-up.sh" terminal and opend a another terminal to the master node. Run the following command to confirm that the first network, "default", in system tenant, has already been created. Its state is empty at this moment.
 ```bash
 ./cluster/kubectl.sh get net
 NAME      TYPE   VPC   PHASE   DNS
 default   flat
 ```
 
-4. Start the arktos-network-controller
+The output will be as follows if you set ARKTOS_NETWORK_TEMPLATE=mizar.
+```bash
+NAME      TYPE   VPC                      PHASE   DNS
+default   vpc    system-default-network           
+```
+
+6. Start the arktos-network-controller
 
 The current version has a limitation which requires cluster admin to specify the IP address of kube-apiserver that this controller connects to. We are working on the improvement that gets rid of this inconvenience. At this monent, please provide the ip address of the master node. Below is assuming 172.31.41.177:
 ```bash
@@ -62,17 +92,21 @@ kind: Config
 preferences: {}
 users: []
 ```
-Now, the default network of system tenant should be Ready
+Now, the default network of system tenant should be Ready.
 ```bash
 ./cluster/kubectl.sh get net
 NAME      TYPE   VPC   PHASE   DNS
 default   flat         Ready   10.0.0.207
 ```
 
-5. Install CNI plugin; below is for flannel
+The output will be slightly different if you set ARKTOS_NETWORK_TEMPLATE=mizar.
+
+7. Leave the arktos-network-controller termainal running and open a new terminal to install CNI plugin; below is for flannel
 ```bash
 ./cluster/kubectl.sh apply -f https://github.com/coreos/flannel/raw/master/Documentation/kube-flannel.yml
 ```
+
+After that, you should see the "arktos-up.sh" terminal no longer displaying "Waiting for node ready at api server" message and the arktos cluster should be successfully up. 
 
 If you want to, you are able to add more worker nodes to the cluster, by following [multi-node setup guide](multi-node-dev-cluster.md).
 In AWS env, please make sure the adequate security group is set properly. In our temporary lab, we allowed inbound rule of ALL-Traffic 0.0.0.0/0.

--- a/docs/setup-guide/arktos-enforces-network-feature.md
+++ b/docs/setup-guide/arktos-enforces-network-feature.md
@@ -19,7 +19,7 @@ Also, please ensure the hostname and its ip address in /etc/hosts. For instance,
 ```
 If this machine will be used as the master of a multi-node cluster, please set adequate permissive security groups. Fro AWS VM in this lab, we allowed inbound rule of ALL-Traffic 0.0.0.0/0.
 
-If mizar cni plugin is to be used, please replace containerd following the instruction of [multi-tansnt aware containerd](https://github.com/futurewei-cloud/containerd/releases/tag/tenant-cni-args).
+If mizar cni plugin is to be used, please replace containerd following the instruction of [multi-tenant aware containerd](https://github.com/futurewei-cloud/containerd/releases/tag/tenant-cni-args).
 
 2. Clean up some left-over network plugin and binaries.
 Delete all the files under the following directories:

--- a/docs/setup-guide/multi-node-dev-cluster.md
+++ b/docs/setup-guide/multi-node-dev-cluster.md
@@ -6,23 +6,36 @@ This doc, as at the moment written, does not mandate which cni plugin to be used
 
 Assuming you have got the Arktos repo downloaded to your local disk and the current folder is at the root of the repo,
 
+0. Make sure the following directories are empty. If not, clean them up.
+```
+/opt/cni/bin/
+/etc/cni/net.d/
+```
+
 1. bootstrap the cluster by starting the master node (no CNI plgin at first)
 ```bash
 export ARKTOS_NO_CNI_PREINSTALLED=y
 ./hack/arktos-up.sh
 ```
 
-2. install CNI plugin
+Note: arktos-up.sh should be stuck in "Waiting for node ready at api server" messages. Don't worry, the apiserver is already up at this point, just the master node status is not "Ready" as we have not installed the network plugin yet. 
+
+2. Open another terminal to the master node to install CNI plugin
 ```bash
 ./cluster/kubectl.sh apply -f https://github.com/coreos/flannel/raw/master/Documentation/kube-flannel.yml
 ```
 
-3. on the GCP instance to be added as worker node, ensure following worker secret files copied from the master node:
+After that, "arktos-up.sh" should get rid of "Waiting for node ready at api server" messages and be successfully started.
+
+3. In the lab machine to be added as a worker node, ensure following worker secret files copied from the master node:
+If the worker node is a GCP instance  
 ```bash
 mkdir -p /tmp/arktos
 gcloud compute scp <master-node-instance>:/var/run/kubernetes/kubelet.kubeconfig /tmp/arktos/
 gcloud compute scp <master-node-instance>:/var/run/kubernetes/client-ca.crt /tmp/arktos/
 ```
+
+If the worker node is an AWS EC2, you can download files /var/run/kubernetes/kubelet.kubeconfig and /var/run/kubernetes/client-ca.crt from the master node, and then upload to /tmp/arktos/ in the worker node.
 
 At the moment this doc is written, kube-proxy does not support multi-tenancy yet, and it won't be deployed in the cluster. After kube-proxy issue has been fixed (we will allocate resource to cope with it soon), probably we will also need to copy over kube-proxy related secret and artifacts.
 
@@ -31,16 +44,26 @@ As a temporary measure to accommodate Flannel pods to access api server through 
 sudo iptables -t nat -A OUTPUT -p tcp -d 10.0.0.1 --dport 443 -j DNAT --to-destination 10.138.0.19:6443
 ```
 
+NOTE: you need to re-run the above command once you restart the machine.
+
 Please be advised that this is a temporary quirk only; after we have the full service support by proper kube-proxy or other means, we don't need it any more.
 
 4. start the worker node and register into cluster
 
-at worker node, run following commands:
+First Make sure the following directories in the worker node are empty. If not, clean them up.
+```
+/opt/cni/bin/
+/etc/cni/net.d/
+```
+
+Then at worker node, run following commands:
 ```bash
 export ARKTOS_NO_CNI_PREINSTALLED=y
 export KUBELET_IP=<worker-ip>
 ./hack/arktos-worker-up.sh
 ```
+
+After the script returns, go to master node terminal and run command "[arktos_repo]/cluster/kubectl.sh get nodes", you should see the work node is displayed and its status should be "Ready".
 
 5. label worker node as vm runtime capable (optional)
 

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -108,9 +108,13 @@ else
 fi
 
 ARKTOS_NETWORK_TEMPLATE=${ARKTOS_NETWORK_TEMPLATE:-}
-DEFAULT_NETWORK_TEMPLATE=${KUBE_ROOT}/hack/runtime/default_flat_network.json
-if [ "${ARKTOS_NETWORK_TEMPLATE}" == "default" ]; then 
-  ARKTOS_NETWORK_TEMPLATE=${DEFAULT_NETWORK_TEMPLATE}
+DEFAULT_FLAT_NETWORK_TEMPLATE=${KUBE_ROOT}/hack/runtime/default_flat_network.json
+DEFAULT_MIZAR_NETWORK_TEMPLATE=${KUBE_ROOT}/hack/runtime/default_mizar_network.json
+if [ "${ARKTOS_NETWORK_TEMPLATE}" == "flat" ]; then 
+  ARKTOS_NETWORK_TEMPLATE=${DEFAULT_FLAT_NETWORK_TEMPLATE}
+fi
+if [ "${ARKTOS_NETWORK_TEMPLATE}" == "mizar" ]; then 
+  ARKTOS_NETWORK_TEMPLATE=${DEFAULT_MIZAR_NETWORK_TEMPLATE}
 fi
 if [ -n "${ARKTOS_NETWORK_TEMPLATE}" ] && [ ! -f "${ARKTOS_NETWORK_TEMPLATE}" ]; then 
   printf "\033[1;33m\nWarning: could not find newtork template file ${ARKTOS_NETWORK_TEMPLATE}. Setting ARKTOS_NETWORK_TEMPLATE to empty.\n\033[0m"

--- a/hack/runtime/default_mizar_network.json
+++ b/hack/runtime/default_mizar_network.json
@@ -4,7 +4,7 @@
         "finalizers": ["arktos.futurewei.com/network"]
     },
     "spec": {
-        "type": "vpc",
+        "type": "mizar",
         "vpcID": "{{.}}-default-network"
     }
 }

--- a/hack/runtime/default_mizar_network.json
+++ b/hack/runtime/default_mizar_network.json
@@ -1,0 +1,10 @@
+{
+    "metadata": {
+        "name": "default",
+        "finalizers": ["arktos.futurewei.com/network"]
+    },
+    "spec": {
+        "type": "vpc",
+        "vpcID": "{{.}}-default-network"
+    }
+}


### PR DESCRIPTION
This PR makes miscellaneous updates per feedback from the Mizar team on Mizar-Arktos integration.

1. Update docs/instructions.
2. Find tune the Arktos-up.sh to support a default network template for mizar.

### Veriification
Verified in the my dev box, when env var ARKTOS_NETWORK_TEMPLATE=mizar, the default network object created under the system tenant when the Arktos cluster is up is:

```bash
NAME      TYPE    VPC                      PHASE   DNS
default   mizar   system-default-network    
```