### PR TITLE
workaround for cicd failures

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -329,7 +329,7 @@ func TestAggregatedWatchOnError(t *testing.T) {
 
 		wg.Wait()
 		agg.Stop()
-		time.Sleep(time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		t.Logf("Channel 1 scheduled to sent 1000 but sent %d", ch1Sent)
 		t.Logf("Channel 2 scheduled to sent 1000 but sent %d", ch2Sent)
 		assert.True(t, 1000 > ch1Sent)


### PR DESCRIPTION
This once-flaky test turns nasty recently. Its consistent failures in multiples PRs ( including several PRs about doc changes) is annoying. 

A workaround is given in this PR. I extended the waiting time and it unblocked me in my local test runs. 